### PR TITLE
Use exact version information for all dependencies to keep the builds reproducible

### DIFF
--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -14,6 +14,6 @@ vulkan = []
 [dependencies]
 
 [build-dependencies]
-cc = "1"
+cc = "1.0.35"
 bindgen = "0.48.1"
 

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -9,14 +9,14 @@ default = []
 vulkan = ["skia-bindings/vulkan"]
 
 [dependencies]
-bitflags = "1.0"
+bitflags = "1.0.4"
 skia-bindings = { path = "../skia-bindings" }
-lazy_static = "1.2"
+lazy_static = "1.3.0"
 
 [dev-dependencies]
 # for skia-org
-offscreen_gl_context = "0.22"
-gleam = "0.6"
-clap = "2.32"
+offscreen_gl_context = "0.22.0"
+gleam = "0.6.16"
+clap = "2.33.0"
 # Entry.try_enumerate_instance_version will be available beginning with 0.29
 ash = { git = "https://github.com/MaikKlein/ash", rev = "775a7d035d836559a30a9ee63a0e726d7b9118f4"}


### PR DESCRIPTION
hoping that dependabot will take care of all the updates.