### PR TITLE
Remove unused DashType

### DIFF
--- a/skia-safe/src/skia/path_effect.rs
+++ b/skia-safe/src/skia/path_effect.rs
@@ -85,17 +85,6 @@ impl PathEffectPointData {
     }
 }
 
-/*
-// TODO: why is this here?
-pub type DashType = EnumHandle<SkPathEffect_DashType>;
-
-#[allow(non_upper_case_globals)]
-impl EnumHandle<SkPathEffect_DashType> {
-    pub const None: Self = Self(SkPathEffect_DashType::kNone_DashType);
-    pub const Dash: Self = Self(SkPathEffect_DashType::kDash_DashType);
-}
-*/
-
 #[derive(Clone, PartialEq, Debug)]
 pub struct PathEffectDashInfo {
     pub intervals: Vec<scalar>,


### PR DESCRIPTION
This type was just used to represent a boolean-like return value which was converted to an `Option<>`, so I think it's safe to remove it for now.