### PR TITLE
SVG Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ We do support most of the SkCanvas, SkPaint, and SkPath and related APIs and are
 - [x] Basic Drawing: Surface, Canvas, Paint, Path.
 - [x] Basic Effects and Shaders.
 - [x] PDF
-- [ ] SVG
+- [x] SVG
 - [ ] Animation
 - [x] Vulkan
 - [x] OpenGL

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -69,12 +69,12 @@ jobs:
   - ${{ if ne(parameters.platform, 'Windows') }}:
     - script: cargo run --release --example skia-org ${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-org $(exampleArgs)
       displayName: Generate skia-org Example Images
-      condition: ne(variables['exampleArgs'], Null)
+      condition: ne(variables['exampleArgs'], '')
 
   - ${{ if eq(parameters.platform, 'Windows') }}:
     - script: cargo run --release --example skia-org %BUILD_ARTIFACTSTAGINGDIRECTORY%/skia-org $(exampleArgs)
       displayName: Generate skia-org Example Images
-      condition: ne(variables['exampleArgs'], Null)
+      condition: ne(variables['exampleArgs'], '')
 
   - task: PublishBuildArtifacts@1
     inputs:

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -11,6 +11,9 @@ jobs:
       stable-vulkan:
         toolchain: stable
         features: 'vulkan'
+      stable-svg:
+        toolchain: stable
+        features: 'svg'
   variables:
     platform: ${{ parameters.platform }}
     image: ${{ parameters.image }}

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -5,6 +5,7 @@ jobs:
       stable:
         toolchain: stable
         features: ''
+        exampleArgs: '--driver cpu --driver pdf'
       beta:
         toolchain: beta
         features: ''
@@ -14,10 +15,10 @@ jobs:
       stable-svg:
         toolchain: stable
         features: 'svg'
+        exampleArgs: '--driver svg'
   variables:
     platform: ${{ parameters.platform }}
     image: ${{ parameters.image }}
-    exampleArgs: '--driver cpu --driver pdf'
   pool:
     vmImage: $(image)
 
@@ -68,12 +69,12 @@ jobs:
   - ${{ if ne(parameters.platform, 'Windows') }}:
     - script: cargo run --release --example skia-org ${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-org $(exampleArgs)
       displayName: Generate skia-org Example Images
-      condition: eq(variables['features'], '')
+      condition: ne(variables['exampleArgs'], Null)
 
   - ${{ if eq(parameters.platform, 'Windows') }}:
     - script: cargo run --release --example skia-org %BUILD_ARTIFACTSTAGINGDIRECTORY%/skia-org $(exampleArgs)
       displayName: Generate skia-org Example Images
-      condition: eq(variables['features'], '')
+      condition: ne(variables['exampleArgs'], Null)
 
   - task: PublishBuildArtifacts@1
     inputs:

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -67,12 +67,12 @@ jobs:
     displayName: Test skia-safe
 
   - ${{ if ne(parameters.platform, 'Windows') }}:
-    - script: cargo run --release --example skia-org ${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-org $(exampleArgs)
+    - script: cargo run --release --features "$(features)" --example skia-org ${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-org $(exampleArgs)
       displayName: Generate skia-org Example Images
       condition: ne(variables['exampleArgs'], '')
 
   - ${{ if eq(parameters.platform, 'Windows') }}:
-    - script: cargo run --release --example skia-org %BUILD_ARTIFACTSTAGINGDIRECTORY%/skia-org $(exampleArgs)
+    - script: cargo run --release --features "$(features)" --example skia-org %BUILD_ARTIFACTSTAGINGDIRECTORY%/skia-org $(exampleArgs)
       displayName: Generate skia-org Example Images
       condition: ne(variables['exampleArgs'], '')
 
@@ -80,4 +80,4 @@ jobs:
     inputs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)/skia-org'
       artifactName: 'skia-org-examples-$(platform)-$(toolchain)'
-    condition: eq(variables['features'], '')
+    condition: ne(variables['exampleArgs'], '')

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -66,15 +66,9 @@ jobs:
   - script: cd skia-safe && cargo test --release --features "$(features)" -vv
     displayName: Test skia-safe
 
-  - ${{ if ne(parameters.platform, 'Windows') }}:
-    - script: cd skia-safe && cargo run --release --features "$(features)" --example skia-org ${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-org $(exampleArgs)
-      displayName: Generate skia-org Example Images
-      condition: ne(variables['exampleArgs'], '')
-
-  - ${{ if eq(parameters.platform, 'Windows') }}:
-    - script: cd skia-safe && cargo run --release --features "$(features)" --example skia-org %BUILD_ARTIFACTSTAGINGDIRECTORY%/skia-org $(exampleArgs)
-      displayName: Generate skia-org Example Images
-      condition: ne(variables['exampleArgs'], '')
+  - script: cd skia-safe && cargo run --release --features "$(features)" --example skia-org "$(Build.ArtifactStagingDirectory)/skia-org" $(exampleArgs)
+    displayName: Generate skia-org Example Images
+    condition: ne(variables['exampleArgs'], '')
 
   - task: PublishBuildArtifacts@1
     inputs:

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -67,12 +67,12 @@ jobs:
     displayName: Test skia-safe
 
   - ${{ if ne(parameters.platform, 'Windows') }}:
-    - script: cargo run --release --features "$(features)" --example skia-org ${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-org $(exampleArgs)
+    - script: cd skia-safe && cargo run --release --features "$(features)" --example skia-org ${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-org $(exampleArgs)
       displayName: Generate skia-org Example Images
       condition: ne(variables['exampleArgs'], '')
 
   - ${{ if eq(parameters.platform, 'Windows') }}:
-    - script: cargo run --release --features "$(features)" --example skia-org %BUILD_ARTIFACTSTAGINGDIRECTORY%/skia-org $(exampleArgs)
+    - script: cd skia-safe && cargo run --release --features "$(features)" --example skia-org %BUILD_ARTIFACTSTAGINGDIRECTORY%/skia-org $(exampleArgs)
       displayName: Generate skia-org Example Images
       condition: ne(variables['exampleArgs'], '')
 

--- a/skia-bindings/CMakeLists.txt
+++ b/skia-bindings/CMakeLists.txt
@@ -7,5 +7,7 @@ include_directories("skia/include/core")
 include_directories("skia/include/docs")
 include_directories("skia/include/effects")
 include_directories("skia/include/gpu")
+include_directories("skia/include/svg")
+include_directories("skia/src/xml")
 
 add_library(skiabindings src/bindings.cpp)

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -10,6 +10,7 @@ include = [ "Cargo.toml", "build.rs", "src/**/*.cpp", "src/lib.rs", "skia/includ
 [features]
 default = []
 vulkan = []
+svg = []
 
 [dependencies]
 

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -38,14 +38,18 @@
 #include "GrContext.h"
 // gpu/gl
 #include "gl/GrGLInterface.h"
+#include "SkRect.h"
 
 #if defined(SK_VULKAN)
-
 #include "vk/GrVkVulkan.h"
 #include "vk/GrVkTypes.h"
 #include "vk/GrVkBackendContext.h"
 #include "GrBackendSurface.h"
+#endif
 
+#if defined(SK_XML)
+#include "SkSVGCanvas.h"
+#include "SkXMLWriter.h"
 #endif
 
 template<typename T>
@@ -1355,6 +1359,18 @@ extern "C" void C_GrVkImageInfo_updateImageLayout(GrVkImageInfo* self, VkImageLa
 
 extern "C" bool C_GrVkImageInfo_Equals(const GrVkImageInfo* lhs, const GrVkImageInfo* rhs) {
     return *lhs == *rhs;
+}
+
+#endif
+
+#if defined(SK_XML)
+
+// Note, we can't use the SkWStream* implementation, because its implementation creates
+// an SkXMLWriter and destroys it before returning (this bug is fixed in Skia master, and
+// so may be available in a future update).
+
+extern "C" SkCanvas* C_SkSVGCanvas_Make(const SkRect* bounds, SkXMLWriter* writer) {
+    return SkSVGCanvas::Make(*bounds, writer).release();
 }
 
 #endif

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1373,4 +1373,8 @@ extern "C" SkCanvas* C_SkSVGCanvas_Make(const SkRect* bounds, SkXMLWriter* write
     return SkSVGCanvas::Make(*bounds, writer).release();
 }
 
+extern "C" void C_SkXMLStreamWriter_destruct(SkXMLStreamWriter* self) {
+    self->~SkXMLStreamWriter();
+}
+
 #endif

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [features]
 default = []
 vulkan = ["skia-bindings/vulkan"]
+svg = ["skia-bindings/svg"]
 
 [dependencies]
 bitflags = "1.0.4"

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -145,7 +145,7 @@ impl NativeAccess<SkCanvas> for Canvas {
     }
 }
 
-/// This is the type representing a canvas that is owned and destructed
+/// This is the type representing a canvas that is owned and dropped
 /// when it goes out of scope _and_ is bound to a the lifetime of another
 /// instance. Function resolvement is done via the Deref trait.
 pub struct OwnedCanvas<'lt>(*mut Canvas, PhantomData<&'lt ()>);

--- a/skia-safe/src/interop/stream.rs
+++ b/skia-safe/src/interop/stream.rs
@@ -13,7 +13,7 @@ pub type DynamicMemoryWStream = Handle<SkDynamicMemoryWStream>;
 impl NativeDrop for SkDynamicMemoryWStream {
     fn drop(&mut self) {
         unsafe {
-            C_SkDynamicMemoryWStream_destruct(self)
+            C_SkDynamicMemoryWStream_destruct(self);
         }
     }
 }

--- a/skia-safe/src/lib.rs
+++ b/skia-safe/src/lib.rs
@@ -4,6 +4,8 @@ mod docs;
 mod effects;
 mod interop;
 pub mod gpu;
+#[cfg(feature = "svg")]
+pub mod svg;
 
 #[macro_use]
 extern crate bitflags;

--- a/skia-safe/src/prelude.rs
+++ b/skia-safe/src/prelude.rs
@@ -231,7 +231,7 @@ impl<H, N> IntoHandle<H> for N
 }
 
 /// Wraps a native type that can be represented as a value
-/// and needs a destructor.
+/// and needs a Drop trait.
 #[repr(transparent)]
 pub struct Handle<N: NativeDrop>(N);
 

--- a/skia-safe/src/svg.rs
+++ b/skia-safe/src/svg.rs
@@ -1,0 +1,3 @@
+mod canvas;
+pub use self::canvas::*;
+

--- a/skia-safe/src/svg/canvas.rs
+++ b/skia-safe/src/svg/canvas.rs
@@ -50,6 +50,7 @@ impl Canvas {
     }
 
     /// Ends the Canvas drawing and returns the resulting SVG.
+    /// TODO: rename to into_svg() or into_svg_data()?
     pub fn end(mut self) -> Data {
         self.deref_mut().flush();
         self.stream.detach_as_data()

--- a/skia-safe/src/svg/canvas.rs
+++ b/skia-safe/src/svg/canvas.rs
@@ -1,0 +1,69 @@
+use crate::interop::DynamicMemoryWStream;
+use crate::prelude::{NativeAccess, NativeTransmutable};
+use crate::{Data, Rect};
+use skia_bindings::{C_SkCanvas_delete, C_SkSVGCanvas_Make, SkCanvas, SkXMLStreamWriter};
+use std::ops::{Deref, DerefMut};
+use std::pin::Pin;
+
+pub struct Canvas {
+    canvas: *mut SkCanvas,
+    #[allow(dead_code)]
+    xml_stream_writer: Pin<Box<SkXMLStreamWriter>>,
+    stream: Pin<Box<DynamicMemoryWStream>>,
+}
+
+impl Drop for Canvas {
+    fn drop(&mut self) {
+        unsafe {
+            C_SkCanvas_delete(self.canvas);
+        }
+    }
+}
+
+impl Deref for Canvas {
+    type Target = crate::Canvas;
+
+    fn deref(&self) -> &Self::Target {
+        crate::Canvas::borrow_from_native(unsafe { &mut *self.canvas })
+    }
+}
+
+impl DerefMut for Canvas {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        crate::Canvas::borrow_from_native(unsafe { &mut *self.canvas })
+    }
+}
+
+impl Canvas {
+    /// Creates a new SVG canvas.
+    pub fn new<B: AsRef<Rect>>(bounds: B) -> Canvas {
+        let bounds = bounds.as_ref();
+        let mut stream = Box::pin(DynamicMemoryWStream::new());
+        let mut xml_stream_writer =
+            Box::pin(unsafe { SkXMLStreamWriter::new(&mut stream.native_mut()._base) });
+        let canvas = unsafe { C_SkSVGCanvas_Make(bounds.native(), &mut xml_stream_writer._base) };
+        Canvas {
+            canvas,
+            xml_stream_writer,
+            stream,
+        }
+    }
+
+    /// Ends the Canvas drawing and returns the resulting SVG.
+    pub fn end(mut self) -> Data {
+        self.deref_mut().flush();
+        self.stream.detach_as_data()
+    }
+}
+
+#[test]
+fn test_svg() {
+    use crate::Paint;
+    let mut canvas = Canvas::new(&Rect::from_size((20, 20)));
+    let paint = Paint::default();
+    canvas.draw_circle((10, 10), 10.0, &paint);
+    let data = canvas.end();
+    let contents = String::from_utf8_lossy(data.bytes());
+    assert!(contents
+        .contains(r#"<ellipse fill="rgb(0,0,0)" stroke="none" cx="10" cy="10" rx="10" ry="10"/>"#));
+}

--- a/skia-safe/src/svg/canvas.rs
+++ b/skia-safe/src/svg/canvas.rs
@@ -1,14 +1,17 @@
 use crate::interop::DynamicMemoryWStream;
-use crate::prelude::{NativeAccess, NativeTransmutable};
+use crate::prelude::*;
 use crate::{Data, Rect};
-use skia_bindings::{C_SkCanvas_delete, C_SkSVGCanvas_Make, SkCanvas, SkXMLStreamWriter};
+use skia_bindings::{
+    C_SkCanvas_delete, C_SkSVGCanvas_Make, C_SkXMLStreamWriter_destruct, SkCanvas,
+    SkXMLStreamWriter,
+};
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
+use std::ptr;
 
 pub struct Canvas {
     canvas: *mut SkCanvas,
-    #[allow(dead_code)]
-    xml_stream_writer: Pin<Box<SkXMLStreamWriter>>,
+    xml_stream_writer: Option<Pin<Box<XMLStreamWriter>>>,
     stream: Pin<Box<DynamicMemoryWStream>>,
 }
 
@@ -39,12 +42,15 @@ impl Canvas {
     pub fn new<B: AsRef<Rect>>(bounds: B) -> Canvas {
         let bounds = bounds.as_ref();
         let mut stream = Box::pin(DynamicMemoryWStream::new());
-        let mut xml_stream_writer =
-            Box::pin(unsafe { SkXMLStreamWriter::new(&mut stream.native_mut()._base) });
-        let canvas = unsafe { C_SkSVGCanvas_Make(bounds.native(), &mut xml_stream_writer._base) };
+        let mut xml_stream_writer = Box::pin(XMLStreamWriter::from_native(unsafe {
+            SkXMLStreamWriter::new(&mut stream.native_mut()._base)
+        }));
+        let canvas = unsafe {
+            C_SkSVGCanvas_Make(bounds.native(), &mut xml_stream_writer.native_mut()._base)
+        };
         Canvas {
             canvas,
-            xml_stream_writer,
+            xml_stream_writer: Some(xml_stream_writer),
             stream,
         }
     }
@@ -52,19 +58,47 @@ impl Canvas {
     /// Ends the Canvas drawing and returns the resulting SVG.
     /// TODO: rename to into_svg() or into_svg_data()?
     pub fn end(mut self) -> Data {
-        self.deref_mut().flush();
+        // note: flushing canvas + XMLStreamWriter does not seem to work,
+        // we have to delete the canvas and destruct the stream writer
+        // to get all data out _and_ keep the referential integrity.
+        unsafe {
+            C_SkCanvas_delete(self.canvas);
+        }
+        self.canvas = ptr::null_mut();
+        self.xml_stream_writer = None;
         self.stream.detach_as_data()
+    }
+}
+
+type XMLStreamWriter = Handle<SkXMLStreamWriter>;
+
+impl NativeDrop for SkXMLStreamWriter {
+    fn drop(&mut self) {
+        unsafe {
+            C_SkXMLStreamWriter_destruct(self);
+        }
     }
 }
 
 #[test]
 fn test_svg() {
     use crate::Paint;
+
     let mut canvas = Canvas::new(&Rect::from_size((20, 20)));
     let paint = Paint::default();
     canvas.draw_circle((10, 10), 10.0, &paint);
     let data = canvas.end();
     let contents = String::from_utf8_lossy(data.bytes());
+    dbg!(&contents);
     assert!(contents
         .contains(r#"<ellipse fill="rgb(0,0,0)" stroke="none" cx="10" cy="10" rx="10" ry="10"/>"#));
+    assert!(contents.contains(r#"</svg>"#));
+}
+
+#[test]
+fn test_svg_without_ending() {
+    use crate::Paint;
+    let mut canvas = Canvas::new(&Rect::from_size((20, 20)));
+    let paint = Paint::default();
+    canvas.draw_circle((10, 10), 10.0, &paint);
 }


### PR DESCRIPTION
This PR is based on the PR in #76 and implements a wrapper for `SkSVGCanvas::Make()` to support SVG. 

SVG will be an optional feature that can be enabled in `Cargo.toml`.
