### PR TITLE
Dependency track binding generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /target
 **/*.rs.bk
-src/bindings.rs
+/src/bindings.rs
 Cargo.lock
 *.png

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -47,8 +47,3 @@ jobs:
   - script: cargo build --release --all-targets -vvv
     env: { INIT_SKIA: true }
     displayName: Build rust-skia
-  - script: |
-      rustup target add wasm32-unknown-unknown
-      cargo check --target wasm32-unknown-unknown
-    displayName: Check WebAssembly target
-    condition: eq(variables['rustup_toolchain'], 'stable')

--- a/build.rs
+++ b/build.rs
@@ -111,17 +111,20 @@ fn main() {
   // note: the bindings are generated into the src directory to support
   // IDE based symbol lookup in dependent projects.
 
-  let skia_lib = "skia/out/Static/skia.lib";
-  let generated_bindings = "src/bindings.rs";
+  let skia_lib = PathBuf::from(&skia_out_dir).join("skia.lib");
+  let generated_bindings = PathBuf::from("src/bindings.rs");
+  let bindings_cpp_src = PathBuf::from("src/bindings.cpp");
+  let us = PathBuf::from("build.rs");
 
   fn mtime(path: &str) -> std::time::SystemTime {
     fs::metadata(path).unwrap().modified().unwrap()
   }
 
   let regenerate_bindings =
-    !Path::new(generated_bindings).exists()
-    || mtime(skia_lib) > mtime(generated_bindings)
-    || mtime("src/bindings.cpp") > mtime(generated_bindings);
+    !generated_bindings.exists()
+    || mtime(&skia_lib) > mtime(&generated_bindings)
+    || mtime(&bindings_cpp_src) > mtime(&generated_bindings)
+    || mtime(&us) > mtime(&generated_bindings);
 
   if regenerate_bindings {
     bindgen_gen(&current_dir_name, &skia_out_dir)

--- a/build.rs
+++ b/build.rs
@@ -104,9 +104,7 @@ fn main() {
     println!("cargo:rustc-link-lib=user32");
   }
 
-  if env::var("INIT_SKIA").is_ok() {
-    bindgen_gen(&current_dir_name, &skia_out_dir)
-  }
+  bindgen_gen(&current_dir_name, &skia_out_dir);
 }
 
 fn bindgen_gen(current_dir_name: &str, skia_out_dir: &str) {

--- a/build.rs
+++ b/build.rs
@@ -108,23 +108,38 @@ fn main() {
 
   // regenerate bindings?
   //
-  // note: the bindings are generated into the src directory to support
-  // IDE based symbol lookup in dependent projects.
+  // The bindings are generated into the src directory to support
+  // IDE based symbol lookup in dependent projects, but this has the consequence
+  // that the IDE and corgo might be confused by its datestamp, so we
+  // avoid the regeneration if possible by implementing our own dependency checks.
+  // The results of this is hard to reproduce. What can be said is that CLion's
+  // cargo check invocation does from time to time takes a lot longer than expected
+  // in dependent projects even though the bindings were not updated.
 
-  let skia_lib = PathBuf::from(&skia_out_dir).join("skia.lib");
-  let generated_bindings = PathBuf::from("src/bindings.rs");
-  let bindings_cpp_src = PathBuf::from("src/bindings.cpp");
-  let us = PathBuf::from("build.rs");
+  let regenerate_bindings = {
+    let generated_bindings = PathBuf::from("src/bindings.rs");
+    if !generated_bindings.exists() { true } else {
 
-  fn mtime(path: &str) -> std::time::SystemTime {
-    fs::metadata(path).unwrap().modified().unwrap()
-  }
+      let skia_lib_filename =
+          if cfg!(windows) { "skia.lib" } else { "libskia.a" };
 
-  let regenerate_bindings =
-    !generated_bindings.exists()
-    || mtime(&skia_lib) > mtime(&generated_bindings)
-    || mtime(&bindings_cpp_src) > mtime(&generated_bindings)
-    || mtime(&us) > mtime(&generated_bindings);
+      let skia_lib = PathBuf::from(&skia_out_dir).join(skia_lib_filename);
+      let bindings_cpp_src = PathBuf::from("src/bindings.cpp");
+      let us = PathBuf::from("build.rs");
+      let config = PathBuf::from("Cargo.toml");
+
+      fn mtime(path: &Path) -> std::time::SystemTime {
+        fs::metadata(path).unwrap().modified().unwrap()
+      }
+
+      let gen_time = mtime(&generated_bindings);
+
+      mtime(&config) > gen_time
+      || mtime(&skia_lib) > gen_time
+      || mtime(&bindings_cpp_src) > gen_time
+      || mtime(&us) > gen_time
+    }
+  };
 
   if regenerate_bindings {
     bindgen_gen(&current_dir_name, &skia_out_dir)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
 mod bindings;
 mod canvas;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+mod bindings;
 mod canvas;
 
-pub use self::canvas::*;
+pub use canvas::*;
+pub use bindings::*;


### PR DESCRIPTION
... to make `cargo check` a lot faster in IDEs. Not always, but a lot of times, the Clion IDE seems to be run a `cargo build` on `rust-skia` for no reason, implementing our own dependency tracking for the bindings seems to fix that. 

Related to #10.