### PR TITLE
Accept Into<T> for simple types to improve API flexibility.

### DIFF
--- a/skia-safe/examples/hello/canvas.rs
+++ b/skia-safe/examples/hello/canvas.rs
@@ -12,7 +12,7 @@ impl Canvas {
 
     pub fn new(width: i32, height: i32) -> Canvas {
         let mut surface =
-            skia::Surface::new_raster_n32_premul((width, height).into())
+            skia::Surface::new_raster_n32_premul((width, height))
                 .expect("no surface!");
         let path = skia::Path::new();
         let mut paint = skia::Paint::default();
@@ -34,7 +34,7 @@ impl Canvas {
 
     #[inline]
     pub fn translate(&mut self, dx: f32, dy: f32) {
-        self.canvas().translate((dx, dy).into());
+        self.canvas().translate((dx, dy));
     }
 
     #[inline]
@@ -45,23 +45,23 @@ impl Canvas {
     #[inline]
     pub fn move_to(&mut self, x: f32, y: f32) {
         self.begin_path();
-        self.path.move_to((x, y).into());
+        self.path.move_to((x, y));
     }
 
     #[inline]
     pub fn line_to(&mut self, x: f32, y: f32) {
-        self.path.line_to((x, y).into());
+        self.path.line_to((x, y));
     }
 
     #[inline]
     pub fn quad_to(&mut self, cpx: f32, cpy: f32, x: f32, y: f32) {
-        self.path.quad_to((cpx, cpy).into(), (x, y).into());
+        self.path.quad_to((cpx, cpy), (x, y));
     }
 
     #[allow(dead_code)]
     #[inline]
     pub fn bezier_curve_to(&mut self, cp1x: f32, cp1y: f32, cp2x: f32, cp2y: f32, x: f32, y: f32) {
-        self.path.cubic_to((cp1x, cp1y).into(), (cp2x, cp2y).into(), (x, y).into());
+        self.path.cubic_to((cp1x, cp1y), (cp2x, cp2y), (x, y));
     }
 
     #[allow(dead_code)]

--- a/skia-safe/examples/skia-org/main.rs
+++ b/skia-safe/examples/skia-org/main.rs
@@ -9,7 +9,7 @@ pub(crate) mod artifact {
 
     pub fn draw_canvas_256<F>(name: &str, func: F)
         where F: Fn(&mut Canvas) -> () {
-        let mut surface = Surface::new_raster_n32_premul((512, 512).into()).unwrap();
+        let mut surface = Surface::new_raster_n32_premul((512, 512)).unwrap();
         let mut canvas = surface.canvas();
         canvas.scale(2.0, 2.0);
         func(&mut canvas);

--- a/skia-safe/examples/skia-org/skcanvas_overview.rs
+++ b/skia-safe/examples/skia-org/skcanvas_overview.rs
@@ -12,25 +12,25 @@ fn draw_heptagram(canvas: &mut Canvas) {
     const R : scalar = 0.45 * SCALE;
     const TAU : scalar = 6.2831853;
     let mut path = Path::default();
-    path.move_to((R, 0.0).into());
+    path.move_to((R, 0.0));
     for i in 1..7 {
         let theta = 3.0 * (i as scalar) * TAU / 7.0;
-        path.line_to((R * scalar::cos(theta), R * scalar::sin(theta)).into());
+        path.line_to((R * scalar::cos(theta), R * scalar::sin(theta)));
     }
 
     path.close();
     let mut p = Paint::default();
     p.set_anti_alias(true);
     canvas.clear(Color::WHITE);
-    canvas.translate((0.5 * SCALE, 0.5 * SCALE).into());
+    canvas.translate((0.5 * SCALE, 0.5 * SCALE));
     canvas.draw_path(&path, &p);
 }
 
 fn draw_rotated_rectangle(canvas: &mut Canvas) {
     canvas.save();
-    canvas.translate((128.0, 128.0).into());
+    canvas.translate((128.0, 128.0));
     canvas.rotate(45.0, None);
-    let rect = Rect::from_point_and_size((-90.5, -90.5).into(), (181.0, 181.0).into());
+    let rect = Rect::from_point_and_size((-90.5, -90.5), (181.0, 181.0));
     let mut paint = Paint::default();
     paint.set_color(Color::BLUE);
     canvas.draw_rect(rect, &paint);
@@ -50,28 +50,28 @@ fn draw_hello_skia(canvas: &mut Canvas) {
     paint.set_stroke_width(4.0);
     paint.set_color(Color::RED);
 
-    let mut rect = Rect::from_point_and_size((50.0, 50.0).into(), (40.0, 60.0).into());
+    let mut rect = Rect::from_point_and_size((50.0, 50.0), (40.0, 60.0));
     canvas.draw_rect(rect, &paint);
 
-    let oval = RRect::new_oval(rect).offset((40.0, 60.0).into());
+    let oval = RRect::new_oval(rect).offset((40.0, 60.0));
     paint.set_color(Color::BLUE);
     canvas.draw_rrect(&oval, &paint);
 
     paint.set_color(Color::CYAN);
-    canvas.draw_circle((180.0, 50.0).into(), 25.0, &paint);
+    canvas.draw_circle((180.0, 50.0), 25.0, &paint);
 
-    rect = rect.with_offset((80.0, 0.0).into());
+    rect = rect.with_offset((80.0, 0.0));
     paint.set_color(Color::YELLOW);
     canvas.draw_round_rect(rect, 10.0, 10.0, &paint);
 
     let mut path = Path::default();
-    path.cubic_to((768.0, 0.0).into(), (-512.0, 256.0).into(), (256.0, 256.0).into());
+    path.cubic_to((768.0, 0.0), (-512.0, 256.0), (256.0, 256.0));
     paint.set_color(Color::GREEN);
     canvas.draw_path(&path, &paint);
 
-    canvas.draw_image(&image, (128.0, 128.0).into(), Some(&paint));
+    canvas.draw_image(&image, (128.0, 128.0), Some(&paint));
 
-    let rect2 = Rect::from_point_and_size((0.0, 0.0).into(), (40.0, 60.0).into());
+    let rect2 = Rect::from_point_and_size((0.0, 0.0), (40.0, 60.0));
     canvas.draw_image_rect(&image, None, rect2, &paint);
 
     let paint2 = Paint::default();
@@ -81,5 +81,5 @@ fn draw_hello_skia(canvas: &mut Canvas) {
     // canvas.drawTextBlob(text.get(), 50, 25, paint2);
 
     let font = Font::from_typeface_with_size(&Typeface::default(), 18.0);
-    canvas.draw_str("Hello, Skia!", (50.0, 25.0).into(), &font, &paint2);
+    canvas.draw_str("Hello, Skia!", (50.0, 25.0), &font, &paint2);
 }

--- a/skia-safe/src/skia/image_info.rs
+++ b/skia-safe/src/skia/image_info.rs
@@ -107,7 +107,8 @@ impl Default for Handle<SkImageInfo> {
 
 impl Handle<SkImageInfo> {
 
-    pub fn new(dimensions: ISize, ct: ColorType, at: AlphaType, cs: Option<ColorSpace>) -> Self {
+    pub fn new<IS: Into<ISize>>(dimensions: IS, ct: ColorType, at: AlphaType, cs: Option<ColorSpace>) -> Self {
+        let dimensions = dimensions.into();
         let mut image_info = Self::default();
 
         unsafe {
@@ -116,11 +117,12 @@ impl Handle<SkImageInfo> {
         image_info
     }
 
-    pub fn new_n32(dimensions: ISize, at: AlphaType, cs: Option<ColorSpace>) -> ImageInfo {
+    pub fn new_n32<IS: Into<ISize>>(dimensions: IS, at: AlphaType, cs: Option<ColorSpace>) -> ImageInfo {
         Self::new(dimensions, ColorType::N32, at, cs)
     }
 
-    pub fn new_s32(dimensions: ISize, at: AlphaType) -> ImageInfo {
+    pub fn new_s32<IS: Into<ISize>>(dimensions: IS, at: AlphaType) -> ImageInfo {
+        let dimensions = dimensions.into();
         let mut image_info = Self::default();
         unsafe {
             skia_bindings::C_SkImageInfo_MakeS32(image_info.native_mut(), dimensions.width, dimensions.height, at.0);
@@ -128,11 +130,11 @@ impl Handle<SkImageInfo> {
         image_info
     }
 
-    pub fn new_n32_premul(dimensions: ISize, cs: Option<ColorSpace>) -> ImageInfo {
+    pub fn new_n32_premul<IS: Into<ISize>>(dimensions: IS, cs: Option<ColorSpace>) -> ImageInfo {
         Self::new(dimensions, ColorType::N32, AlphaType::Premul, cs)
     }
 
-    pub fn new_a8(dimensions: ISize) -> ImageInfo {
+    pub fn new_a8<IS: Into<ISize>>(dimensions: IS) -> ImageInfo {
         Self::new(dimensions, ColorType::Alpha8, AlphaType::Premul, None)
     }
 
@@ -188,7 +190,7 @@ impl Handle<SkImageInfo> {
             .unwrap_or(false)
     }
 
-    pub fn with_dimensions(&self, new_dimensions: ISize) -> Self {
+    pub fn with_dimensions<IS: Into<ISize>>(&self, new_dimensions: IS) -> Self {
         Self::new(new_dimensions, self.color_type(), self.alpha_type(), self.color_space())
     }
 
@@ -222,7 +224,8 @@ impl Handle<SkImageInfo> {
         }
     }
 
-    pub fn compute_offset(&self, point: IPoint, row_bytes: usize) -> usize {
+    pub fn compute_offset<IP: Into<IPoint>>(&self, point: IP, row_bytes: usize) -> usize {
+        let point = point.into();
         unsafe {
             self.native().computeOffset(point.x, point.y, row_bytes)
         }
@@ -254,7 +257,7 @@ fn ref_cnt_in_relation_to_color_space() {
     let cs = ColorSpace::new_srgb();
     let before = cs.ref_cnt();
     {
-        let ii = ImageInfo::new_n32(ISize::new(10, 10), AlphaType::Premul, Some(cs.clone()));
+        let ii = ImageInfo::new_n32((10, 10), AlphaType::Premul, Some(cs.clone()));
         let cs = ii.color_space();
         // one for clone, one for the reference in image info.
         assert_eq!(before+2, cs.unwrap().ref_cnt())

--- a/skia-safe/src/skia/matrix44.rs
+++ b/skia-safe/src/skia/matrix44.rs
@@ -166,7 +166,7 @@ impl Handle<SkMatrix44> {
         self
     }
 
-    #[warn(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     pub fn set_3x3(&mut self,
                    m_00: scalar, m_10: scalar, m_20: scalar,
                    m_01: scalar, m_11: scalar, m_21: scalar,

--- a/skia-safe/src/skia/path.rs
+++ b/skia-safe/src/skia/path.rs
@@ -214,16 +214,16 @@ impl Handle<SkPath> {
         self
     }
 
-    pub fn is_line_degenerate(p1: Point, p2: Point, exact: bool) -> bool {
-        unsafe { SkPath::IsLineDegenerate(p1.native(), p2.native(), exact) }
+    pub fn is_line_degenerate<P: Into<Point>>(p1: P, p2: P, exact: bool) -> bool {
+        unsafe { SkPath::IsLineDegenerate(p1.into().native(), p2.into().native(), exact) }
     }
 
-    pub fn is_quad_degenerate(p1: Point, p2: Point, p3: Point, exact: bool) -> bool {
-        unsafe { SkPath::IsQuadDegenerate(p1.native(), p2.native(), p3.native(), exact) }
+    pub fn is_quad_degenerate<P: Into<Point>>(p1: P, p2: P, p3: P, exact: bool) -> bool {
+        unsafe { SkPath::IsQuadDegenerate(p1.into().native(), p2.into().native(), p3.into().native(), exact) }
     }
 
-    pub fn is_cubic_degenerate(p1: Point, p2: Point, p3: Point, p4: Point, exact: bool) -> bool {
-        unsafe { SkPath::IsCubicDegenerate(p1.native(), p2.native(), p3.native(), p4.native(), exact) }
+    pub fn is_cubic_degenerate<P: Into<Point>>(p1: P, p2: P, p3: P, p4: P, exact: bool) -> bool {
+        unsafe { SkPath::IsCubicDegenerate(p1.into().native(), p2.into().native(), p3.into().native(), p4.into().native(), exact) }
     }
 
     pub fn is_line(&self) -> Option<(Point, Point)> {
@@ -296,52 +296,57 @@ impl Handle<SkPath> {
         self
     }
 
-    pub fn move_to(&mut self, p: Point) -> &mut Self {
-        unsafe { self.native_mut().moveTo1(p.native()); }
+    pub fn move_to<P: Into<Point>>(&mut self, p: P) -> &mut Self {
+        unsafe { self.native_mut().moveTo1(p.into().native()); }
         self
     }
 
-    pub fn r_move_to(&mut self, d: Vector) -> &mut Self {
+    pub fn r_move_to<V: Into<Vector>>(&mut self, d: V) -> &mut Self {
+        let d = d.into();
         unsafe { self.native_mut().rMoveTo(d.x, d.y); }
         self
     }
 
-    pub fn line_to(&mut self, p: Point) -> &mut Self {
-        unsafe { self.native_mut().lineTo1(p.native()); }
+    pub fn line_to<P: Into<Point>>(&mut self, p: P) -> &mut Self {
+        unsafe { self.native_mut().lineTo1(p.into().native()); }
         self
     }
 
-    pub fn r_line_to(&mut self, p: Vector) -> &mut Self {
-        unsafe { self.native_mut().rLineTo(p.x, p.y); }
+    pub fn r_line_to<V: Into<Vector>>(&mut self, d: V) -> &mut Self {
+        let d = d.into();
+        unsafe { self.native_mut().rLineTo(d.x, d.y); }
         self
     }
 
-    pub fn quad_to(&mut self, p1: Point, p2: Point) -> &mut Self {
-        unsafe { self.native_mut().quadTo1(p1.native(), p2.native()) };
+    pub fn quad_to<P: Into<Point>>(&mut self, p1: P, p2: P) -> &mut Self {
+        unsafe { self.native_mut().quadTo1(p1.into().native(), p2.into().native()) };
         self
     }
 
-    pub fn r_quad_to(&mut self, dx1: Vector, dx2: Vector) -> &mut Self {
+    pub fn r_quad_to<V: Into<Vector>>(&mut self, dx1: V, dx2: V) -> &mut Self {
+        let (dx1, dx2) = (dx1.into(), dx2.into());
         unsafe { self.native_mut().rQuadTo(dx1.x, dx1.y, dx2.x, dx2.y) };
         self
     }
 
-    pub fn conic_to(&mut self, p1: Point, p2: Point, w: scalar) -> &mut Self {
-        unsafe { self.native_mut().conicTo1(p1.native(), p2.native(), w) };
+    pub fn conic_to<P: Into<Point>>(&mut self, p1: P, p2: P, w: scalar) -> &mut Self {
+        unsafe { self.native_mut().conicTo1(p1.into().native(), p2.into().native(), w) };
         self
     }
 
-    pub fn r_conic_to(&mut self, d1: Vector, d2: Vector, w: scalar) -> &mut Self {
+    pub fn r_conic_to<V: Into<Vector>>(&mut self, d1: V, d2: V, w: scalar) -> &mut Self {
+        let (d1, d2) = (d1.into(), d2.into());
         unsafe { self.native_mut().rConicTo(d1.x, d1.y, d2.x, d2.y, w) };
         self
     }
 
-    pub fn cubic_to(&mut self, p1: Point, p2: Point, p3: Point) -> &mut Self {
-        unsafe { self.native_mut().cubicTo1(p1.native(), p2.native(), p3.native()) };
+    pub fn cubic_to<P: Into<Point>>(&mut self, p1: P, p2: P, p3: P) -> &mut Self {
+        unsafe { self.native_mut().cubicTo1(p1.into().native(), p2.into().native(), p3.into().native()) };
         self
     }
 
-    pub fn r_cubic_to(&mut self, d1: Vector, d2: Vector, d3: Vector) -> &mut Self {
+    pub fn r_cubic_to<V: Into<Vector>>(&mut self, d1: V, d2: V, d3: V) -> &mut Self {
+        let (d1, d2, d3) = (d1.into(), d2.into(), d3.into());
         unsafe { self.native_mut().rCubicTo(d1.x, d1.y, d2.x, d2.y, d3.x, d3.y) };
         self
     }
@@ -351,19 +356,22 @@ impl Handle<SkPath> {
         self
     }
 
-    pub fn arc_to_tangent(&mut self, p1: Point, p2: Point, radius: scalar) -> &mut Self {
+    pub fn arc_to_tangent<P: Into<Point>>(&mut self, p1: P, p2: P, radius: scalar) -> &mut Self {
         // does not link:
         // unsafe { self.native_mut().arcTo2(*p1.native(), *p2.native(), radius) };
+        let (p1, p2) = (p1.into(), p2.into());
         unsafe { self.native_mut().arcTo1(p1.x, p1.y, p2.x, p2.y, radius) };
         self
     }
 
-    pub fn arc_to_rotated(&mut self, r: Point, x_axis_rotate: scalar, large_arc: PathArcSize, sweep: PathDirection, xy: Point) -> &mut Self {
+    pub fn arc_to_rotated<P: Into<Point>>(&mut self, r: P, x_axis_rotate: scalar, large_arc: PathArcSize, sweep: PathDirection, xy: P) -> &mut Self {
+        let (r, xy) = (r.into(), xy.into());
         unsafe { self.native_mut().arcTo4(*r.native(), x_axis_rotate, large_arc.into_native(), sweep.into_native(), *xy.native()) };
         self
     }
 
-    pub fn r_arc_to_rotated(&mut self, r: Point, x_axis_rotate: scalar, large_arc: PathArcSize, sweep: PathDirection, xy: Point) -> &mut Self {
+    pub fn r_arc_to_rotated<P: Into<Point>>(&mut self, r: P, x_axis_rotate: scalar, large_arc: PathArcSize, sweep: PathDirection, xy: P) -> &mut Self {
+        let (r, xy) = (r.into(), xy.into());
         unsafe { self.native_mut().rArcTo(r.x, r.y, x_axis_rotate, large_arc.into_native(), sweep.into_native(), xy.x, xy.y) };
         self
     }
@@ -373,7 +381,8 @@ impl Handle<SkPath> {
         self
     }
 
-    pub fn convert_conic_to_quads(p0: Point, p1: Point, p2: Point, w: scalar, pts: &mut [Point], pow2: usize) -> Option<usize> {
+    pub fn convert_conic_to_quads<P: Into<Point>>(p0: P, p1: P, p2: P, w: scalar, pts: &mut [Point], pow2: usize) -> Option<usize> {
+        let (p0, p1, p2) = (p0.into(), p1.into(), p2.into());
         let max_pts_storage = 1 + 2 * (1 << pow2);
         if max_pts_storage <= pts.len() {
             Some(unsafe {
@@ -422,7 +431,8 @@ impl Handle<SkPath> {
     }
 
     // TODO: make path direction optional, or add a _direction variant.
-    pub fn add_circle(&mut self, p: Point, radius: scalar, dir: PathDirection) -> &mut Self {
+    pub fn add_circle<P: Into<Point>>(&mut self, p: P, radius: scalar, dir: PathDirection) -> &mut Self {
+        let p = p.into();
         unsafe {
             self.native_mut().addCircle(p.x, p.y, radius, dir.into_native())
         };
@@ -462,7 +472,8 @@ impl Handle<SkPath> {
     }
 
     // TODO: mode
-    pub fn add_path(&mut self, src: &Path, d: Vector, mode: AddPathMode) -> &mut Self {
+    pub fn add_path<V: Into<Vector>>(&mut self, src: &Path, d: V, mode: AddPathMode) -> &mut Self {
+        let d = d.into();
         unsafe {
             self.native_mut().addPath(src.native(), d.x, d.y, mode.into_native())
         };
@@ -484,7 +495,8 @@ impl Handle<SkPath> {
         self
     }
 
-    pub fn offset(&mut self, d: Vector) -> &mut Self {
+    pub fn offset<V: Into<Vector>>(&mut self, d: V) -> &mut Self {
+        let d = d.into();
         unsafe {
             self.native_mut().offset1(d.x, d.y)
         };
@@ -492,7 +504,8 @@ impl Handle<SkPath> {
     }
 
     #[must_use]
-    pub fn with_offset(&self, d: Vector) -> Path {
+    pub fn with_offset<V: Into<Vector>>(&self, d: V) -> Path {
+        let d = d.into();
         let mut path = Path::default();
         unsafe {
             self.native().offset(d.x, d.y, path.native_mut())
@@ -523,7 +536,8 @@ impl Handle<SkPath> {
         }.if_true_some(last_pt)
     }
 
-    pub fn set_last_pt(&mut self, p: Point) -> &mut Self {
+    pub fn set_last_pt<P: Into<Point>>(&mut self, p: P) -> &mut Self {
+        let p = p.into();
         unsafe {
             // does not link:
             // self.native_mut().setLastPt1(p.native())
@@ -541,7 +555,8 @@ impl Handle<SkPath> {
     // TODO: Iter
     // TODO: RawIter
 
-    pub fn contains(&self, p: Point) -> bool {
+    pub fn contains<P: Into<Point>>(&self, p: P) -> bool {
+        let p = p.into();
         unsafe { self.native().contains(p.x, p.y) }
     }
 

--- a/skia-safe/src/skia/rect.rs
+++ b/skia-safe/src/skia/rect.rs
@@ -36,7 +36,8 @@ impl IRect {
         IRect { left, top, right, bottom }
     }
 
-    pub fn from_size(size: ISize) -> IRect {
+    pub fn from_size<IS: Into<ISize>>(size: IS) -> IRect {
+        let size = size.into();
         Self::new(0, 0, size.width, size.height)
     }
 
@@ -81,7 +82,8 @@ impl IRect {
     }
 
     #[must_use]
-    pub fn with_offset(&self, delta: IVector) -> Self {
+    pub fn with_offset<IV: Into<IVector>>(&self, delta: IV) -> Self {
+        let delta = delta.into();
         let cloned = *self;
         Self::from_native(unsafe {
             cloned.native().makeOffset(delta.x, delta.y)
@@ -89,26 +91,28 @@ impl IRect {
     }
 
     #[must_use]
-    pub fn with_inset(&self, delta: IVector) -> Self {
+    pub fn with_inset<IV: Into<IVector>>(&self, delta: IV) -> Self {
         /* does not link:
         Self::from_native(unsafe {
             cloned.native().makeInset(delta.x, delta.y)
         }) */
-        self.with_outset(-delta)
+        self.with_outset(-delta.into())
     }
 
     #[must_use]
-    pub fn with_outset(&self, delta: IVector) -> Self {
+    pub fn with_outset<IV: Into<IVector>>(&self, delta: IV) -> Self {
+        let delta = delta.into();
         Self::from_native(unsafe {
             self.native().makeOutset(delta.x, delta.y)
         })
     }
 
     #[must_use]
-    pub fn with_offset_to(&self, new_x: i32, new_y: i32) -> Self {
+    pub fn with_offset_to<IP: Into<IPoint>>(&self, new_p: IP) -> Self {
+        let new_p = new_p.into();
         let mut copied = *self;
         unsafe {
-            copied.native_mut().offsetTo(new_x, new_y)
+            copied.native_mut().offsetTo(new_p.x, new_p.y)
         }
         copied
     }
@@ -207,18 +211,13 @@ impl Rect {
         Self { left, top, right, bottom }
     }
 
-    pub fn from_size(size: Size) -> Self {
-        (Point::default(), size).into()
+    pub fn from_size<S: Into<Size>>(size: S) -> Self {
+        (Point::default(), size.into()).into()
     }
 
     // replacement for new_xywh
-    pub fn from_point_and_size(p: Point, sz: Size) -> Self {
-        (p, sz).into()
-    }
-
-    // TODO: do we need that?
-    pub fn from_isize(size: ISize) -> Rect {
-        Self::from_size(size.into())
+    pub fn from_point_and_size<P: Into<Point>, S: Into<Size>>(p: P, sz: S) -> Self {
+        (p.into(), sz.into()).into()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -281,23 +280,31 @@ impl Rect {
             .if_true_some(r)
     }
 
-    pub fn with_offset(&self, d: Vector) -> Self {
+    #[must_use]
+    pub fn with_offset<V: Into<Vector>>(&self, d: V) -> Self {
+        let d = d.into();
         Self::new(self.left + d.x, self.top + d.y, self.right + d.x, self.bottom + d.y)
     }
 
-    pub fn with_inset(&self, d: Vector) -> Self {
+    #[must_use]
+    pub fn with_inset<V: Into<Vector>>(&self, d: V) -> Self {
+        let d = d.into();
         Self::new(self.left + d.x, self.top + d.y, self.right - d.x, self.bottom - d.y)
     }
 
-    pub fn with_outset(&self, d: Vector) -> Self {
+    #[must_use]
+    pub fn with_outset<V: Into<Vector>>(&self, d: V) -> Self {
+        let d = d.into();
         Self::new(self.left - d.x, self.top - d.y, self.right + d.x, self.bottom + d.y)
     }
 
-    pub fn with_offset_to(&self, new_x: scalar, new_y: scalar) -> Self {
+    #[must_use]
+    pub fn with_offset_to<P: Into<Point>>(&self, new_p: P) -> Self {
+        let new_p = new_p.into();
         // does not link:
         // let mut r = self.clone();
         // unsafe { r.native_mut().offsetTo(new_x, new_y) };
-        Self::new(new_x, new_y, new_x - self.left, new_y - self.top)
+        Self::new(new_p.x, new_p.y, new_p.x - self.left, new_p.y - self.top)
     }
 
     pub fn intersect(a: &Rect, b: &Rect) -> Option<Rect> {

--- a/skia-safe/src/skia/rrect.rs
+++ b/skia-safe/src/skia/rrect.rs
@@ -144,7 +144,8 @@ impl ValueHandle<SkRRect> {
     }
 
     #[must_use]
-    pub fn inset(&self, delta: Vector) -> Self {
+    pub fn inset<V: Into<Vector>>(&self, delta: V) -> Self {
+        let delta = delta.into();
         // inset1 does not link.
         let mut r = Self::default();
         unsafe { self.native().inset(delta.x, delta.y, r.native_mut()) };
@@ -153,13 +154,14 @@ impl ValueHandle<SkRRect> {
 
 
     #[must_use]
-    pub fn outset(&self, delta: Vector) -> Self {
+    pub fn outset<V: Into<Vector>>(&self, delta: V) -> Self {
         // outset and outset1 does not link.
-        self.inset(-delta)
+        self.inset(-delta.into())
     }
 
     #[must_use]
-    pub fn offset(&self, delta: Vector) -> Self {
+    pub fn offset<V: Into<Vector>>(&self, delta: V) -> Self {
+        let delta = delta.into();
         // makeOffset and offset does not link.
         let mut copied = *self;
         unsafe { copied.native_mut().fRect.offset(delta.x, delta.y) }

--- a/skia-safe/src/skia/surface.rs
+++ b/skia-safe/src/skia/surface.rs
@@ -24,7 +24,8 @@ impl NativeRefCountedBase for SkSurface {
 
 impl RCHandle<SkSurface> {
 
-    pub fn new_raster_n32_premul(size: ISize) -> Option<Self> {
+    pub fn new_raster_n32_premul<IS: Into<ISize>>(size: IS) -> Option<Self> {
+        let size = size.into();
         Self::from_ptr(unsafe {
             skia_bindings::C_SkSurface_MakeRasterN32Premul(size.width, size.height, ptr::null())
         })
@@ -76,7 +77,7 @@ impl RCHandle<SkSurface> {
 
 #[test]
 fn create() {
-    assert!(Surface::new_raster_n32_premul((0, 0).into()).is_none());
-    let surface = Surface::new_raster_n32_premul((1, 1).into()).unwrap();
+    assert!(Surface::new_raster_n32_premul((0, 0)).is_none());
+    let surface = Surface::new_raster_n32_premul((1, 1)).unwrap();
     assert_eq!(1, surface.native().ref_cnt())
 }


### PR DESCRIPTION
I've changed some functions to accept `Into<T>` instead of `T`, for some simple point and size types.

As a result, all `.into()` invocations could be removed from the examples.

I think we should support that, but I am not yet sure how it interacts with the `AsRef<>` trait. May be we can combine these two?