### PR TITLE
Skia org example artifacts

### DIFF
--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -47,7 +47,7 @@ jobs:
     displayName: Build all targets
   - script: cargo test --release -p skia-safe -vv
     displayName: Test skia-safe
-  - script: cargo run --example skia-org $env:BUILD_ARTIFACTSTAGINGDIRECTORY/skia-org
+  - script: cargo run --example skia-org ${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-org
     displayName: Run skia-org Example
   - task: PublishBuildArtifacts@1
     inputs:

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -48,7 +48,7 @@ jobs:
   - script: cargo test --release -p skia-safe -vv
     displayName: Test skia-safe
   - script: cargo run --example skia-org $env:BUILD_ARTIFACTSTAGINGDIRECTORY/skia-org
-  	displayName: Run skia-org Example
+    displayName: Run skia-org Example
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)/skia-org'

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -47,3 +47,9 @@ jobs:
     displayName: Build all targets
   - script: cargo test --release -p skia-safe -vv
     displayName: Test skia-safe
+  - script: cargo run --example skia-org $env:BUILD_ARTIFACTSTAGINGDIRECTORY/skia-org
+  	displayName: Run skia-org Example
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)/skia-org'
+      artifactName: 'skia-org-examples'

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -56,4 +56,4 @@ jobs:
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)/skia-org'
-      artifactName: 'skia-org-examples'
+      artifactName: 'skia-org-examples-${{ parameters.name }}-$(rustup_toolchain)'

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -47,8 +47,12 @@ jobs:
     displayName: Build all targets
   - script: cargo test --release -p skia-safe -vv
     displayName: Test skia-safe
-  - script: cargo run --example skia-org ${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-org
-    displayName: Run skia-org Example
+  - ${{ if ne(parameters.name, 'Windows') }}:
+    - script: cargo run --release --example skia-org ${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-org
+      displayName: Run skia-org Example
+  - ${{ if eq(parameters.name, 'Windows') }}:
+    - script: cargo run --release --example skia-org %BUILD_ARTIFACTSTAGINGDIRECTORY%/skia-org
+      displayName: Run skia-org Example
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)/skia-org'

--- a/skia-safe/examples/skia-org/skcanvas_overview.rs
+++ b/skia-safe/examples/skia-org/skcanvas_overview.rs
@@ -1,10 +1,13 @@
+use std::path::PathBuf;
 use skia_safe::skia::{Canvas, Path, scalar, Paint, Color, Rect, PaintStyle, BlendMode, RRect, Font, Typeface, Image, Data};
 use crate::artifact;
 
-pub fn draw() {
-    artifact::draw_canvas_256("heptagram", draw_heptagram);
-    artifact::draw_canvas_256("rotated-rectangle", draw_rotated_rectangle);
-    artifact::draw_canvas_256("hello-skia", draw_hello_skia);
+pub fn draw(path: &PathBuf) {
+    let path = path.join("SkCanvas-Overview");
+
+    artifact::draw_canvas_256(&path, "heptagram", draw_heptagram);
+    artifact::draw_canvas_256(&path, "rotated-rectangle", draw_rotated_rectangle);
+    artifact::draw_canvas_256(&path, "hello-skia", draw_hello_skia);
 }
 
 fn draw_heptagram(canvas: &mut Canvas) {

--- a/skia-safe/examples/skia-org/skpath_overview.rs
+++ b/skia-safe/examples/skia-org/skpath_overview.rs
@@ -1,12 +1,15 @@
+use std::path::PathBuf;
 use skia_safe::skia::{Canvas, Path, Paint, Color, PaintStyle, Font, PaintCap};
 use crate::artifact;
 
-pub fn draw() {
-    artifact::draw_canvas_256("example1", draw_example1);
-    artifact::draw_canvas_256("example2", draw_example2);
-    artifact::draw_canvas_256("example3", draw_example3);
-    artifact::draw_canvas_256("example4", draw_example4);
-    artifact::draw_canvas_256("example5", draw_example5);
+pub fn draw(path: &PathBuf) {
+    let path = path.join("SkPath-Overview");
+
+    artifact::draw_canvas_256(&path, "example1", draw_example1);
+    artifact::draw_canvas_256(&path, "example2", draw_example2);
+    artifact::draw_canvas_256(&path, "example3", draw_example3);
+    artifact::draw_canvas_256(&path, "example4", draw_example4);
+    artifact::draw_canvas_256(&path, "example5", draw_example5);
 }
 
 fn draw_example1(canvas: &mut Canvas) {


### PR DESCRIPTION
This PR tries to generate the PNG images of the skia-org example on azure and stores them into a downloadable build artifact. 

This way we can automatically generate the example images on all platforms.