### PR TITLE
Windows build fixes

### DIFF
--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -36,7 +36,7 @@ fn main() {
     let keep_inline_functions = true;
 
     let mut args =
-      r#"--args=is_official_build=true skia_use_system_expat=false skia_use_system_icu=false skia_use_system_libjpeg_turbo=false skia_use_system_libpng=false skia_use_libwebp=false skia_use_system_zlib=false cc="clang" cxx="clang++""#
+      r#"--args=is_official_build=true skia_use_expat=false skia_use_icu=false skia_use_system_libjpeg_turbo=false skia_use_system_libpng=false skia_use_libwebp=false skia_use_system_zlib=false cc="clang" cxx="clang++""#
       .to_owned();
 
     if cfg!(feature="vulkan") {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -926,6 +926,10 @@ extern "C" bool C_SkShader_isOpaque(const SkShader* self) {
     return self->isOpaque();
 }
 
+extern "C" bool C_SkShader_isAImage(const SkShader* self) {
+    return self->isAImage();
+}
+
 extern "C" SkShader::GradientType C_SkShader_asAGradient(const SkShader* self, SkShader::GradientInfo* info) {
     return self->asAGradient(info);
 }

--- a/skia-safe/src/skia/shader.rs
+++ b/skia-safe/src/skia/shader.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use skia_bindings::{SkShader, SkRefCntBase, SkShader_TileMode, SkShader_GradientType, SkShader_GradientInfo, C_SkShader_asAGradient, C_SkShader_makeWithLocalMatrix, C_SkShader_makeWithColorFilter, C_SkShader_MakeEmptyShader, C_SkShader_MakeColorShader, C_SkShader_MakeColorShader2, C_SkShader_MakeCompose, C_SkShader_MakeMixer, C_SkShader_MakeBitmapShader, C_SkShader_MakePictureShader, C_SkShader_makeAsALocalMatrixShader};
+use skia_bindings::{SkShader, SkRefCntBase, SkShader_TileMode, SkShader_GradientType, SkShader_GradientInfo, C_SkShader_asAGradient, C_SkShader_makeWithLocalMatrix, C_SkShader_makeWithColorFilter, C_SkShader_MakeEmptyShader, C_SkShader_MakeColorShader, C_SkShader_MakeColorShader2, C_SkShader_MakeCompose, C_SkShader_MakeMixer, C_SkShader_MakeBitmapShader, C_SkShader_MakePictureShader, C_SkShader_makeAsALocalMatrixShader, C_SkShader_isAImage};
 use crate::skia::{Matrix, Image, Color, scalar, Point, ColorFilter, ColorSpace, Color4f, BlendMode, Bitmap, Rect, Picture};
 use std::mem;
 
@@ -86,7 +86,9 @@ impl RCHandle<SkShader> {
 
     pub fn is_a_image(&self) -> bool {
         unsafe {
-            self.native().isAImage1()
+            // does not link under Windows.
+            // self.native().isAImage1()
+            C_SkShader_isAImage(self.native())
         }
     }
 


### PR DESCRIPTION
Hmm, not sure why, but I tried to set up my Notebook and some unexpected build errors turned up. This PR fixes them.

One Expat related:

```
libskia_bindings-79a47c77b634b4d0.rlib(expat.xmlparse.obj) : error LNK2019: unresolved external symbol _Expat_LoadLibrary referenced in function writeRandomBytes_RtlGenRandom
```

And another linking problem with a small function:

```
error LNK2019: unresolved external symbol "public: bool __cdecl SkShader::isAImage(void)const " (?isAImage@SkShader@@QEBA_NXZ) referenced in function _ZN13skia_bindings8bindings8SkShader9isAImage117hd3c10d0f9f1d8db2E
```