### PR TITLE
M74

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Build Status](https://dev.azure.com/pragmatrix-github/rust-skia/_apis/build/status/rust-skia.rust-skia?branchName=master)](https://dev.azure.com/pragmatrix-github/rust-skia/_build/latest?definitionId=2&branchName=master)
 
-Skia Submodule Status: chrome/m73 ([pending changes][skiapending]).
+Skia Submodule Status: chrome/m74 ([pending changes][skiapending]).
 
-[skiapending]: https://github.com/google/skia/compare/2c36ee834ae04d036363cd3b8f3f33ec65d657f0...chrome/m73
+[skiapending]: https://github.com/google/skia/compare/ae4b97edd5b9eeee9e4fe9814f67e3abc4ba1a75...chrome/m74
 
 ## Goals
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skia-bindings"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"

--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -27,6 +27,15 @@ mod build {
 
     /// Build with SVG support?
     pub const SVG: bool = cfg!(feature = "svg");
+
+    /// Build with animation support.
+    pub const ANIMATION: bool = false;
+
+    /// Support DNG file format.
+    pub const DNG: bool = false;
+
+    /// Build the particles module.
+    pub const PARTICLES: bool = false;
 }
 
 fn main() {
@@ -82,6 +91,10 @@ fn main() {
             ("skia_use_system_libpng", no()),
             ("skia_use_libwebp", no()),
             ("skia_use_system_zlib", no()),
+            ("skia_enable_skottie", if build::ANIMATION { yes() } else { no() }),
+            ("skia_use_xps", no()),
+            ("skia_use_dng_sdk", if build::DNG { yes() } else { no() }),
+            ("skia_enable_particles", if build::PARTICLES { yes() } else { no() }),
             ("cc", quote("clang")),
             ("cxx", quote("clang++")),
         ];

--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -245,7 +245,6 @@ fn bindgen_gen(current_dir: &Path, skia_out_dir: &str) {
         .whitelist_type("SkDocument")
 
         .whitelist_type("SkDynamicMemoryWStream")
-        .whitelist_type("SkXMLStreamWriter")
 
         .whitelist_type("GrGLBackendState")
 

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -49,7 +49,6 @@
 
 #if defined(SK_XML)
 #include "SkSVGCanvas.h"
-#include "SkXMLWriter.h"
 #endif
 
 template<typename T>
@@ -1373,16 +1372,8 @@ extern "C" bool C_GrVkImageInfo_Equals(const GrVkImageInfo* lhs, const GrVkImage
 
 #if defined(SK_XML)
 
-// Note, we can't use the SkWStream* implementation, because its implementation creates
-// an SkXMLWriter and destroys it before returning (this bug is fixed in Skia master, and
-// so may be available in a future update).
-
-extern "C" SkCanvas* C_SkSVGCanvas_Make(const SkRect* bounds, SkXMLWriter* writer) {
+extern "C" SkCanvas* C_SkSVGCanvas_Make(const SkRect* bounds, SkWStream* writer) {
     return SkSVGCanvas::Make(*bounds, writer).release();
-}
-
-extern "C" void C_SkXMLStreamWriter_destruct(SkXMLStreamWriter* self) {
-    self->~SkXMLStreamWriter();
 }
 
 #endif

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -931,6 +931,10 @@ extern "C" SkColorFilter* C_SkColorFilter_MakeSRGBToLinearGamma() {
     return SkColorFilter::MakeSRGBToLinearGamma().release();
 }
 
+extern "C" SkColorFilter* C_SkColorFilter_MakeMixer(const SkColorFilter* cf0, const SkColorFilter* cf1, float weight) {
+    return SkColorFilter::MakeMixer(spFromConst(cf0), spFromConst(cf1), weight).release();
+}
+
 extern "C" bool C_SkColorFilter_asColorMode(const SkColorFilter* self, SkColor* color, SkBlendMode* mode) {
     return self->asColorMode(color, mode);
 }

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -402,10 +402,6 @@ extern "C" void C_SkPaint_setMaskFilter(SkPaint* self, const SkMaskFilter* maskF
     self->setMaskFilter(spFromConst(maskFilter));
 }
 
-extern "C" SkFontHinting C_SkPaint_getHinting(const SkPaint* self) {
-    return self->getHinting();
-}
-
 // postponed
 
 /*

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -872,6 +872,14 @@ extern "C" SkData* C_SkVertices_encode(const SkVertices* self) {
 }
 
 //
+// SkVertices::Bone
+//
+
+extern "C" SkRect C_SkVertices_Bone_mapRect(const SkVertices::Bone* self, const SkRect* rect) {
+    return self->mapRect(*rect);
+}
+
+//
 // SkVertices::Builder
 //
 

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skia-safe"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 

--- a/skia-safe/src/core/bitmap.rs
+++ b/skia-safe/src/core/bitmap.rs
@@ -176,6 +176,12 @@ impl Handle<SkBitmap> {
         unsafe { self.native_mut().tryAllocPixelsFlags(image_info.native(), flags.bits()) }
     }
 
+    pub fn alloc_pixels_flags(&mut self, image_info: &ImageInfo, flags: BitmapAllocFlags) {
+        self.try_alloc_pixels_flags(image_info, flags)
+            .to_option()
+            .expect("Bitmap::alloc_pixels_flags failed");
+    }
+
     #[must_use]
     pub fn try_alloc_pixels_info(&mut self, image_info: &ImageInfo, row_bytes: Option<usize>) -> bool {
         match row_bytes {
@@ -186,10 +192,22 @@ impl Handle<SkBitmap> {
         }
     }
 
+    pub fn alloc_pixels_info(&mut self, image_info: &ImageInfo, row_bytes: Option<usize>) {
+        self.try_alloc_pixels_info(image_info, row_bytes)
+            .to_option()
+            .expect("Bitmap::alloc_pixels_info failed");
+    }
+
     #[must_use]
-    pub fn try_alloc_n32_pixels(&mut self, width: i32, height: i32, is_opaque: bool) -> bool {
+    pub fn try_alloc_n32_pixels(&mut self, (width, height): (i32, i32), is_opaque: bool) -> bool {
         // accessing the instance method causes a linker error.
         unsafe { C_SkBitmap_tryAllocN32Pixels(self.native_mut(), width, height, is_opaque) }
+    }
+
+    pub fn alloc_n32_pixels(&mut self, (width, height): (i32, i32), is_opaque: bool) {
+        self.try_alloc_n32_pixels((width, height), is_opaque)
+            .to_option()
+            .expect("Bitmap::alloc_n32_pixels_failed")
     }
 
     pub unsafe fn install_pixels(&mut self, image_info: &ImageInfo, pixels: *mut ffi::c_void, row_bytes: usize) -> bool {
@@ -200,6 +218,12 @@ impl Handle<SkBitmap> {
     pub fn try_alloc_pixels(&mut self) -> bool {
         // linker errr.
         unsafe { C_SkBitmap_tryAllocPixels(self.native_mut()) }
+    }
+
+    pub fn alloc_pixels(&mut self) {
+        self.try_alloc_pixels()
+            .to_option()
+            .expect("Bitmap::alloc_pixels failed")
     }
 
     pub fn pixel_ref_origin(&self) -> IPoint {

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -241,8 +241,6 @@ impl Canvas {
         Canvas::own_from_native_ptr(ptr).unwrap()
     }
 
-    // TODO: getMetaData()
-
     pub fn image_info(&self) -> ImageInfo {
         let mut ii = ImageInfo::default();
         unsafe {

--- a/skia-safe/src/core/color.rs
+++ b/skia-safe/src/core/color.rs
@@ -249,6 +249,16 @@ impl Color4f {
         self.a == 1.0
     }
 
+    // TODO: this is the copied implementation, it would probably be better to call the Skia function.
+
+    pub fn fits_in_bytes(&self) -> bool {
+        debug_assert!(self.a >= 0.0 && self.a <= 1.0);
+        return
+            self.r >= 0.0 && self.r <= 1.0 &&
+                self.g >= 0.0 && self.g <= 1.0 &&
+                self.b >= 0.0 && self.b <= 1.0;
+    }
+
     pub fn to_color(&self) -> Color {
         fn c(f: f32) -> u8 {
             (f.max(0.0).min(1.0) * 255.0) as u8

--- a/skia-safe/src/core/color_filter.rs
+++ b/skia-safe/src/core/color_filter.rs
@@ -8,22 +8,7 @@ use crate::core::{
     ColorSpace,
     scalar
 };
-use skia_bindings::{
-    C_SkColorFilter_MakeLinearToSRGBGamma,
-    C_SkColorFilter_MakeMatrixFilterRowMajor255,
-    C_SkColorFilter_makeComposed,
-    C_SkColorFilter_getFlags,
-    C_SkColorFilter_asComponentTable,
-    C_SkColorFilter_asColorMatrix,
-    C_SkColorFilter_asColorMode,
-    SkColor,
-    SkBlendMode,
-    C_SkColorFilter_MakeModeFilter,
-    SkRefCntBase,
-    SkColorFilter,
-    C_SkColorFilter_MakeSRGBToLinearGamma,
-    SkColorFilter_Flags_kAlphaUnchanged_Flag
-};
+use skia_bindings::{C_SkColorFilter_MakeLinearToSRGBGamma, C_SkColorFilter_MakeMatrixFilterRowMajor255, C_SkColorFilter_makeComposed, C_SkColorFilter_getFlags, C_SkColorFilter_asComponentTable, C_SkColorFilter_asColorMatrix, C_SkColorFilter_asColorMode, SkColor, SkBlendMode, C_SkColorFilter_MakeModeFilter, SkRefCntBase, SkColorFilter, C_SkColorFilter_MakeSRGBToLinearGamma, SkColorFilter_Flags_kAlphaUnchanged_Flag, C_SkColorFilter_MakeMixer};
 
 bitflags! {
     pub struct ColorFilterFlags: u32 {
@@ -111,6 +96,12 @@ impl RCHandle<SkColorFilter> {
         ColorFilter::from_ptr(unsafe {
             C_SkColorFilter_MakeSRGBToLinearGamma()
         }).unwrap()
+    }
+
+    pub fn new_mixer(cf0: &ColorFilter, cf1: &ColorFilter, weight: f32) -> Option<ColorFilter> {
+        ColorFilter::from_ptr(unsafe {
+            C_SkColorFilter_MakeMixer(cf0.shared_native(), cf1.shared_native(), weight)
+        })
     }
 }
 

--- a/skia-safe/src/core/color_space.rs
+++ b/skia-safe/src/core/color_space.rs
@@ -1,11 +1,8 @@
-use std::mem;
 use super::{Matrix44, Data};
 use crate::prelude::*;
 use skia_bindings::{
-    SkColorSpaceTransferFn,
     SkColorSpace,
     SkColorSpacePrimaries,
-    SkColorSpace_Gamut,
 };
 
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -34,15 +31,9 @@ pub struct ColorSpaceTransferFn {
     pub f: f32
 }
 
-impl NativeTransmutable<SkColorSpaceTransferFn> for ColorSpaceTransferFn {}
-
-#[test]
-fn test_color_space_transfer_fn_layout() {
-    ColorSpaceTransferFn::test_layout()
-}
-
 pub struct NamedTransferFn {}
 
+// TODO: Make the binding generator provide all these constants.
 #[allow(non_upper_case_globals)]
 impl NamedTransferFn {
     pub const SRGB: ColorSpaceTransferFn = ColorSpaceTransferFn {
@@ -101,13 +92,6 @@ impl ColorSpace {
 
     pub fn new_srgb_linear() -> ColorSpace {
         ColorSpace::from_ptr(unsafe { skia_bindings::C_SkColorSpace_MakeSRGBLinear() }).unwrap()
-    }
-
-    pub fn is_numerical_transfer_fn(&self) -> Option<ColorSpaceTransferFn> {
-        let mut tfn : ColorSpaceTransferFn = unsafe { mem::zeroed() };
-        unsafe {
-            self.native().isNumericalTransferFn(tfn.native_mut())
-        }.if_true_some(tfn)
     }
 
     pub fn to_xyzd50(&self) -> Option<Matrix44> {

--- a/skia-safe/src/core/color_space.rs
+++ b/skia-safe/src/core/color_space.rs
@@ -142,16 +142,6 @@ impl ColorSpace {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-#[repr(i32)]
-pub enum ColorSpaceGamut {
-    SRGB = SkColorSpace_Gamut::kSRGB_Gamut as _,
-    DCIP3D65 = SkColorSpace_Gamut::kDCIP3_D65_Gamut as _,
-}
-
-impl NativeTransmutable<SkColorSpace_Gamut> for ColorSpaceGamut {}
-#[test] fn test_color_space_gamut_layout () { ColorSpaceGamut::test_layout() }
-
 pub struct XYZD50Hash(pub u32);
 
 #[cfg(test)]

--- a/skia-safe/src/core/font.rs
+++ b/skia-safe/src/core/font.rs
@@ -258,26 +258,6 @@ impl Handle<SkFont> {
         unsafe { self.native().unicharToGlyph(uni) }
     }
 
-    pub fn contains_str(&self, str: &str) -> bool {
-        let bytes = str.as_bytes();
-        unsafe {
-            self.native().containsText(bytes.as_ptr() as _, bytes.len(), TextEncoding::UTF8.into_native())
-        }
-    }
-
-    // note that the returned usize value is the bytes of the str that fits and not the characters.
-    pub fn break_str(&self, str: &str, max_width: scalar) -> (usize, scalar) {
-        let bytes = str.as_bytes();
-
-        let mut measured_width = scalar::default();
-        let bytes_fit = unsafe { self.native()
-            .breakText(
-                bytes.as_ptr() as _, bytes.len(), TextEncoding::UTF8.into_native(),
-                max_width, &mut measured_width) };
-
-        (bytes_fit, measured_width)
-    }
-
     pub fn measure_str(&self, str: &str, paint: Option<&Paint>) -> (scalar, Rect) {
         let bytes = str.as_bytes();
         let mut bounds = Rect::default();

--- a/skia-safe/src/core/image_info.rs
+++ b/skia-safe/src/core/image_info.rs
@@ -45,6 +45,7 @@ pub enum ColorType {
     RGBA1010102 = SkColorType::kRGBA_1010102_SkColorType as _,
     RGB101010x = SkColorType::kRGB_101010x_SkColorType as _,
     Gray8 = SkColorType::kGray_8_SkColorType as _,
+    F16Norm = SkColorType::kRGBA_F16Norm_SkColorType as _,
     RGBAF16 = SkColorType::kRGBA_F16_SkColorType as _,
     RGBAF32 = SkColorType::kRGBA_F32_SkColorType as _,
 }

--- a/skia-safe/src/core/paint.rs
+++ b/skia-safe/src/core/paint.rs
@@ -117,15 +117,6 @@ impl Handle<SkPaint> {
         self
     }
 
-    pub fn set_hinting(&mut self, hinting_level: FontHinting) -> &mut Self {
-        unsafe { self.native_mut().setHinting(hinting_level.into_native()) }
-        self
-    }
-
-    pub fn hinting(&self) -> FontHinting {
-        FontHinting::from_native(unsafe { self.native().getHinting() })
-    }
-
     pub fn is_anti_alias(&self) -> bool {
         unsafe { self.native().isAntiAlias() }
     }

--- a/skia-safe/src/core/paint.rs
+++ b/skia-safe/src/core/paint.rs
@@ -154,8 +154,17 @@ impl Handle<SkPaint> {
         self
     }
 
+    pub fn alpha_f(&self) -> f32 {
+        unsafe { self.native().getAlphaf() }
+    }
+
     pub fn alpha(&self) -> u8 {
         unsafe { self.native().getAlpha() }
+    }
+
+    pub fn set_alpha_f(&mut self, alpha: f32) -> &mut Self {
+        unsafe { self.native_mut().setAlphaf(alpha) }
+        self
     }
 
     pub fn set_alpha(&mut self, alpha: u8) -> &mut Self {

--- a/skia-safe/src/core/paint.rs
+++ b/skia-safe/src/core/paint.rs
@@ -4,31 +4,8 @@ use std::hash::{
     Hasher
 };
 use crate::prelude::*;
-use crate::core::{Color, FontHinting, FilterQuality, Color4f, ColorSpace, scalar, Path, Rect, ColorFilter, BlendMode, PathEffect, MaskFilter, Shader};
+use crate::core::{Color, FilterQuality, Color4f, ColorSpace, scalar, Path, Rect, ColorFilter, BlendMode, PathEffect, MaskFilter, Shader};
 use skia_bindings::{C_SkPaint_setMaskFilter, C_SkPaint_setPathEffect, C_SkPaint_setColorFilter, SkPaint_Cap, SkPaint, C_SkPaint_destruct, SkPaint_Style, SkPaint_Join, C_SkPaint_Equals, C_SkPaint_setShader};
-use skia_bindings::{
-    SkPaint_Flags_kAntiAlias_Flag,
-    SkPaint_Flags_kDither_Flag,
-    SkPaint_Flags_kFakeBoldText_Flag,
-    SkPaint_Flags_kLinearText_Flag,
-    SkPaint_Flags_kSubpixelText_Flag,
-    SkPaint_Flags_kLCDRenderText_Flag,
-    SkPaint_Flags_kEmbeddedBitmapText_Flag,
-    SkPaint_Flags_kAutoHinting_Flag
-};
-
-bitflags! {
-    pub struct PaintFlags: u32 {
-        const ANTI_ALIAS = SkPaint_Flags_kAntiAlias_Flag as _;
-        const DITHER = SkPaint_Flags_kDither_Flag as _;
-        const FAKE_BOLD_TEXT = SkPaint_Flags_kFakeBoldText_Flag as _;
-        const LINEAR_TEXT = SkPaint_Flags_kLinearText_Flag as _;
-        const SUBPIXEL_TEXT = SkPaint_Flags_kSubpixelText_Flag as _;
-        const LCD_RENDER_TEXT = SkPaint_Flags_kLCDRenderText_Flag as _;
-        const EMBEDDED_BITMAP_TEXT = SkPaint_Flags_kEmbeddedBitmapText_Flag as _;
-        const AUTO_HINTING = SkPaint_Flags_kAutoHinting_Flag as _;
-    }
-}
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(u8)]

--- a/skia-safe/src/core/vertices.rs
+++ b/skia-safe/src/core/vertices.rs
@@ -7,26 +7,7 @@ use crate::core::{
     Color,
     Data
 };
-use skia_bindings::{
-    C_SkVertices_Decode,
-    C_SkVertices_applyBones,
-    C_SkVertices_Builder_detach,
-    C_SkVertices_Builder_destruct,
-    SkVertices_Builder,
-    SkColor,
-    SkPoint,
-    C_SkVertices_MakeCopy,
-    C_SkVertices_ref,
-    SkVertices,
-    C_SkVertices_unref,
-    SkVertices_Bone,
-    SkVertices_VertexMode,
-    C_SkVertices_encode,
-    SkVertices_BuilderFlags_kHasTexCoords_BuilderFlag,
-    SkVertices_BuilderFlags_kHasColors_BuilderFlag,
-    SkVertices_BuilderFlags_kHasBones_BuilderFlag,
-    SkVertices_BuilderFlags_kIsNonVolatile_BuilderFlag
-};
+use skia_bindings::{C_SkVertices_Decode, C_SkVertices_applyBones, C_SkVertices_Builder_detach, C_SkVertices_Builder_destruct, SkVertices_Builder, SkColor, SkPoint, C_SkVertices_MakeCopy, C_SkVertices_ref, SkVertices, C_SkVertices_unref, SkVertices_Bone, SkVertices_VertexMode, C_SkVertices_encode, SkVertices_BuilderFlags_kHasTexCoords_BuilderFlag, SkVertices_BuilderFlags_kHasColors_BuilderFlag, SkVertices_BuilderFlags_kHasBones_BuilderFlag, SkVertices_BuilderFlags_kIsNonVolatile_BuilderFlag, C_SkVertices_Bone_mapRect};
 #[cfg(test)]
 use skia_bindings::{SkVertices_BoneIndices, SkVertices_BoneWeights};
 #[cfg(test)]
@@ -77,7 +58,9 @@ impl VerticesBone {
 
     pub fn map_rect<R: AsRef<Rect>>(&self, rect: R) -> Rect {
         Rect::from_native(unsafe {
-            self.native().mapRect(rect.as_ref().native())
+            // does not link.
+            // self.native().mapRect(rect.as_ref().native())
+            C_SkVertices_Bone_mapRect(self.native(), rect.as_ref().native())
         })
     }
 }

--- a/skia-safe/src/gpu/context.rs
+++ b/skia-safe/src/gpu/context.rs
@@ -13,7 +13,7 @@ pub type Context = RCHandle<GrContext>;
 impl NativeRefCountedBase for GrContext {
     type Base = SkRefCntBase;
     fn ref_counted_base(&self) -> &Self::Base {
-        &self._base._base
+        &self._base._base._base._base._base
     }
 }
 
@@ -68,11 +68,15 @@ impl RCHandle<GrContext> {
         self
     }
 
+    // This function delegates to a base class. We remove this function until the base
+    // class is supported.
+    /*
     pub fn abandoned(&self) -> bool {
         unsafe {
             self.native().abandoned()
         }
     }
+    */
 
     pub fn release_resources_and_abandon(&mut self) -> &mut Self {
         unsafe {

--- a/skia-safe/src/gpu/context.rs
+++ b/skia-safe/src/gpu/context.rs
@@ -60,6 +60,13 @@ impl RCHandle<GrContext> {
         self
     }
 
+    pub fn reset_gl_texture_bindings(&mut self) -> &mut Self {
+        unsafe {
+            self.native_mut().resetGLTextureBindings()
+        }
+        self
+    }
+
     pub fn abandon(&mut self) -> &mut Self {
         unsafe {
             // self.native_mut().abandonContext()

--- a/skia-safe/src/gpu/context.rs
+++ b/skia-safe/src/gpu/context.rs
@@ -178,12 +178,6 @@ impl RCHandle<GrContext> {
 
     // TODO: flushAndSignalSemaphores
 
-    pub fn unique_id(&mut self) -> u32 {
-        unsafe {
-            self.native_mut().uniqueID()
-        }
-    }
-
     pub fn supports_distance_field_text(&self) -> bool {
         unsafe {
             self.native().supportsDistanceFieldText()

--- a/skia-safe/src/gpu/context.rs
+++ b/skia-safe/src/gpu/context.rs
@@ -75,15 +75,11 @@ impl RCHandle<GrContext> {
         self
     }
 
-    // This function delegates to a base class. We remove this function until the base
-    // class is supported.
-    /*
     pub fn abandoned(&self) -> bool {
         unsafe {
-            self.native().abandoned()
+            self.native()._base._base.abandoned()
         }
     }
-    */
 
     pub fn release_resources_and_abandon(&mut self) -> &mut Self {
         unsafe {

--- a/skia-safe/src/gpu/vk/types.rs
+++ b/skia-safe/src/gpu/vk/types.rs
@@ -234,7 +234,8 @@ pub struct DrawableInfo {
     color_attachment_index: u32,
     compatible_render_pass: RenderPass,
     format: Format,
-    draw_bounds: *mut Rect2D
+    draw_bounds: *mut Rect2D,
+    image: Image
 }
 
 impl NativeTransmutable<GrVkDrawableInfo> for DrawableInfo {}


### PR DESCRIPTION
Because Chrome 74 ~~is around the corner~~may be out soon, we should be prepared for the release. 

This PR contains the needed changes for updating rust-skia to the Skia branch [chrome/m74](https://github.com/google/skia/tree/chrome/m74) (which might be updated while this PR is open!).

- [x] Make skia-safe compilable
- [x] Test skia-org examples.
- [x] Do the bindgen generated layouts fit?
- [x] Add new functions in existing wrappers.
- [ ] Add new include files (pretty much optional)
  - [ ] SkContourMeasure
  - [ ] SkCubicMap
- [x] Update README.md ([Rendered](https://github.com/rust-skia/rust-skia/blob/m74/README.md))
- [x] Update the versions of the `skia-bindings` and `skia-safe`.