### PR TITLE
Pin LLVM version to 7.0.1 on the CI builds

### DIFF
--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -33,7 +33,7 @@ jobs:
         rustup-init.exe -y --default-toolchain %RUSTUP_TOOLCHAIN%
         set PATH=%PATH%;%USERPROFILE%\.cargo\bin
         echo "##vso[task.setvariable variable=PATH;]%PATH%;%USERPROFILE%\.cargo\bin"
-        choco install llvm
+        choco install llvm --version 7.0.1
       displayName: Install rust (windows)
   # All platforms.
   - script: |

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -18,7 +18,7 @@ jobs:
       architecture: 'x64'
   - ${{ if eq(parameters.name, 'macOS') }}:
     - script: |
-        brew update && brew install llvm
+        brew update && brew install llvm@7
       displayName: Install llvm
   - ${{ if ne(parameters.name, 'Windows') }}:
     # Linux and macOS.


### PR DESCRIPTION
Since llvm was updated to version 8, Mac OS X CI builds fail with the following error message in the binding generation step: 

```
/Users/vsts/agent/2.148.2/work/1/s/skia-bindings/skia/include/private/../private/SkOnce.h:11:10: fatal error: 'atomic' file not found
/Users/vsts/agent/2.148.2/work/1/s/skia-bindings/skia/include/private/../private/SkOnce.h:11:10: fatal error: 'atomic' file not found, err: true
thread 'main' panicked at 'Unable to generate bindings: ()', src/libcore/result.rs:997:5
```

To mitigate, I am trying to pin all CI builds to LLVM 7 for now.