### PR TITLE
Use build.rs controlled dependency checks.

### DIFF
--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -207,14 +207,19 @@ fn bindgen_gen(current_dir_name: &str, skia_out_dir: &str) {
 
   let mut cc_build = Build::new();
 
-  builder = builder.header("src/bindings.cpp");
+  let bindings_source = "src/bindings.cpp";
+  cargo::add_dependent_path(bindings_source);
+
+  builder = builder.header(bindings_source);
 
   for include_dir in fs::read_dir("skia/include").expect("Unable to read skia/include") {
     let dir = include_dir.unwrap();
+    cargo::add_dependent_path(dir.path().to_str().unwrap());
     let include_path = format!("{}/{}", &current_dir_name, &dir.path().to_str().unwrap());
     builder = builder.clang_arg(format!("-I{}", &include_path));
     cc_build.include(&include_path);
   }
+
 
   if cfg!(feature="vulkan") {
 	builder = builder
@@ -231,7 +236,7 @@ fn bindgen_gen(current_dir_name: &str, skia_out_dir: &str) {
   cc_build
     .cpp(true)
     .flag("-std=c++14")
-    .file("src/bindings.cpp")
+    .file(bindings_source)
     .out_dir(skia_out_dir)
     .compile("skiabinding");
 
@@ -241,4 +246,10 @@ fn bindgen_gen(current_dir_name: &str, skia_out_dir: &str) {
   bindings
     .write_to_file(out_path.join("bindings.rs"))
     .expect("Couldn't write bindings!");
+}
+
+mod cargo {
+  pub fn add_dependent_path(path: &str) {
+    println!("cargo:rerun-if-changed={}", path);
+  }
 }


### PR DESCRIPTION
This was bugging me for a long time and made working in the IDE with `cargo check` almost unbearably slow. 

I learned today that `build.rs` based projects run in one of two modes: Either `build.rs` reruns when one of the project files has changed (independently of the `include` or `exclude` Cargo.toml settings), or, if provided via `cargo:rerun-if-changed=PATH`, it just looks for the paths that were provided in the run before.

This PR provides some paths to cargo, which reduces the time of a freshness check for _all_ projects from about 6 to 0.15 seconds on my Windows machine. 

We might add some paths later, but this should be good enough for now.