### PR TITLE
Modernize legacy enums

### DIFF
--- a/skia-safe/src/skia/bitmap.rs
+++ b/skia-safe/src/skia/bitmap.rs
@@ -74,7 +74,7 @@ impl Handle<SkBitmap> {
     }
 
     pub fn color_type(&self) -> ColorType {
-        ColorType(unsafe { self.native().colorType() })
+        ColorType::from_native(unsafe { self.native().colorType() })
     }
 
     pub fn alpha_type(&self) -> AlphaType {

--- a/skia-safe/src/skia/bitmap.rs
+++ b/skia-safe/src/skia/bitmap.rs
@@ -78,7 +78,7 @@ impl Handle<SkBitmap> {
     }
 
     pub fn alpha_type(&self) -> AlphaType {
-        AlphaType(unsafe { self.native().alphaType() })
+        AlphaType::from_native(unsafe { self.native().alphaType() })
     }
 
     pub fn color_space(&self) -> Option<ColorSpace> {
@@ -114,7 +114,7 @@ impl Handle<SkBitmap> {
     }
 
     pub fn set_alpha_type(&mut self, alpha_type: AlphaType) -> bool {
-        unsafe { self.native_mut().setAlphaType(alpha_type.0) }
+        unsafe { self.native_mut().setAlphaType(alpha_type.into_native()) }
     }
 
     pub unsafe fn pixels(&mut self) -> *mut ffi::c_void {

--- a/skia-safe/src/skia/image.rs
+++ b/skia-safe/src/skia/image.rs
@@ -109,7 +109,7 @@ impl RCHandle<SkImage> {
                 context.native_mut(),
                 backend_texture.native(),
                 origin.into_native(),
-                color_type.0,
+                color_type.into_native(),
                 alpha_type.into_native(),
                 color_space.shared_ptr())
         })
@@ -146,7 +146,7 @@ impl RCHandle<SkImage> {
                 context.native_mut(),
                 backend_texture.native(),
                 origin.into_native(),
-                color_type.0,
+                color_type.into_native(),
                 alpha_type.into_native(),
                 color_space.shared_ptr())
         })
@@ -305,7 +305,7 @@ impl RCHandle<SkImage> {
     }
 
     pub fn color_type(&self) -> ColorType {
-        ColorType(unsafe { self.native().colorType() })
+        ColorType::from_native(unsafe { self.native().colorType() })
     }
 
     pub fn color_space(&self) -> ColorSpace {

--- a/skia-safe/src/skia/image.rs
+++ b/skia-safe/src/skia/image.rs
@@ -110,7 +110,7 @@ impl RCHandle<SkImage> {
                 backend_texture.native(),
                 origin.into_native(),
                 color_type.0,
-                alpha_type.0,
+                alpha_type.into_native(),
                 color_space.shared_ptr())
         })
     }
@@ -147,7 +147,7 @@ impl RCHandle<SkImage> {
                 backend_texture.native(),
                 origin.into_native(),
                 color_type.0,
-                alpha_type.0,
+                alpha_type.into_native(),
                 color_space.shared_ptr())
         })
     }
@@ -301,7 +301,7 @@ impl RCHandle<SkImage> {
     }
 
     pub fn alpha_type(&self) -> AlphaType {
-        AlphaType(unsafe { self.native().alphaType() })
+        AlphaType::from_native(unsafe { self.native().alphaType() })
     }
 
     pub fn color_type(&self) -> ColorType {

--- a/skia-safe/src/skia/image.rs
+++ b/skia-safe/src/skia/image.rs
@@ -164,7 +164,7 @@ impl RCHandle<SkImage> {
         Image::from_ptr(unsafe {
             C_SkImage_MakeFromYUVATexturesCopy(
                 context.native_mut(),
-                yuv_color_space.0,
+                yuv_color_space.into_native(),
                 yuva_textures.native().as_ptr(),
                 yuva_indices.native().as_ptr(),
                 image_size.into_native(),
@@ -191,7 +191,7 @@ impl RCHandle<SkImage> {
         Image::from_ptr(unsafe {
             C_SkImage_MakeFromYUVATexturesCopyWithExternalBackend(
                 context.native_mut(),
-                yuv_color_space.0,
+                yuv_color_space.into_native(),
                 yuva_textures.native().as_ptr(),
                 yuva_indices.as_ptr(),
                 image_size.into_native(),
@@ -216,7 +216,7 @@ impl RCHandle<SkImage> {
         Image::from_ptr(unsafe {
             C_SkImage_MakeFromYUVATextures(
                 context.native_mut(),
-                yuv_color_space.0,
+                yuv_color_space.into_native(),
                 yuva_textures.native().as_ptr(),
                 yuva_indices.as_ptr(),
                 image_size.into_native(),
@@ -235,7 +235,7 @@ impl RCHandle<SkImage> {
         Image::from_ptr(unsafe {
             C_SkImage_MakeFromNV12TexturesCopy(
                 context.native_mut(),
-                yuv_color_space.0,
+                yuv_color_space.into_native(),
                 nv12_textures.native().as_ptr(),
                 image_origin.into_native(),
                 image_color_space.shared_ptr())
@@ -253,7 +253,7 @@ impl RCHandle<SkImage> {
         Image::from_ptr(unsafe {
             C_SkImage_MakeFromNV12TexturesCopyWithExternalBackend(
                 context.native_mut(),
-                yuv_color_space.0,
+                yuv_color_space.into_native(),
                 nv12_textures.native().as_ptr(),
                 image_origin.into_native(),
                 backend_texture.native(),

--- a/skia-safe/src/skia/image_info.rs
+++ b/skia-safe/src/skia/image_info.rs
@@ -84,14 +84,16 @@ impl ColorType {
     }
 }
 
-pub struct YUVColorSpace(pub(crate) SkYUVColorSpace);
-#[allow(non_upper_case_globals)]
-
-impl YUVColorSpace {
-    pub const JPEG: Self = Self(SkYUVColorSpace::kJPEG_SkYUVColorSpace);
-    pub const Rec601: Self = Self(SkYUVColorSpace::kRec601_SkYUVColorSpace);
-    pub const Rec709: Self = Self(SkYUVColorSpace::kRec709_SkYUVColorSpace);
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[repr(i32)]
+pub enum YUVColorSpace {
+    JPEG = SkYUVColorSpace::kJPEG_SkYUVColorSpace as _,
+    Rec601 = SkYUVColorSpace::kRec601_SkYUVColorSpace as _,
+    Rec709 = SkYUVColorSpace::kRec709_SkYUVColorSpace as _
 }
+
+impl NativeTransmutable<SkYUVColorSpace> for YUVColorSpace {}
+#[test] fn test_yuv_color_space_layout() { YUVColorSpace::test_layout() }
 
 pub type ImageInfo = Handle<SkImageInfo>;
 

--- a/skia-safe/src/skia/yuva_index.rs
+++ b/skia-safe/src/skia/yuva_index.rs
@@ -4,15 +4,17 @@ use skia_bindings::{
     SkColorChannel
 };
 
-#[derive(Copy, Clone)]
-pub struct ColorChannel(pub(crate) SkColorChannel);
-
-impl ColorChannel {
-    pub const R: Self = Self(SkColorChannel::kR);
-    pub const G: Self = Self(SkColorChannel::kG);
-    pub const B: Self = Self(SkColorChannel::kB);
-    pub const A: Self = Self(SkColorChannel::kA);
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[repr(i32)]
+pub enum ColorChannel {
+    R = SkColorChannel::kR as _,
+    G = SkColorChannel::kG as _,
+    B = SkColorChannel::kB as _,
+    A = SkColorChannel::kA as _
 }
+
+impl NativeTransmutable<SkColorChannel> for ColorChannel {}
+#[test] fn test_color_channel_layout() { ColorChannel::test_layout() }
 
 #[derive(Copy, Clone)]
 pub struct YUVAIndex(pub(crate) SkYUVAIndex);
@@ -32,13 +34,13 @@ impl YUVAIndex {
                 assert!(index < 4);
                 YUVAIndex::from_native(SkYUVAIndex {
                     fIndex: index.try_into().unwrap(),
-                    fChannel: channel.0
+                    fChannel: channel.into_native()
                 })
             },
             None => {
                 YUVAIndex::from_native(SkYUVAIndex {
                     fIndex: -1,
-                    fChannel: ColorChannel::A.0
+                    fChannel: ColorChannel::A.into_native()
                 })
             }
         }


### PR DESCRIPTION
Some enums fell under the radar in #34, because they were originally represented as newtypes.

This PR "modernizes" them.