### PR TITLE
Extend SkData wrapper.

### DIFF
--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -357,13 +357,23 @@ extern "C" SkData* C_SkData_MakeWithCopy(const void* data, size_t length) {
     return SkData::MakeWithCopy(data, length).release();
 }
 
+extern "C" SkData* C_SkData_MakeSubset(const SkData* src, size_t offset, size_t length) {
+    return SkData::MakeSubset(src, offset, length).release();
+}
+
+extern "C" SkData* C_SkData_MakeUninitialized(size_t length) {
+    return SkData:: MakeUninitialized(length).release();
+}
+
+extern "C" SkData* C_SkData_MakeWithCString(const char* cstr) {
+    return SkData::MakeWithCString(cstr).release();
+}
+
 extern "C" SkData* C_SkData_MakeWithoutCopy(const void* data, size_t length) {
     return SkData::MakeWithoutCopy(data, length).release();
 }
 
-extern "C" SkData* C_SkData_MakeSubset(const SkData* src, size_t offset, size_t length) {
-    return SkData::MakeSubset(src, offset, length).release();
-}
+
 
 extern "C" SkData* C_SkData_MakeEmpty() {
     return SkData::MakeEmpty().release();

--- a/skia-safe/src/core/data.rs
+++ b/skia-safe/src/core/data.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use std::slice;
-use skia_bindings::{SkData, C_SkData_unref, C_SkData_ref, C_SkData_MakeWithCopy, C_SkData_MakeEmpty, C_SkData_MakeSubset, C_SkData_MakeUninitialized};
+use skia_bindings::{SkData, C_SkData_unref, C_SkData_ref, C_SkData_MakeWithCopy, C_SkData_MakeEmpty, C_SkData_MakeSubset, C_SkData_MakeUninitialized, C_SkData_MakeWithCString};
 use std::ops::Deref;
 use std::ffi::CStr;
 

--- a/skia-safe/src/core/data.rs
+++ b/skia-safe/src/core/data.rs
@@ -1,11 +1,8 @@
 use crate::prelude::*;
 use std::slice;
-use skia_bindings::{
-    SkData,
-    C_SkData_unref,
-    C_SkData_ref,
-    C_SkData_MakeWithCopy
-};
+use skia_bindings::{SkData, C_SkData_unref, C_SkData_ref, C_SkData_MakeWithCopy, C_SkData_MakeEmpty, C_SkData_MakeSubset, C_SkData_MakeUninitialized};
+use std::ops::Deref;
+use std::ffi::CStr;
 
 pub type Data = RCHandle<SkData>;
 
@@ -19,17 +16,33 @@ impl NativeRefCounted for SkData {
     }
 }
 
+impl Deref for RCHandle<SkData> {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        self.bytes()
+    }
+}
+
+impl PartialEq for RCHandle<SkData> {
+    // Although there is an implementation in SkData for equality testig, we
+    // prefer to stay on the Rust side for that.
+    fn eq(&self, other: &Self) -> bool {
+        self.deref().eq(other.deref())
+    }
+}
+
 // TODO: complete the implementation.
-// TODO: think about if we should support Data at all, Rust arrays and slices seem to
-// cover that.
 impl RCHandle<SkData> {
 
-    pub fn new_copy(data: &[u8]) -> Self {
-        Data::from_ptr(unsafe {
-            C_SkData_MakeWithCopy(data.as_ptr() as _, data.len())
-        }).unwrap()
+    pub fn size(&self) -> usize {
+        unsafe { self.native().size() }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.size() == 0
+    }
+
+    // TODO: as_bytes?
     pub fn bytes(&self) -> &[u8] {
         unsafe {
             let bytes = self.native().bytes();
@@ -37,7 +50,45 @@ impl RCHandle<SkData> {
         }
     }
 
-    pub fn size(&self) -> usize {
-        unsafe { self.native().size() }
+    // TODO: rename to copy_from ?
+    pub fn new_copy(data: &[u8]) -> Self {
+        Data::from_ptr(unsafe {
+            C_SkData_MakeWithCopy(data.as_ptr() as _, data.len())
+        }).unwrap()
     }
+
+    pub fn new_uninitialized(length: usize) -> Data {
+        Data::from_ptr(unsafe {
+            C_SkData_MakeUninitialized(length)
+        }).unwrap()
+    }
+
+    pub fn new_subset(data: &Data, offset: usize, length: usize) -> Data {
+        Data::from_ptr(unsafe {
+            C_SkData_MakeSubset(data.native(), offset, length)
+        }).unwrap()
+    }
+
+    pub fn new_cstr(cstr: &CStr) -> Data {
+        Data::from_ptr(unsafe {
+            C_SkData_MakeWithCString(cstr.as_ptr())
+        }).unwrap()
+    }
+
+    // TODO: MakeFromFileName (not sure if we need that)
+    // TODO: MakeFromFile (not sure if we need that)
+
+    pub fn new_empty() -> Self {
+        Data::from_ptr(unsafe {
+            C_SkData_MakeEmpty()
+        }).unwrap()
+    }
+}
+
+#[test]
+fn data_supports_equals() {
+    let x : &[u8] = &[1u8, 2u8, 3u8];
+    let d1 = Data::new_copy(x);
+    let d2 = Data::new_copy(x);
+    assert!(d1 == d2)
 }

--- a/skia-safe/src/core/document.rs
+++ b/skia-safe/src/core/document.rs
@@ -85,7 +85,6 @@ impl Document {
 
     /// Close the document and return the encoded representation.
     /// This function consumes and drops the document.
-    /// TODO: Completely hide Data?
     pub fn close(mut self) -> Data {
         unsafe {
             self.document.native_mut().close();


### PR DESCRIPTION
This PR extends the `SkData` wrapper with a `Deref<[u8]>` trait and adds some missing functions. 

I've decided to keep the wrapper around, because I don't see a way to make SkData accessible via a Rust type without copying the bytes contained.
