### PR TITLE
Make `cargo doc` work by blacklisting `SkColorFilter_asComponentTable`

### DIFF
--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -151,6 +151,9 @@ fn bindgen_gen(current_dir_name: &str, skia_out_dir: &str) {
     .whitelist_function("SkPreMultiplyColor")
     .whitelist_function("SkBlendMode_Name")
 
+    // functions for which the doc generation fails.
+    .blacklist_function("SkColorFilter_asComponentTable")
+
     .whitelist_type("SkColorSpacePrimaries")
     .whitelist_type("SkVector4")
     .whitelist_type("SkPictureRecorder")


### PR DESCRIPTION
... which we wrapped in bindings.cpp anyway.

The automatically generated documentation of this function caused `cargo doc` to fail because of an parsing error. Blacklisting it made `cargo doc` work again.

This is to further prepare for #23.