### PR TITLE
Add ref-count for GrGLInterface before passing it to GrContext::MakeGL

### DIFF
--- a/skia-safe/src/gpu/context.rs
+++ b/skia-safe/src/gpu/context.rs
@@ -34,7 +34,7 @@ impl RCHandle<GrContext> {
     // TODO: support variant with GrContextOptions
     pub fn new_gl(interface: Option<&gl::Interface>) -> Option<Context> {
         Context::from_ptr(unsafe {
-            C_GrContext_MakeGL(interface.native_ptr_or_null())
+            C_GrContext_MakeGL(interface.shared_ptr())
         })
     }
 


### PR DESCRIPTION
Closes #59 

Sorry, no testcase possible (can't render OpenGL on the CI). I've tested that locally with skia-org.