### PR TITLE
Complete SkImageFilter wrapper and add additional image filter effects.

### DIFF
--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skia-bindings"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -31,6 +31,8 @@
 // effects/
 #include "Sk1DPathEffect.h"
 #include "Sk2DPathEffect.h"
+#include "SkAlphaThresholdFilter.h"
+#include "SkArithmeticImageFilter.h"
 #include "SkCornerPathEffect.h"
 #include "SkDashPathEffect.h"
 #include "SkDiscretePathEffect.h"
@@ -1226,6 +1228,22 @@ extern "C" SkPathEffect* C_SkLine2DPathEffect_Make(SkScalar width, const SkMatri
 
 extern "C" SkPathEffect* C_SkPath2DPathEffect_Make(const SkMatrix* matrix, const SkPath* path) {
     return SkPath2DPathEffect::Make(*matrix, *path).release();
+}
+
+//
+// SkAlphaThresholdFilter
+//
+
+extern "C" SkImageFilter* C_SkAlphaThresholdFilter_Make(const SkRegion* region, SkScalar innerMin, SkScalar outerMax, const SkImageFilter* input, const SkImageFilter::CropRect* cropRect) {
+    return SkAlphaThresholdFilter::Make(*region, innerMin, outerMax, spFromConst(input), cropRect).release();
+}
+
+//
+// SkArithmeticImageFilter
+//
+
+extern "C" SkImageFilter* C_SkArithmeticImageFilter_Make(float k1, float k2, float k3, float k4, bool enforcePMColor, const SkImageFilter* background, const SkImageFilter* foreground, const SkImageFilter::CropRect* cropRect) {
+    return SkArithmeticImageFilter::Make(k1, k2, k3, k4, enforcePMColor, spFromConst(background), spFromConst(foreground), cropRect).release();
 }
 
 //

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1438,7 +1438,7 @@ C_SkMatrixConvolutionImageFilter_Make(const SkISize &kernelSize,
 //
 
 extern "C" SkImageFilter *
-C_SkMergeImageFilter_Make(const SkImageFilter *filters[], int count, const SkImageFilter::CropRect *cropRect) {
+C_SkMergeImageFilter_Make(const SkImageFilter *const filters[], int count, const SkImageFilter::CropRect *cropRect) {
     auto array = new sk_sp<SkImageFilter>[count];
     for (int i = 0; i < count; ++i) {
         array[i] = spFromConst(filters[i]);

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -33,12 +33,28 @@
 #include "Sk2DPathEffect.h"
 #include "SkAlphaThresholdFilter.h"
 #include "SkArithmeticImageFilter.h"
+#include "SkBlurImageFilter.h"
+#include "SkColorFilterImageFilter.h"
+#include "SkComposeImageFilter.h"
 #include "SkCornerPathEffect.h"
 #include "SkDashPathEffect.h"
 #include "SkDiscretePathEffect.h"
+#include "SkDisplacementMapEffect.h"
+#include "SkDropShadowImageFilter.h"
 #include "SkGradientShader.h"
+#include "SkImageSource.h"
+#include "SkLightingImageFilter.h"
+#include "SkMagnifierImageFilter.h"
+#include "SkMatrixConvolutionImageFilter.h"
+#include "SkMergeImageFilter.h"
+#include "SkMorphologyImageFilter.h"
+#include "SkOffsetImageFilter.h"
+#include "SkPaintImageFilter.h"
+#include "SkPictureImageFilter.h"
 #include "SkPerlinNoiseShader.h"
 #include "SkTableColorFilter.h"
+#include "SkTileImageFilter.h"
+#include "SkXfermodeImageFilter.h"
 // gpu/
 #include "GrContext.h"
 // gpu/gl
@@ -1195,7 +1211,288 @@ extern "C" SkShader* C_SkPerlinNoiseShader_MakeImprovedNoise(SkScalar baseFreque
 }
 
 //
-// SkTableColorFilter
+// effects/SkPath1DPathEffect
+//
+
+extern "C" SkPathEffect* C_SkPath1DPathEffect_Make(const SkPath* path, SkScalar advance, SkScalar phase, SkPath1DPathEffect::Style style) {
+    return SkPath1DPathEffect::Make(*path, advance, phase, style).release();
+}
+
+//
+// effects/SkLine2DPathEffect
+//
+
+extern "C" SkPathEffect* C_SkLine2DPathEffect_Make(SkScalar width, const SkMatrix* matrix) {
+    return SkLine2DPathEffect::Make(width, *matrix).release();
+}
+
+//
+// effects/SkPath2DPathEffect
+//
+
+extern "C" SkPathEffect* C_SkPath2DPathEffect_Make(const SkMatrix* matrix, const SkPath* path) {
+    return SkPath2DPathEffect::Make(*matrix, *path).release();
+}
+
+//
+// effects/SkAlphaThresholdFilter
+//
+
+extern "C" SkImageFilter *
+C_SkAlphaThresholdFilter_Make(const SkRegion &region, SkScalar innerMin, SkScalar outerMax, const SkImageFilter &input,
+                              const SkImageFilter::CropRect *cropRect) {
+    return SkAlphaThresholdFilter::Make(region, innerMin, outerMax, spFromConst(&input), cropRect).release();
+}
+
+//
+// effects/SkArithmeticImageFilter
+//
+
+extern "C" SkImageFilter *C_SkArithmeticImageFilter_Make(float k1, float k2, float k3, float k4, bool enforcePMColor,
+                                                         const SkImageFilter &background,
+                                                         const SkImageFilter &foreground,
+                                                         const SkImageFilter::CropRect *cropRect) {
+    return SkArithmeticImageFilter::Make(k1, k2, k3, k4, enforcePMColor, spFromConst(&background),
+                                         spFromConst(&foreground), cropRect).release();
+}
+
+//
+// SkBlurImageFilter
+//
+
+extern "C" SkImageFilter *C_SkBlurImageFilter_Make(SkScalar sigmaX, SkScalar sigmaY, const SkImageFilter &input,
+                                                   const SkImageFilter::CropRect *cropRect,
+                                                   SkBlurImageFilter::TileMode tileMode) {
+    return SkBlurImageFilter::Make(sigmaX, sigmaY, spFromConst(&input), cropRect, tileMode).release();
+}
+
+//
+// effects/SkColorFilterImageFilter
+//
+
+extern "C" SkImageFilter *C_SkColorFilterImageFilter_Make(const SkColorFilter &cf, const SkImageFilter &input,
+                                                          const SkImageFilter::CropRect *cropRect) {
+    return SkColorFilterImageFilter::Make(spFromConst(&cf), spFromConst(&input), cropRect).release();
+}
+
+//
+// effects/SkComposeImageFilter
+//
+
+extern "C" SkImageFilter *C_SkComposeImageFilter_Make(const SkImageFilter &outer, const SkImageFilter &inner) {
+    return SkComposeImageFilter::Make(spFromConst(&outer), spFromConst(&inner)).release();
+}
+
+//
+// effects/SkCornerPathEffect
+//
+
+extern "C" SkPathEffect* C_SkCornerPathEffect_Make(SkScalar radius) {
+    return SkCornerPathEffect::Make(radius).release();
+}
+
+//
+// effects/SkDashPathEffect
+//
+
+extern "C" SkPathEffect* C_SkDashPathEffect_Make(const SkScalar intervals[], int count, SkScalar phase) {
+    return SkDashPathEffect::Make(intervals, count, phase).release();
+}
+
+//
+// effects/SkDiscretePathEffect
+//
+
+extern "C" SkPathEffect* C_SkDiscretePathEffect_Make(SkScalar segLength, SkScalar dev, uint32_t seedAssist) {
+    return SkDiscretePathEffect::Make(segLength, dev, seedAssist).release();
+}
+
+//
+// effects/SkDisplacementMapEffect
+//
+
+extern "C" SkImageFilter *C_SkDisplacementMapEffect_Make(SkDisplacementMapEffect::ChannelSelectorType xChannelSelector,
+                                                         SkDisplacementMapEffect::ChannelSelectorType yChannelSelector,
+                                                         SkScalar scale, const SkImageFilter &displacement,
+                                                         const SkImageFilter &color,
+                                                         const SkImageFilter::CropRect *cropRect) {
+
+    return SkDisplacementMapEffect::Make(xChannelSelector, yChannelSelector, scale, spFromConst(&displacement),
+                                         spFromConst(&color), cropRect).release();
+}
+
+//
+// effects/SkDropShadowImageFilter
+//
+
+extern "C" SkImageFilter *C_SkDropShadowImageFilter_Make(SkScalar dx, SkScalar dy, SkScalar sigmaX, SkScalar sigmaY,
+                                                         SkColor color, SkDropShadowImageFilter::ShadowMode shadowMode,
+                                                         const SkImageFilter &input,
+                                                         const SkImageFilter::CropRect *cropRect) {
+    return SkDropShadowImageFilter::Make(dx, dy, sigmaX, sigmaY, color, shadowMode, spFromConst(&input),
+                                         cropRect).release();
+}
+
+//
+// effects/SkImageSource
+//
+
+extern "C" SkImageFilter *C_SkImageSource_Make(const SkImage &image) {
+    return SkImageSource::Make(spFromConst(&image)).release();
+}
+
+extern "C" SkImageFilter *
+C_SkImageSource_Make2(const SkImage &image, const SkRect &srcRect, const SkRect &dstRect,
+                      SkFilterQuality filterQuality) {
+    return SkImageSource::Make(spFromConst(&image), srcRect, dstRect, filterQuality).release();
+}
+
+//
+// effects/SkLightingImageFilter
+//
+
+extern "C" SkImageFilter *
+C_SkLightingImageFilter_MakeDistantLitDiffuse(const SkPoint3 &direction, SkColor lightColor, SkScalar surfaceScale,
+                                              SkScalar kd, const SkImageFilter &input,
+                                              const SkImageFilter::CropRect *cropRect) {
+    return SkLightingImageFilter::MakeDistantLitDiffuse(direction, lightColor, surfaceScale, kd, spFromConst(&input),
+                                                        cropRect).release();
+}
+
+extern "C" SkImageFilter *
+C_SkLightingImageFilter_MakePointLitDiffuse(const SkPoint3 &location, SkColor lightColor, SkScalar surfaceScale,
+                                            SkScalar kd, const SkImageFilter &input,
+                                            const SkImageFilter::CropRect *cropRect) {
+    return SkLightingImageFilter::MakePointLitDiffuse(location, lightColor, surfaceScale, kd, spFromConst(&input),
+                                                      cropRect).release();
+}
+
+extern "C" SkImageFilter *
+C_SkLightingImageFilter_MakeSpotLitDiffuse(const SkPoint3 &location,
+                                           const SkPoint3 &target, SkScalar specularExponent, SkScalar cutoffAngle,
+                                           SkColor lightColor, SkScalar surfaceScale, SkScalar kd,
+                                           const SkImageFilter *input, const SkImageFilter::CropRect *cropRect) {
+    return SkLightingImageFilter::MakeSpotLitDiffuse(location, target, specularExponent, cutoffAngle, lightColor,
+                                                     surfaceScale, kd, spFromConst(input), cropRect).release();
+}
+
+extern "C" SkImageFilter *
+C_SkLightingImageFilter_MakeDistantLitSpecular(const SkPoint3 &direction,
+                                               SkColor lightColor, SkScalar surfaceScale, SkScalar ks,
+                                               SkScalar shininess, const SkImageFilter &input,
+                                               const SkImageFilter::CropRect *cropRect) {
+    return SkLightingImageFilter::MakeDistantLitSpecular(direction, lightColor, surfaceScale, ks, shininess,
+                                                         spFromConst(&input), cropRect).release();
+}
+
+extern "C" SkImageFilter *
+C_SkLightingImageFilter_MakePointLitSpecular(const SkPoint3 &location,
+                                             SkColor lightColor, SkScalar surfaceScale, SkScalar ks,
+                                             SkScalar shininess, const SkImageFilter &input,
+                                             const SkImageFilter::CropRect *cropRect) {
+    return SkLightingImageFilter::MakePointLitSpecular(location, lightColor, surfaceScale, ks, shininess,
+                                                       spFromConst(&input), cropRect).release();
+}
+
+extern "C" SkImageFilter *
+C_SkLightingImageFilter_MakeSpotLitSpecular(const SkPoint3 &location,
+                                            const SkPoint3 &target, SkScalar specularExponent, SkScalar cutoffAngle,
+                                            SkColor lightColor, SkScalar surfaceScale, SkScalar ks,
+                                            SkScalar shininess, const SkImageFilter &input,
+                                            const SkImageFilter::CropRect *cropRect) {
+    return SkLightingImageFilter::MakeSpotLitSpecular(location, target, specularExponent, cutoffAngle, lightColor,
+                                                      surfaceScale, ks, shininess, spFromConst(&input),
+                                                      cropRect).release();
+}
+
+//
+// effects/SkMagnifierImageFilter
+//
+
+extern "C" SkImageFilter *
+C_SkMagnifierImageFilter_Make(const SkRect &srcRect, SkScalar inset, const SkImageFilter &input,
+                              const SkImageFilter::CropRect *cropRect) {
+    return SkMagnifierImageFilter::Make(srcRect, inset, spFromConst(&input), cropRect).release();
+}
+
+//
+// effects/SkMatrixConvolutionImageFilter
+//
+
+extern "C" SkImageFilter *
+C_SkMatrixConvolutionImageFilter_Make(const SkISize &kernelSize,
+                                      const SkScalar *kernel,
+                                      SkScalar gain,
+                                      SkScalar bias,
+                                      const SkIPoint &kernelOffset,
+                                      SkMatrixConvolutionImageFilter::TileMode tileMode,
+                                      bool convolveAlpha,
+                                      const SkImageFilter &input,
+                                      const SkImageFilter::CropRect *cropRect) {
+    return SkMatrixConvolutionImageFilter::Make(kernelSize, kernel, gain, bias, kernelOffset, tileMode, convolveAlpha,
+                                                spFromConst(&input), cropRect).release();
+}
+
+//
+// effects/SkMergeImageFilter
+//
+
+extern "C" SkImageFilter *
+C_SkMergeImageFilter_Make(const SkImageFilter *filters[], int count, const SkImageFilter::CropRect *cropRect) {
+    auto array = new sk_sp<SkImageFilter>[count];
+    for (int i = 0; i < count; ++i) {
+        array[i] = spFromConst(filters[i]);
+    }
+    auto imageFilter = SkMergeImageFilter::Make(array, count, cropRect).release();
+    delete[] array;
+    return imageFilter;
+}
+
+//
+// effects/SkMorphologyImageFiter
+//
+
+extern "C" SkImageFilter *C_SkDilateImageFilter_Make(int radiusX, int radiusY, const SkImageFilter &input,
+                                                     const SkImageFilter::CropRect *cropRect) {
+    return SkDilateImageFilter::Make(radiusX, radiusY, spFromConst(&input), cropRect).release();
+}
+
+extern "C" SkImageFilter *C_SkErodeImageFilter_Make(int radiusX, int radiusY, const SkImageFilter &input,
+                                                    const SkImageFilter::CropRect *cropRect) {
+    return SkErodeImageFilter::Make(radiusX, radiusY, spFromConst(&input), cropRect).release();
+}
+
+//
+// effects/SkOffsetImageFilter
+//
+
+extern "C" SkImageFilter *C_SkOffsetImageFilter_Make(SkScalar dx, SkScalar dy, const SkImageFilter &input,
+                                                     const SkImageFilter::CropRect *cropRect) {
+    return SkOffsetImageFilter::Make(dx, dy, spFromConst(&input), cropRect).release();
+}
+
+//
+// effects/SkPaintImageFilter
+//
+
+extern "C" SkImageFilter *C_SkPaintImageFilter_Make(const SkPaint &paint, const SkImageFilter::CropRect *cropRect) {
+    return SkPaintImageFilter::Make(paint, cropRect).release();
+}
+
+//
+// effects/SkPictureImageFilter
+//
+
+extern "C" SkImageFilter *C_SkPictureImageFilter_Make(const SkPicture &picture, const SkRect *cropRect) {
+    if (cropRect) {
+        return SkPictureImageFilter::Make(spFromConst(&picture), *cropRect).release();
+    } else {
+        return SkPictureImageFilter::Make(spFromConst(&picture)).release();
+    }
+}
+
+//
+// effects/SkTableColorFilter
 //
 
 extern "C" SkColorFilter* C_SkTableColorFilter_Make(const uint8_t table[256]) {
@@ -1207,67 +1504,21 @@ extern "C" SkColorFilter* C_SkTableColorFilter_MakeARGB(const uint8_t tableA[256
 }
 
 //
-// SkPath1DPathEffect
+// effects/SkTileImageFilter
 //
 
-extern "C" SkPathEffect* C_SkPath1DPathEffect_Make(const SkPath* path, SkScalar advance, SkScalar phase, SkPath1DPathEffect::Style style) {
-    return SkPath1DPathEffect::Make(*path, advance, phase, style).release();
+extern "C" SkImageFilter *C_SkTileImageFilter_Make(const SkRect &src, const SkRect &dst, const SkImageFilter &input) {
+    return SkTileImageFilter::Make(src, dst, spFromConst(&input)).release();
 }
 
 //
-// SkLine2DPathEffect
+// effects/SkXfermodeImageFilter
 //
 
-extern "C" SkPathEffect* C_SkLine2DPathEffect_Make(SkScalar width, const SkMatrix* matrix) {
-    return SkLine2DPathEffect::Make(width, *matrix).release();
-}
-
-//
-// SkPath2DPathEffect
-//
-
-extern "C" SkPathEffect* C_SkPath2DPathEffect_Make(const SkMatrix* matrix, const SkPath* path) {
-    return SkPath2DPathEffect::Make(*matrix, *path).release();
-}
-
-//
-// SkAlphaThresholdFilter
-//
-
-extern "C" SkImageFilter* C_SkAlphaThresholdFilter_Make(const SkRegion* region, SkScalar innerMin, SkScalar outerMax, const SkImageFilter* input, const SkImageFilter::CropRect* cropRect) {
-    return SkAlphaThresholdFilter::Make(*region, innerMin, outerMax, spFromConst(input), cropRect).release();
-}
-
-//
-// SkArithmeticImageFilter
-//
-
-extern "C" SkImageFilter* C_SkArithmeticImageFilter_Make(float k1, float k2, float k3, float k4, bool enforcePMColor, const SkImageFilter* background, const SkImageFilter* foreground, const SkImageFilter::CropRect* cropRect) {
-    return SkArithmeticImageFilter::Make(k1, k2, k3, k4, enforcePMColor, spFromConst(background), spFromConst(foreground), cropRect).release();
-}
-
-//
-// SkCornerPathEffect
-//
-
-extern "C" SkPathEffect* C_SkCornerPathEffect_Make(SkScalar radius) {
-    return SkCornerPathEffect::Make(radius).release();
-}
-
-//
-// SkDashPathEffect
-//
-
-extern "C" SkPathEffect* C_SkDashPathEffect_Make(const SkScalar intervals[], int count, SkScalar phase) {
-    return SkDashPathEffect::Make(intervals, count, phase).release();
-}
-
-//
-// SkDiscretePathEffect
-//
-
-extern "C" SkPathEffect* C_SkDiscretePathEffect_Make(SkScalar segLength, SkScalar dev, uint32_t seedAssist) {
-    return SkDiscretePathEffect::Make(segLength, dev, seedAssist).release();
+extern "C" SkImageFilter *
+C_SkXfermodeImageFilter_Make(SkBlendMode mode, const SkImageFilter &background, const SkImageFilter *foreground,
+                             const SkImageFilter::CropRect *cropRect) {
+    return SkXfermodeImageFilter::Make(mode, spFromConst(&background), spFromConst(foreground), cropRect).release();
 }
 
 //

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -414,13 +414,9 @@ extern "C" void C_SkPaint_setMaskFilter(SkPaint* self, const SkMaskFilter* maskF
     self->setMaskFilter(spFromConst(maskFilter));
 }
 
-// postponed
-
-/*
-extern "C" void C_SkPaint_setImageFilter(SkPaint* self, SkImageFilter* imageFilter) {
-    self->setImageFilter(sk_sp<SkImageFilter>(imageFilter));
+extern "C" void C_SkPaint_setImageFilter(SkPaint* self, const SkImageFilter* imageFilter) {
+    self->setImageFilter(spFromConst(imageFilter));
 }
-*/
 
 //
 // SkPath
@@ -981,6 +977,22 @@ extern "C" void C_SkContourMeasureIter_destruct(SkContourMeasureIter* self) {
 
 extern "C" SkContourMeasure* C_SkContourMeasureIter_next(SkContourMeasureIter* self) {
     return self->next().release();
+}
+
+//
+// SkImageFilter
+//
+
+extern "C" SkRect C_SkImageFilter_computeFastBounds(const SkImageFilter* self, const SkRect* bounds) {
+    return self->computeFastBounds(*bounds);
+}
+
+extern "C" SkImageFilter* C_SkImageFilter_makeWithLocalMatrix(const SkImageFilter* self, const SkMatrix* matrix) {
+    return self->makeWithLocalMatrix(*matrix).release();
+}
+
+extern "C" SkImageFilter* C_SkImageFilter_MakeMatrixFilter(const SkMatrix* matrix, SkFilterQuality quality, const SkImageFilter* input) {
+    return SkImageFilter::MakeMatrixFilter(*matrix, quality, spFromConst(input)).release();
 }
 
 //

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skia-safe"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 

--- a/skia-safe/examples/skia-org/skpaint_overview.rs
+++ b/skia-safe/examples/skia-org/skpaint_overview.rs
@@ -234,11 +234,11 @@ fn draw_bitmap_shader(canvas: &mut Canvas) {
     let mut matrix = Matrix::default();
     matrix.set_scale((0.75, 0.75), None).pre_rotate(30.0, None);
     let paint = &mut Paint::default();
-    paint.set_shader(Some(
+    paint.set_shader(
         image
             .as_shader((ShaderTileMode::Repeat, ShaderTileMode::Repeat), &matrix)
             .as_ref(),
-    ));
+    );
     canvas.draw_paint(paint);
 }
 
@@ -343,7 +343,7 @@ fn draw_mask_filter(canvas: &mut Canvas) {
         BlendMode::default(),
     );
     let paint = &mut Paint::default();
-    paint.set_mask_filter(Some(&MaskFilter::blur(BlurStyle::Normal, 5.0, None)));
+    paint.set_mask_filter(&MaskFilter::blur(BlurStyle::Normal, 5.0, None));
     let blob = &TextBlob::from_str(
         "Skia",
         &Font::from_typeface_with_size(&Typeface::default(), 120.0),
@@ -354,7 +354,7 @@ fn draw_mask_filter(canvas: &mut Canvas) {
 fn draw_color_filter(c: &mut Canvas) {
     fn f(c: &mut Canvas, (x, y): (scalar, scalar), color_matrix: &[scalar; 20]) {
         let paint = &mut Paint::default();
-        paint.set_color_filter(Some(&ColorFilter::from_matrix_row_major_255(color_matrix)));
+        paint.set_color_filter(&ColorFilter::from_matrix_row_major_255(color_matrix));
 
         let image = &resources::mandrill();
 
@@ -385,12 +385,12 @@ fn draw_color_table_color_filter(canvas: &mut Canvas) {
         *v = x.max(0).min(255) as _;
     }
     let mut paint = Paint::default();
-    paint.set_color_filter(Some(&TableColorFilter::from_argb(
+    paint.set_color_filter(&TableColorFilter::from_argb(
         None,
         Some(ct),
         Some(ct),
         Some(ct),
-    )));
+    ));
     canvas.draw_image(&image, (0, 0), Some(&paint));
 }
 
@@ -411,7 +411,7 @@ fn draw_path_2d_effect(canvas: &mut Canvas) {
     let matrix = &Matrix::new_scale((4.0 * scale, 4.0 * scale));
     let paint = &mut Paint::default();
     paint
-        .set_path_effect(Some(&Path2DPathEffect::new(matrix, path)))
+        .set_path_effect(&Path2DPathEffect::new(matrix, path))
         .set_anti_alias(true);
     canvas.clear(Color::WHITE);
     let bounds = Rect::new(-4.0 * scale, -4.0 * scale, 256.0, 256.0);
@@ -494,10 +494,10 @@ fn draw_compose_path_effect(canvas: &mut Canvas) {
     const INTERVALS: [scalar; 4] = [10.0, 5.0, 2.0, 5.0];
     let paint = &mut Paint::default();
     paint
-        .set_path_effect(Some(&PathEffect::compose(
+        .set_path_effect(&PathEffect::compose(
             &DashPathEffect::new(&INTERVALS, 0.0).unwrap(),
             &DiscretePathEffect::new(10.0, 4.0, None).unwrap(),
-        )))
+        ))
         .set_style(PaintStyle::Stroke)
         .set_stroke_width(2.0)
         .set_anti_alias(true);
@@ -508,10 +508,10 @@ fn draw_compose_path_effect(canvas: &mut Canvas) {
 fn draw_sum_path_effect(canvas: &mut Canvas) {
     let paint = &mut Paint::default();
     paint
-        .set_path_effect(Some(&PathEffect::sum(
+        .set_path_effect(&PathEffect::sum(
             &DiscretePathEffect::new(10.0, 4.0, None).unwrap(),
             &DiscretePathEffect::new(10.0, 4.0, Some(1245)).unwrap(),
-        )))
+        ))
         .set_style(PaintStyle::Stroke)
         .set_stroke_width(2.0)
         .set_anti_alias(true);

--- a/skia-safe/examples/skia-org/skpaint_overview.rs
+++ b/skia-safe/examples/skia-org/skpaint_overview.rs
@@ -1,8 +1,4 @@
-use skia_safe::{
-    scalar, AutoCanvasRestore, BlendMode, BlurStyle, Canvas, Color, ColorFilter, Font, MaskFilter,
-    Matrix, Paint, PaintStyle, Path, PathEffect, Point, Rect, Shader, ShaderTileMode, TextBlob,
-    Typeface,
-};
+use skia_safe::{scalar, AutoCanvasRestore, BlendMode, BlurStyle, Canvas, Color, ColorFilter, Font, MaskFilter, Matrix, Paint, PaintStyle, Path, PathEffect, Point, Rect, Shader, ShaderTileMode, TextBlob, Typeface, ImageFilter};
 use skia_safe::{
     CornerPathEffect, DashPathEffect, DiscretePathEffect, GradientShader, Line2DPathEffect,
     Path1DPathEffect, Path1DPathEffectStyle, Path2DPathEffect, PerlinNoiseShader, TableColorFilter,

--- a/skia-safe/examples/skia-org/skpaint_overview.rs
+++ b/skia-safe/examples/skia-org/skpaint_overview.rs
@@ -1,12 +1,15 @@
-use skia_safe::{scalar, AutoCanvasRestore, BlendMode, BlurStyle, Canvas, Color, ColorFilter, Font, MaskFilter, Matrix, Paint, PaintStyle, Path, PathEffect, Point, Rect, Shader, ShaderTileMode, TextBlob, Typeface, ImageFilter};
+use crate::artifact::DrawingDriver;
+use crate::resources;
+use skia_safe::{
+    scalar, AutoCanvasRestore, BlendMode, BlurStyle, Canvas, Color, ColorFilter, Font, MaskFilter,
+    Matrix, Paint, PaintStyle, Path, PathEffect, Point, Rect, Shader, ShaderTileMode, TextBlob,
+    Typeface,
+};
 use skia_safe::{
     CornerPathEffect, DashPathEffect, DiscretePathEffect, GradientShader, Line2DPathEffect,
     Path1DPathEffect, Path1DPathEffectStyle, Path2DPathEffect, PerlinNoiseShader, TableColorFilter,
 };
 use std::path::PathBuf;
-
-use crate::artifact::DrawingDriver;
-use crate::resources;
 
 pub fn draw<Driver: DrawingDriver>(path: &PathBuf) {
     let path = &path.join("SkPaint-Overview");

--- a/skia-safe/src/core/color_filter.rs
+++ b/skia-safe/src/core/color_filter.rs
@@ -72,33 +72,33 @@ impl RCHandle<SkColorFilter> {
     }
 
     #[must_use]
-    pub fn composed(&self, inner: &ColorFilter) -> Option<ColorFilter> {
+    pub fn composed(&self, inner: &ColorFilter) -> Option<Self> {
         ColorFilter::from_ptr(unsafe {
             C_SkColorFilter_makeComposed(self.native(), inner.shared_native() )
         })
     }
 
-    pub fn from_matrix_row_major_255(matrix: &[scalar; 20]) -> ColorFilter {
+    pub fn from_matrix_row_major_255(matrix: &[scalar; 20]) -> Self {
         ColorFilter::from_ptr(unsafe {
             C_SkColorFilter_MakeMatrixFilterRowMajor255(matrix.as_ptr())
         }).unwrap()
     }
 
     // TODO: not sure if we need the new_ prefix here.
-    pub fn new_linear_to_srgb_gamma() -> ColorFilter {
+    pub fn new_linear_to_srgb_gamma() -> self {
         ColorFilter::from_ptr(unsafe {
             C_SkColorFilter_MakeLinearToSRGBGamma()
         }).unwrap()
     }
 
     // TODO: not sure if we need the new_ prefix here.
-    pub fn new_srgb_to_linear_gamma() -> ColorFilter {
+    pub fn new_srgb_to_linear_gamma() -> Self {
         ColorFilter::from_ptr(unsafe {
             C_SkColorFilter_MakeSRGBToLinearGamma()
         }).unwrap()
     }
 
-    pub fn new_mixer(cf0: &ColorFilter, cf1: &ColorFilter, weight: f32) -> Option<ColorFilter> {
+    pub fn new_mixer(cf0: &ColorFilter, cf1: &ColorFilter, weight: f32) -> Option<Self> {
         ColorFilter::from_ptr(unsafe {
             C_SkColorFilter_MakeMixer(cf0.shared_native(), cf1.shared_native(), weight)
         })

--- a/skia-safe/src/core/color_filter.rs
+++ b/skia-safe/src/core/color_filter.rs
@@ -85,7 +85,7 @@ impl RCHandle<SkColorFilter> {
     }
 
     // TODO: not sure if we need the new_ prefix here.
-    pub fn new_linear_to_srgb_gamma() -> self {
+    pub fn new_linear_to_srgb_gamma() -> Self {
         ColorFilter::from_ptr(unsafe {
             C_SkColorFilter_MakeLinearToSRGBGamma()
         }).unwrap()

--- a/skia-safe/src/core/filter_quality.rs
+++ b/skia-safe/src/core/filter_quality.rs
@@ -7,8 +7,11 @@ pub enum FilterQuality {
     None = SkFilterQuality::kNone_SkFilterQuality as _,
     Low = SkFilterQuality::kLow_SkFilterQuality as _,
     Medium = SkFilterQuality::kMedium_SkFilterQuality as _,
-    High = SkFilterQuality::kHigh_SkFilterQuality as _
+    High = SkFilterQuality::kHigh_SkFilterQuality as _,
 }
 
 impl NativeTransmutable<SkFilterQuality> for FilterQuality {}
-#[test] fn test_filter_quality_layout() { FilterQuality::test_layout() }
+#[test]
+fn test_filter_quality_layout() {
+    FilterQuality::test_layout()
+}

--- a/skia-safe/src/core/image_filter.rs
+++ b/skia-safe/src/core/image_filter.rs
@@ -235,7 +235,7 @@ impl RCHandle<SkImageFilter> {
         unsafe { self.native().canComputeFastBounds() }
     }
 
-    pub fn with_local_matrix(&self, matrix: &Matrix) -> Option<ImageFilter> {
+    pub fn new_with_local_matrix(&self, matrix: &Matrix) -> Option<ImageFilter> {
         ImageFilter::from_ptr(unsafe {
             C_SkImageFilter_makeWithLocalMatrix(self.native(), matrix.native())
         })
@@ -245,17 +245,16 @@ impl RCHandle<SkImageFilter> {
         unsafe { self.native().canHandleComplexCTM() }
     }
 
-    // TODO: rename from_matrix?
-    pub fn new_matrix_filter(
+    pub fn with_matrix(
+        &self,
         matrix: &Matrix,
         quality: FilterQuality,
-        input: &ImageFilter,
     ) -> ImageFilter {
         ImageFilter::from_ptr(unsafe {
             C_SkImageFilter_MakeMatrixFilter(
                 matrix.native(),
                 quality.into_native(),
-                input.shared_native(),
+                self.shared_native(),
             )
         })
         .unwrap()

--- a/skia-safe/src/core/image_filter.rs
+++ b/skia-safe/src/core/image_filter.rs
@@ -201,6 +201,8 @@ impl RCHandle<SkImageFilter> {
     pub fn as_a_color_filter(&self) -> Option<ColorFilter> {
         let mut filter_ptr: *mut SkColorFilter = ptr::null_mut();
         if unsafe { self.native().asAColorFilter(&mut filter_ptr) } {
+            // If set, filter_ptr is also "ref'd" here, so we don't
+            // need to increase the reference count.
             ColorFilter::from_ptr(filter_ptr)
         } else {
             None

--- a/skia-safe/src/core/image_filter.rs
+++ b/skia-safe/src/core/image_filter.rs
@@ -8,13 +8,11 @@ use skia_bindings::{
     SkImageFilter_TileUsage, SkRefCntBase,
 };
 use std::ptr;
-use std::marker::PhantomData;
 
 #[repr(C)]
 pub struct ImageFilterOutputProperties<'a> {
     color_type: ColorType,
-    color_space: *mut SkColorSpace,
-    phantom_data: PhantomData<&'a SkColorSpace>,
+    color_space: &'a SkColorSpace,
 }
 
 impl<'a> NativeTransmutable<SkImageFilter_OutputProperties> for ImageFilterOutputProperties<'a> {}
@@ -30,7 +28,7 @@ impl<'a> ImageFilterOutputProperties<'a> {
     }
 
     pub fn color_space(&self) -> Option<ColorSpace> {
-        ColorSpace::from_unshared_ptr(self.color_space)
+        ColorSpace::from_unshared_ptr(self.color_space as *const _ as *mut _)
     }
 }
 

--- a/skia-safe/src/core/image_filter.rs
+++ b/skia-safe/src/core/image_filter.rs
@@ -1,10 +1,160 @@
-// TODO: complete the implementation
-
 use crate::prelude::*;
+use crate::{ColorFilter, ColorSpace, ColorType, FilterQuality, IRect, Matrix, Rect};
 use skia_bindings::{
-    SkImageFilter,
-    SkRefCntBase
+    C_SkImageFilter_MakeMatrixFilter, C_SkImageFilter_computeFastBounds,
+    C_SkImageFilter_makeWithLocalMatrix, SkColorFilter, SkColorSpace, SkImageFilter,
+    SkImageFilterCache, SkImageFilter_Context, SkImageFilter_CropRect,
+    SkImageFilter_CropRect_CropEdge, SkImageFilter_MapDirection, SkImageFilter_OutputProperties,
+    SkImageFilter_TileUsage, SkRefCntBase,
 };
+use std::ptr;
+use std::marker::PhantomData;
+
+#[repr(C)]
+pub struct ImageFilterOutputProperties<'a> {
+    color_type: ColorType,
+    color_space: *mut SkColorSpace,
+    phantom_data: PhantomData<&'a SkColorSpace>,
+}
+
+impl<'a> NativeTransmutable<SkImageFilter_OutputProperties> for ImageFilterOutputProperties<'a> {}
+
+#[test]
+fn test_output_properties_layout() {
+    ImageFilterOutputProperties::test_layout();
+}
+
+impl<'a> ImageFilterOutputProperties<'a> {
+    pub fn color_type(&self) -> ColorType {
+        self.color_type
+    }
+
+    pub fn color_space(&self) -> Option<ColorSpace> {
+        ColorSpace::from_unshared_ptr(self.color_space)
+    }
+}
+
+#[repr(C)]
+pub struct ImageFilterContext<'a> {
+    ctm: Matrix,
+    clip_bounds: IRect,
+    cache: &'a mut SkImageFilterCache,
+    output_properties: ImageFilterOutputProperties<'a>,
+}
+
+impl<'a> NativeTransmutable<SkImageFilter_Context> for ImageFilterContext<'a> {}
+
+#[test]
+fn test_context_layout() {
+    ImageFilterContext::test_layout();
+}
+
+impl<'a> ImageFilterContext<'a> {
+    pub fn ctm(&self) -> &Matrix {
+        &self.ctm
+    }
+
+    pub fn clip_bounds(&self) -> &IRect {
+        &self.clip_bounds
+    }
+
+    // TODO support access to SkImageFilterCache, even though it's declared in src/core?
+
+    pub fn output_properties(&self) -> &ImageFilterOutputProperties {
+        &self.output_properties
+    }
+
+    pub fn is_valid(&self) -> bool {
+        unsafe { self.native().isValid() }
+    }
+}
+
+bitflags! {
+    pub struct ImageFilterCropRectCropEdge : u32 {
+        const HAS_LEFT = SkImageFilter_CropRect_CropEdge::kHasLeft_CropEdge as _;
+        const HAS_TOP = SkImageFilter_CropRect_CropEdge::kHasTop_CropEdge as _;
+        const HAS_WIDTH = SkImageFilter_CropRect_CropEdge::kHasWidth_CropEdge as _;
+        const HAS_HEIGHT = SkImageFilter_CropRect_CropEdge::kHasHeight_CropEdge as _;
+        const HAS_ALL = Self::HAS_LEFT.bits | Self::HAS_TOP.bits | Self::HAS_WIDTH.bits | Self::HAS_HEIGHT.bits;
+    }
+}
+
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct ImageFilterCropRect(SkImageFilter_CropRect);
+
+impl NativeTransmutable<SkImageFilter_CropRect> for ImageFilterCropRect {}
+
+#[test]
+fn test_crop_rect_layout() {
+    ImageFilterCropRect::test_layout();
+}
+
+impl Default for ImageFilterCropRect {
+    fn default() -> Self {
+        ImageFilterCropRect::from_native(unsafe { SkImageFilter_CropRect::new() })
+    }
+}
+
+impl ImageFilterCropRect {
+    pub fn new<R: AsRef<Rect>>(rect: R, flags: ImageFilterCropRectCropEdge) -> Self {
+        ImageFilterCropRect::from_native(unsafe {
+            SkImageFilter_CropRect::new1(rect.as_ref().native(), flags.bits())
+        })
+    }
+
+    pub fn flags(&self) -> ImageFilterCropRectCropEdge {
+        ImageFilterCropRectCropEdge::from_bits_truncate(unsafe { self.native().flags() })
+    }
+
+    pub fn rect(&self) -> &Rect {
+        Rect::from_native_ref(unsafe { &*self.native().rect() })
+    }
+
+    pub fn apply_to<IR: AsRef<IRect>>(
+        &self,
+        image_bounds: IR,
+        matrix: &Matrix,
+        embiggen: bool,
+    ) -> IRect {
+        let mut cropped = IRect::default();
+        unsafe {
+            self.native().applyTo(
+                image_bounds.as_ref().native(),
+                matrix.native(),
+                embiggen,
+                cropped.native_mut(),
+            )
+        }
+        cropped
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[repr(i32)]
+pub enum ImageFilterTileUsage {
+    Possible = SkImageFilter_TileUsage::kPossible_TileUsage as _,
+    Never = SkImageFilter_TileUsage::kNever_TileUsage as _,
+}
+
+impl NativeTransmutable<SkImageFilter_TileUsage> for ImageFilterTileUsage {}
+#[test]
+fn test_tile_usage_layout() {
+    ImageFilterTileUsage::test_layout();
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[repr(i32)]
+pub enum ImageFilterMapDirection {
+    Forward = SkImageFilter_MapDirection::kForward_MapDirection as _,
+    Reverse = SkImageFilter_MapDirection::kReverse_MapDirection as _,
+}
+
+impl NativeTransmutable<SkImageFilter_MapDirection> for ImageFilterMapDirection {}
+#[test]
+fn test_map_direction_layout() {
+    ImageFilterMapDirection::test_layout();
+}
 
 pub type ImageFilter = RCHandle<SkImageFilter>;
 
@@ -13,4 +163,105 @@ impl NativeRefCountedBase for SkImageFilter {
     fn ref_counted_base(&self) -> &Self::Base {
         &self._base._base._base
     }
+}
+
+impl RCHandle<SkImageFilter> {
+    // TODO: filterImage() SkSpecialImage is declared in src/core/
+
+    pub fn filter_bounds<'a, IRS: AsRef<IRect>, IR: Into<Option<&'a IRect>>>(
+        &self,
+        src: IRS,
+        ctm: &Matrix,
+        map_direction: ImageFilterMapDirection,
+        input_rect: IR,
+    ) -> IRect {
+        IRect::from_native(unsafe {
+            self.native().filterBounds(
+                src.as_ref().native(),
+                ctm.native(),
+                map_direction.into_native(),
+                input_rect.into().native_ptr_or_null(),
+            )
+        })
+    }
+
+    // TODO: DrawWithFP()
+
+    pub fn color_filter_node(&self) -> Option<ColorFilter> {
+        let mut filter_ptr: *mut SkColorFilter = ptr::null_mut();
+        if unsafe { self.native().isColorFilterNode(&mut filter_ptr) } {
+            // according to the documentation, this must be set to a ref'd colorfilter
+            // (which is one with an increased ref count I assume).
+            ColorFilter::from_ptr(filter_ptr)
+        } else {
+            None
+        }
+    }
+
+    // TODO: removeKey() SkImageFilterCacheKey is declared in src/core/
+
+    pub fn as_a_color_filter(&self) -> Option<ColorFilter> {
+        let mut filter_ptr: *mut SkColorFilter = ptr::null_mut();
+        if unsafe { self.native().asAColorFilter(&mut filter_ptr) } {
+            ColorFilter::from_ptr(filter_ptr)
+        } else {
+            None
+        }
+    }
+
+    pub fn count_inputs(&self) -> usize {
+        unsafe { self.native().countInputs() }.try_into().unwrap()
+    }
+
+    pub fn input(&self, i: usize) -> Option<ImageFilter> {
+        ImageFilter::from_unshared_ptr(unsafe { self.native().getInput(i.try_into().unwrap()) })
+    }
+
+    pub fn crop_rect_is_set(&self) -> bool {
+        unsafe { self.native().cropRectIsSet() }
+    }
+
+    pub fn crop_rect(&self) -> ImageFilterCropRect {
+        ImageFilterCropRect::from_native(unsafe { self.native().getCropRect() })
+    }
+
+    pub fn compute_fast_bounds<R: AsRef<Rect>>(&self, bounds: R) -> Rect {
+        Rect::from_native(unsafe {
+            C_SkImageFilter_computeFastBounds(self.native(), bounds.as_ref().native())
+        })
+    }
+
+    pub fn can_compute_fast_bounds(&self) -> bool {
+        unsafe { self.native().canComputeFastBounds() }
+    }
+
+    pub fn with_local_matrix(&self, matrix: &Matrix) -> Option<ImageFilter> {
+        ImageFilter::from_ptr(unsafe {
+            C_SkImageFilter_makeWithLocalMatrix(self.native(), matrix.native())
+        })
+    }
+
+    pub fn can_handle_complex_ctm(&self) -> bool {
+        unsafe { self.native().canHandleComplexCTM() }
+    }
+
+    // TODO: rename from_matrix?
+    pub fn new_matrix_filter(
+        matrix: &Matrix,
+        quality: FilterQuality,
+        input: &ImageFilter,
+    ) -> ImageFilter {
+        ImageFilter::from_ptr(unsafe {
+            C_SkImageFilter_MakeMatrixFilter(
+                matrix.native(),
+                quality.into_native(),
+                input.shared_native(),
+            )
+        })
+        .unwrap()
+    }
+
+    // TODO: GetFlattenabletype()?
+    // TODO: getFlattenableType()?
+    // TODO: Deserialize?
 }

--- a/skia-safe/src/core/paint.rs
+++ b/skia-safe/src/core/paint.rs
@@ -5,7 +5,8 @@ use std::hash::{
 };
 use crate::prelude::*;
 use crate::core::{Color, FilterQuality, Color4f, ColorSpace, scalar, Path, Rect, ColorFilter, BlendMode, PathEffect, MaskFilter, Shader};
-use skia_bindings::{C_SkPaint_setMaskFilter, C_SkPaint_setPathEffect, C_SkPaint_setColorFilter, SkPaint_Cap, SkPaint, C_SkPaint_destruct, SkPaint_Style, SkPaint_Join, C_SkPaint_Equals, C_SkPaint_setShader};
+use skia_bindings::{C_SkPaint_setMaskFilter, C_SkPaint_setPathEffect, C_SkPaint_setColorFilter, SkPaint_Cap, SkPaint, C_SkPaint_destruct, SkPaint_Style, SkPaint_Join, C_SkPaint_Equals, C_SkPaint_setShader, C_SkPaint_setImageFilter};
+use crate::ImageFilter;
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(u8)]
@@ -303,22 +304,18 @@ impl Handle<SkPaint> {
         self
     }
 
-    /* TODO: ImageFilter postponed
-
     pub fn image_filter(&self) -> Option<ImageFilter> {
         ImageFilter::from_unshared_ptr(unsafe {
             self.native().getImageFilter()
         })
     }
 
-    pub fn set_image_filter(&mut self, image_filter: Option<&ImageFilter>) -> &mut Self {
+    pub fn set_image_filter<'a, IF: Into<Option<&'a ImageFilter>>>(&mut self, image_filter: IF) -> &mut Self {
         unsafe {
-            C_SkPaint_setImageFilter(self.native_mut(), image_filter.shared_ptr())
+            C_SkPaint_setImageFilter(self.native_mut(), image_filter.into().shared_ptr())
         }
         self
     }
-
-    */
 
     // TODO: getDrawLooper, setDrawLooper
 

--- a/skia-safe/src/core/paint.rs
+++ b/skia-safe/src/core/paint.rs
@@ -238,9 +238,9 @@ impl Handle<SkPaint> {
         })
     }
 
-    pub fn set_shader(&mut self, shader: Option<&Shader>) -> &mut Self {
+    pub fn set_shader<'a, S: Into<Option<&'a Shader>>>(&mut self, shader: S) -> &mut Self {
         unsafe {
-            C_SkPaint_setShader(self.native_mut(), shader.shared_ptr())
+            C_SkPaint_setShader(self.native_mut(), shader.into().shared_ptr())
         }
         self
     }
@@ -252,9 +252,9 @@ impl Handle<SkPaint> {
     }
 
 
-    pub fn set_color_filter(&mut self, color_filter: Option<&ColorFilter>) -> &mut Self {
+    pub fn set_color_filter<'a, CF: Into<Option<&'a ColorFilter>>>(&mut self, color_filter: CF) -> &mut Self {
         unsafe {
-            C_SkPaint_setColorFilter(self.native_mut(), color_filter.shared_ptr())
+            C_SkPaint_setColorFilter(self.native_mut(), color_filter.into().shared_ptr())
         }
         self
     }
@@ -284,9 +284,9 @@ impl Handle<SkPaint> {
         })
     }
 
-    pub fn set_path_effect(&mut self, path_effect: Option<&PathEffect>) -> &mut Self {
+    pub fn set_path_effect<'a, PE: Into<Option<&'a PathEffect>>>(&mut self, path_effect: PE) -> &mut Self {
         unsafe {
-            C_SkPaint_setPathEffect(self.native_mut(), path_effect.shared_ptr())
+            C_SkPaint_setPathEffect(self.native_mut(), path_effect.into().shared_ptr())
         }
         self
     }
@@ -297,9 +297,9 @@ impl Handle<SkPaint> {
         })
     }
 
-    pub fn set_mask_filter(&mut self, mask_filter: Option<&MaskFilter>) -> &mut Self {
+    pub fn set_mask_filter<'a, MF: Into<Option<&'a MaskFilter>>>(&mut self, mask_filter: MF) -> &mut Self {
         unsafe {
-            C_SkPaint_setMaskFilter(self.native_mut(), mask_filter.shared_ptr())
+            C_SkPaint_setMaskFilter(self.native_mut(), mask_filter.into().shared_ptr())
         }
         self
     }

--- a/skia-safe/src/core/paint.rs
+++ b/skia-safe/src/core/paint.rs
@@ -4,9 +4,8 @@ use std::hash::{
     Hasher
 };
 use crate::prelude::*;
-use crate::core::{Color, FilterQuality, Color4f, ColorSpace, scalar, Path, Rect, ColorFilter, BlendMode, PathEffect, MaskFilter, Shader};
+use crate::{Color, FilterQuality, Color4f, ColorSpace, scalar, Path, Rect, ColorFilter, BlendMode, PathEffect, MaskFilter, Shader, ImageFilter};
 use skia_bindings::{C_SkPaint_setMaskFilter, C_SkPaint_setPathEffect, C_SkPaint_setColorFilter, SkPaint_Cap, SkPaint, C_SkPaint_destruct, SkPaint_Style, SkPaint_Join, C_SkPaint_Equals, C_SkPaint_setShader, C_SkPaint_setImageFilter};
-use crate::ImageFilter;
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(u8)]

--- a/skia-safe/src/effects.rs
+++ b/skia-safe/src/effects.rs
@@ -55,6 +55,12 @@ pub use self::merge_image_filter::*;
 mod morphology_image_filter;
 pub use self::morphology_image_filter::*;
 
+mod offset_image_filter;
+pub use self::offset_image_filter::*;
+
+mod paint_image_filter;
+pub use self::paint_image_filter::*;
+
 mod perlin_noise_shader;
 pub use self::perlin_noise_shader::*;
 

--- a/skia-safe/src/effects.rs
+++ b/skia-safe/src/effects.rs
@@ -52,6 +52,9 @@ pub use self::matrix_convolution_image_filter::*;
 mod merge_image_filter;
 pub use self::merge_image_filter::*;
 
+mod morphology_image_filter;
+pub use self::morphology_image_filter::*;
+
 mod perlin_noise_shader;
 pub use self::perlin_noise_shader::*;
 

--- a/skia-safe/src/effects.rs
+++ b/skia-safe/src/effects.rs
@@ -69,3 +69,6 @@ pub use self::perlin_noise_shader::*;
 
 mod table_color_filter;
 pub use self::table_color_filter::*;
+
+mod tile_image_filter;
+pub use self::tile_image_filter::*;

--- a/skia-safe/src/effects.rs
+++ b/skia-safe/src/effects.rs
@@ -1,3 +1,15 @@
+mod _1d_path_effect;
+pub use self::_1d_path_effect::*;
+
+mod _2d_path_effect;
+pub use self::_2d_path_effect::*;
+
+mod alpha_threshold_filter;
+pub use self::alpha_threshold_filter::*;
+
+mod arithmetic_image_filter;
+pub use self::arithmetic_image_filter::*;
+
 mod corner_path_effect;
 pub use self::corner_path_effect::*;
 
@@ -9,12 +21,6 @@ pub use self::discrete_path_effect::*;
 
 mod gradient_shader;
 pub use self::gradient_shader::*;
-
-mod _1d_path_effect;
-pub use self::_1d_path_effect::*;
-
-mod _2d_path_effect;
-pub use self::_2d_path_effect::*;
 
 mod perlin_noise_shader;
 pub use self::perlin_noise_shader::*;

--- a/skia-safe/src/effects.rs
+++ b/skia-safe/src/effects.rs
@@ -40,6 +40,18 @@ pub use self::gradient_shader::*;
 mod image_source;
 pub use self::image_source::*;
 
+mod lighting_image_filter;
+pub use self::lighting_image_filter::*;
+
+mod magnifier_image_filter;
+pub use self::magnifier_image_filter::*;
+
+mod matrix_convolution_image_filter;
+pub use self::matrix_convolution_image_filter::*;
+
+mod merge_image_filter;
+pub use self::merge_image_filter::*;
+
 mod perlin_noise_shader;
 pub use self::perlin_noise_shader::*;
 

--- a/skia-safe/src/effects.rs
+++ b/skia-safe/src/effects.rs
@@ -13,6 +13,12 @@ pub use self::arithmetic_image_filter::*;
 mod blur_image_filter;
 pub use self::blur_image_filter::*;
 
+mod color_filter_image_filter;
+pub use self::color_filter_image_filter::*;
+
+mod compose_image_filter;
+pub use self::compose_image_filter::*;
+
 mod corner_path_effect;
 pub use self::corner_path_effect::*;
 
@@ -22,8 +28,17 @@ pub use self::dash_path_effect::*;
 mod discrete_path_effect;
 pub use self::discrete_path_effect::*;
 
+mod displacement_map_effect;
+pub use self::displacement_map_effect::*;
+
+mod drop_shadow_image_filter;
+pub use self::drop_shadow_image_filter::*;
+
 mod gradient_shader;
 pub use self::gradient_shader::*;
+
+mod image_source;
+pub use self::image_source::*;
 
 mod perlin_noise_shader;
 pub use self::perlin_noise_shader::*;

--- a/skia-safe/src/effects.rs
+++ b/skia-safe/src/effects.rs
@@ -61,6 +61,9 @@ pub use self::offset_image_filter::*;
 mod paint_image_filter;
 pub use self::paint_image_filter::*;
 
+mod picture_image_filter;
+pub use self::picture_image_filter::*;
+
 mod perlin_noise_shader;
 pub use self::perlin_noise_shader::*;
 

--- a/skia-safe/src/effects.rs
+++ b/skia-safe/src/effects.rs
@@ -72,3 +72,6 @@ pub use self::table_color_filter::*;
 
 mod tile_image_filter;
 pub use self::tile_image_filter::*;
+
+mod xfer_mode_image_filter;
+pub use self::xfer_mode_image_filter::*;

--- a/skia-safe/src/effects.rs
+++ b/skia-safe/src/effects.rs
@@ -10,6 +10,9 @@ pub use self::alpha_threshold_filter::*;
 mod arithmetic_image_filter;
 pub use self::arithmetic_image_filter::*;
 
+mod blur_image_filter;
+pub use self::blur_image_filter::*;
+
 mod corner_path_effect;
 pub use self::corner_path_effect::*;
 

--- a/skia-safe/src/effects/_1d_path_effect.rs
+++ b/skia-safe/src/effects/_1d_path_effect.rs
@@ -1,6 +1,6 @@
 use crate::core::{scalar, Path, PathEffect};
 use crate::prelude::*;
-use skia_bindings::{C_SkPath1DPathEffect_Make, SkPath1DPathEffect_Style};
+use skia_bindings::{C_SkPath1DPathEffect_Make, SkPath1DPathEffect_Style, SkPathEffect};
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
@@ -29,5 +29,16 @@ impl Path1DPathEffect {
         PathEffect::from_ptr(unsafe {
             C_SkPath1DPathEffect_Make(path.native(), advance, phase, style.into_native())
         })
+    }
+}
+
+impl RCHandle<SkPathEffect> {
+    pub fn path_1d(
+        path: &Path,
+        advance: scalar,
+        phase: scalar,
+        style: Path1DPathEffectStyle,
+    ) -> Option<PathEffect> {
+        Path1DPathEffect::new(path, advance, phase, style)
     }
 }

--- a/skia-safe/src/effects/_2d_path_effect.rs
+++ b/skia-safe/src/effects/_2d_path_effect.rs
@@ -1,27 +1,32 @@
 use crate::prelude::*;
-use crate::core::{PathEffect, Matrix, scalar, Path};
-use skia_bindings::{C_SkLine2DPathEffect_Make, C_SkPath2DPathEffect_Make};
+use crate::{scalar, Matrix, Path, PathEffect};
+use skia_bindings::{C_SkLine2DPathEffect_Make, C_SkPath2DPathEffect_Make, SkPathEffect};
 
 pub enum Line2DPathEffect {}
 
 impl Line2DPathEffect {
-
     #[allow(clippy::new_ret_no_self)]
     pub fn new(width: scalar, matrix: &Matrix) -> Option<PathEffect> {
-        PathEffect::from_ptr(unsafe {
-            C_SkLine2DPathEffect_Make(width, matrix.native())
-        })
+        PathEffect::from_ptr(unsafe { C_SkLine2DPathEffect_Make(width, matrix.native()) })
     }
 }
 
 pub enum Path2DPathEffect {}
 
 impl Path2DPathEffect {
-
     #[allow(clippy::new_ret_no_self)]
     pub fn new(matrix: &Matrix, path: &Path) -> PathEffect {
-        PathEffect::from_ptr(unsafe {
-            C_SkPath2DPathEffect_Make(matrix.native(), path.native())
-        }).unwrap()
+        PathEffect::from_ptr(unsafe { C_SkPath2DPathEffect_Make(matrix.native(), path.native()) })
+            .unwrap()
+    }
+}
+
+impl RCHandle<SkPathEffect> {
+    pub fn line_2d(width: scalar, matrix: &Matrix) -> Option<PathEffect> {
+        Line2DPathEffect::new(width, matrix)
+    }
+
+    pub fn path_2d(matrix: &Matrix, path: &Path) -> PathEffect {
+        Path2DPathEffect::new(matrix, path)
     }
 }

--- a/skia-safe/src/effects/alpha_threshold_filter.rs
+++ b/skia-safe/src/effects/alpha_threshold_filter.rs
@@ -1,0 +1,26 @@
+use crate::prelude::*;
+use crate::{scalar, ImageFilter, ImageFilterCropRect, Region};
+use skia_bindings::C_SkAlphaThresholdFilter_Make;
+
+pub enum AlphaThresholdFilter {}
+
+impl AlphaThresholdFilter {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        region: &Region,
+        inner_min: scalar,
+        outer_max: scalar,
+        input: &ImageFilter,
+        crop_rect: CR,
+    ) -> Option<ImageFilter> {
+        ImageFilter::from_ptr(unsafe {
+            C_SkAlphaThresholdFilter_Make(
+                region.native(),
+                inner_min,
+                outer_max,
+                input.shared_native(),
+                crop_rect.into().native_ptr_or_null(),
+            )
+        })
+    }
+}

--- a/skia-safe/src/effects/alpha_threshold_filter.rs
+++ b/skia-safe/src/effects/alpha_threshold_filter.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::{scalar, ImageFilter, ImageFilterCropRect, Region};
-use skia_bindings::C_SkAlphaThresholdFilter_Make;
+use skia_bindings::{C_SkAlphaThresholdFilter_Make, SkImageFilter};
 
 pub enum AlphaThresholdFilter {}
 
@@ -22,5 +22,17 @@ impl AlphaThresholdFilter {
                 crop_rect.into().native_ptr_or_null(),
             )
         })
+    }
+}
+
+impl RCHandle<SkImageFilter> {
+    pub fn alpha_threshold<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        &self,
+        crop_rect: CR,
+        region: &Region,
+        inner_min: scalar,
+        outer_max: scalar,
+    ) -> Option<Self> {
+        AlphaThresholdFilter::new(region, inner_min, outer_max, self, crop_rect)
     }
 }

--- a/skia-safe/src/effects/arithmetic_image_filter.rs
+++ b/skia-safe/src/effects/arithmetic_image_filter.rs
@@ -1,19 +1,33 @@
 use crate::prelude::*;
-
-use skia_bindings::C_SkArithmeticImageFilter_Make;
 use crate::{ImageFilter, ImageFilterCropRect};
+use skia_bindings::C_SkArithmeticImageFilter_Make;
 
 pub enum ArithmeticImageFilter {}
 
 impl ArithmeticImageFilter {
-
-    pub fn new<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(k1: f32, k2: f32, k3: f32, k4: f32, enforce_pm_color: bool, background: &ImageFilter, foreground: &ImageFilter, crop_rect: CR) -> Option<ImageFilter> {
+    #[allow(clippy::new_ret_no_self)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        k1: f32,
+        k2: f32,
+        k3: f32,
+        k4: f32,
+        enforce_pm_color: bool,
+        background: &ImageFilter,
+        foreground: &ImageFilter,
+        crop_rect: CR,
+    ) -> Option<ImageFilter> {
         ImageFilter::from_ptr(unsafe {
-            C_SkArithmeticImageFilter_Make(k1, k2, k3, k4, enforce_pm_color, background.shared_native(), foreground.shared_native(), crop_rect.into().native_ptr_or_null())
+            C_SkArithmeticImageFilter_Make(
+                k1,
+                k2,
+                k3,
+                k4,
+                enforce_pm_color,
+                background.shared_native(),
+                foreground.shared_native(),
+                crop_rect.into().native_ptr_or_null(),
+            )
         })
-
-
-
-
     }
 }

--- a/skia-safe/src/effects/arithmetic_image_filter.rs
+++ b/skia-safe/src/effects/arithmetic_image_filter.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::{ImageFilter, ImageFilterCropRect};
-use skia_bindings::C_SkArithmeticImageFilter_Make;
+use skia_bindings::{C_SkArithmeticImageFilter_Make, SkImageFilter};
 
 pub enum ArithmeticImageFilter {}
 
@@ -29,5 +29,30 @@ impl ArithmeticImageFilter {
                 crop_rect.into().native_ptr_or_null(),
             )
         })
+    }
+}
+
+impl RCHandle<SkImageFilter> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn arithmetic<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        k1: f32,
+        k2: f32,
+        k3: f32,
+        k4: f32,
+        enforce_pm_color: bool,
+        background: &Self,
+        foreground: &Self,
+        crop_rect: CR,
+    ) -> Option<Self> {
+        ArithmeticImageFilter::new(
+            k1,
+            k2,
+            k3,
+            k4,
+            enforce_pm_color,
+            background,
+            foreground,
+            crop_rect,
+        )
     }
 }

--- a/skia-safe/src/effects/arithmetic_image_filter.rs
+++ b/skia-safe/src/effects/arithmetic_image_filter.rs
@@ -4,26 +4,42 @@ use skia_bindings::{C_SkArithmeticImageFilter_Make, SkImageFilter};
 
 pub enum ArithmeticImageFilter {}
 
+#[derive(Clone, Debug)]
+pub struct ArithmeticImageFilterFPInputs {
+    pub k: [f32; 4],
+    pub enforce_pm_color: bool,
+}
+
+impl From<([f32; 4], bool)> for ArithmeticImageFilterFPInputs {
+    fn from((k, enforce_pm_color): ([f32; 4], bool)) -> Self {
+        ArithmeticImageFilterFPInputs {
+            k,
+            enforce_pm_color,
+        }
+    }
+}
+
 impl ArithmeticImageFilter {
     #[allow(clippy::new_ret_no_self)]
     #[allow(clippy::too_many_arguments)]
-    pub fn new<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
-        k1: f32,
-        k2: f32,
-        k3: f32,
-        k4: f32,
-        enforce_pm_color: bool,
+    pub fn new<
+        'a,
+        II: Into<ArithmeticImageFilterFPInputs>,
+        CR: Into<Option<&'a ImageFilterCropRect>>,
+    >(
+        inputs: II,
         background: &ImageFilter,
         foreground: &ImageFilter,
         crop_rect: CR,
     ) -> Option<ImageFilter> {
+        let inputs = inputs.into();
         ImageFilter::from_ptr(unsafe {
             C_SkArithmeticImageFilter_Make(
-                k1,
-                k2,
-                k3,
-                k4,
-                enforce_pm_color,
+                inputs.k[0],
+                inputs.k[1],
+                inputs.k[2],
+                inputs.k[3],
+                inputs.enforce_pm_color,
                 background.shared_native(),
                 foreground.shared_native(),
                 crop_rect.into().native_ptr_or_null(),
@@ -34,25 +50,16 @@ impl ArithmeticImageFilter {
 
 impl RCHandle<SkImageFilter> {
     #[allow(clippy::too_many_arguments)]
-    pub fn arithmetic<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
-        k1: f32,
-        k2: f32,
-        k3: f32,
-        k4: f32,
-        enforce_pm_color: bool,
+    pub fn arithmetic<
+        'a,
+        II: Into<ArithmeticImageFilterFPInputs>,
+        CR: Into<Option<&'a ImageFilterCropRect>>,
+    >(
+        inputs: II,
         background: &Self,
         foreground: &Self,
         crop_rect: CR,
     ) -> Option<Self> {
-        ArithmeticImageFilter::new(
-            k1,
-            k2,
-            k3,
-            k4,
-            enforce_pm_color,
-            background,
-            foreground,
-            crop_rect,
-        )
+        ArithmeticImageFilter::new(inputs, background, foreground, crop_rect)
     }
 }

--- a/skia-safe/src/effects/arithmetic_image_filter.rs
+++ b/skia-safe/src/effects/arithmetic_image_filter.rs
@@ -1,0 +1,19 @@
+use crate::prelude::*;
+
+use skia_bindings::C_SkArithmeticImageFilter_Make;
+use crate::{ImageFilter, ImageFilterCropRect};
+
+pub enum ArithmeticImageFilter {}
+
+impl ArithmeticImageFilter {
+
+    pub fn new<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(k1: f32, k2: f32, k3: f32, k4: f32, enforce_pm_color: bool, background: &ImageFilter, foreground: &ImageFilter, crop_rect: CR) -> Option<ImageFilter> {
+        ImageFilter::from_ptr(unsafe {
+            C_SkArithmeticImageFilter_Make(k1, k2, k3, k4, enforce_pm_color, background.shared_native(), foreground.shared_native(), crop_rect.into().native_ptr_or_null())
+        })
+
+
+
+
+    }
+}

--- a/skia-safe/src/effects/blur_image_filter.rs
+++ b/skia-safe/src/effects/blur_image_filter.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::{scalar, ImageFilter, ImageFilterCropRect};
-use skia_bindings::{C_SkBlurImageFilter_Make, SkBlurImageFilter_TileMode};
+use skia_bindings::{C_SkBlurImageFilter_Make, SkBlurImageFilter_TileMode, SkImageFilter};
 
 pub enum BlurImageFilter {}
 
@@ -42,5 +42,20 @@ impl BlurImageFilter {
                     .into_native(),
             )
         })
+    }
+}
+
+impl RCHandle<SkImageFilter> {
+    pub fn blur<
+        'a,
+        CR: Into<Option<&'a ImageFilterCropRect>>,
+        TM: Into<Option<BlurImageFilterTileMode>>,
+    >(
+        &self,
+        crop_rect: CR,
+        sigma: (scalar, scalar),
+        tile_mode: TM,
+    ) -> Option<Self> {
+        BlurImageFilter::new(sigma, self, crop_rect, tile_mode)
     }
 }

--- a/skia-safe/src/effects/blur_image_filter.rs
+++ b/skia-safe/src/effects/blur_image_filter.rs
@@ -1,4 +1,4 @@
-use crate::prelude::{NativePointerOrNull2, NativeTransmutable};
+use crate::prelude::*;
 use crate::{scalar, ImageFilter, ImageFilterCropRect};
 use skia_bindings::{C_SkBlurImageFilter_Make, SkBlurImageFilter_TileMode};
 

--- a/skia-safe/src/effects/blur_image_filter.rs
+++ b/skia-safe/src/effects/blur_image_filter.rs
@@ -1,0 +1,46 @@
+use crate::prelude::{NativePointerOrNull2, NativeTransmutable};
+use crate::{scalar, ImageFilter, ImageFilterCropRect};
+use skia_bindings::{C_SkBlurImageFilter_Make, SkBlurImageFilter_TileMode};
+
+pub enum BlurImageFilter {}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[repr(i32)]
+pub enum BlurImageFilterTileMode {
+    Clamp = SkBlurImageFilter_TileMode::kClamp_TileMode as _,
+    Repeat = SkBlurImageFilter_TileMode::kRepeat_TileMode as _,
+    ClampToBlack = SkBlurImageFilter_TileMode::kClampToBlack_TileMode as _,
+}
+
+impl NativeTransmutable<SkBlurImageFilter_TileMode> for BlurImageFilterTileMode {}
+#[test]
+fn test_tile_mode_layout() {
+    BlurImageFilterTileMode::test_layout();
+}
+
+impl BlurImageFilter {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new<
+        'a,
+        CR: Into<Option<&'a ImageFilterCropRect>>,
+        TM: Into<Option<BlurImageFilterTileMode>>,
+    >(
+        (sigma_x, sigma_y): (scalar, scalar),
+        input: &ImageFilter,
+        crop_rect: CR,
+        tile_mode: TM,
+    ) -> Option<ImageFilter> {
+        ImageFilter::from_ptr(unsafe {
+            C_SkBlurImageFilter_Make(
+                sigma_x,
+                sigma_y,
+                input.shared_native(),
+                crop_rect.into().native_ptr_or_null(),
+                tile_mode
+                    .into()
+                    .unwrap_or(BlurImageFilterTileMode::ClampToBlack)
+                    .into_native(),
+            )
+        })
+    }
+}

--- a/skia-safe/src/effects/color_filter_image_filter.rs
+++ b/skia-safe/src/effects/color_filter_image_filter.rs
@@ -1,0 +1,22 @@
+use crate::prelude::*;
+use crate::{ColorFilter, ImageFilter, ImageFilterCropRect};
+use skia_bindings::C_SkColorFilterImageFilter_Make;
+
+pub enum ColorFilterImageFilter {}
+
+impl ColorFilterImageFilter {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        cf: &ColorFilter,
+        input: &ImageFilter,
+        crop_rect: CR,
+    ) -> Option<ImageFilter> {
+        ImageFilter::from_ptr(unsafe {
+            C_SkColorFilterImageFilter_Make(
+                cf.shared_native(),
+                input.shared_native(),
+                crop_rect.into().native_ptr_or_null(),
+            )
+        })
+    }
+}

--- a/skia-safe/src/effects/color_filter_image_filter.rs
+++ b/skia-safe/src/effects/color_filter_image_filter.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::{ColorFilter, ImageFilter, ImageFilterCropRect};
-use skia_bindings::C_SkColorFilterImageFilter_Make;
+use skia_bindings::{C_SkColorFilterImageFilter_Make, SkImageFilter};
 
 pub enum ColorFilterImageFilter {}
 
@@ -18,5 +18,15 @@ impl ColorFilterImageFilter {
                 crop_rect.into().native_ptr_or_null(),
             )
         })
+    }
+}
+
+impl RCHandle<SkImageFilter> {
+    pub fn color_filter<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        &self,
+        crop_rect: CR,
+        cf: &ColorFilter,
+    ) -> Option<Self> {
+        ColorFilterImageFilter::new(cf, self, crop_rect)
     }
 }

--- a/skia-safe/src/effects/compose_image_filter.rs
+++ b/skia-safe/src/effects/compose_image_filter.rs
@@ -1,0 +1,13 @@
+use crate::ImageFilter;
+use skia_bindings::C_SkComposeImageFilter_Make;
+
+pub enum ComposeImageFilter {}
+
+impl ComposeImageFilter {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(outer: &ImageFilter, inner: &ImageFilter) -> Option<ImageFilter> {
+        ImageFilter::from_ptr(unsafe {
+            C_SkComposeImageFilter_Make(outer.shared_native(), inner.shared_native())
+        })
+    }
+}

--- a/skia-safe/src/effects/compose_image_filter.rs
+++ b/skia-safe/src/effects/compose_image_filter.rs
@@ -1,5 +1,6 @@
+use crate::prelude::*;
 use crate::ImageFilter;
-use skia_bindings::C_SkComposeImageFilter_Make;
+use skia_bindings::{C_SkComposeImageFilter_Make, SkImageFilter};
 
 pub enum ComposeImageFilter {}
 
@@ -9,5 +10,11 @@ impl ComposeImageFilter {
         ImageFilter::from_ptr(unsafe {
             C_SkComposeImageFilter_Make(outer.shared_native(), inner.shared_native())
         })
+    }
+}
+
+impl RCHandle<SkImageFilter> {
+    pub fn compose(outer: &ImageFilter, inner: &ImageFilter) -> Option<Self> {
+        ComposeImageFilter::new(outer, inner)
     }
 }

--- a/skia-safe/src/effects/corner_path_effect.rs
+++ b/skia-safe/src/effects/corner_path_effect.rs
@@ -1,5 +1,6 @@
 use crate::core::{scalar, PathEffect};
-use skia_bindings::C_SkCornerPathEffect_Make;
+use crate::prelude::*;
+use skia_bindings::{C_SkCornerPathEffect_Make, SkPathEffect};
 
 pub enum CornerPathEffect {}
 
@@ -7,5 +8,11 @@ impl CornerPathEffect {
     #[allow(clippy::new_ret_no_self)]
     pub fn new(radius: scalar) -> Option<PathEffect> {
         PathEffect::from_ptr(unsafe { C_SkCornerPathEffect_Make(radius) })
+    }
+}
+
+impl RCHandle<SkPathEffect> {
+    pub fn corner_path(radius: scalar) -> Option<Self> {
+        CornerPathEffect::new(radius)
     }
 }

--- a/skia-safe/src/effects/dash_path_effect.rs
+++ b/skia-safe/src/effects/dash_path_effect.rs
@@ -1,6 +1,6 @@
-use crate::core::{scalar, PathEffect};
 use crate::prelude::*;
-use skia_bindings::C_SkDashPathEffect_Make;
+use crate::{scalar, PathEffect};
+use skia_bindings::{C_SkDashPathEffect_Make, SkPathEffect};
 
 pub enum DashPathEffect {}
 
@@ -14,5 +14,11 @@ impl DashPathEffect {
                 phase,
             )
         })
+    }
+}
+
+impl RCHandle<SkPathEffect> {
+    pub fn dash(intervals: &[scalar], phase: scalar) -> Option<Self> {
+        DashPathEffect::new(intervals, phase)
     }
 }

--- a/skia-safe/src/effects/discrete_path_effect.rs
+++ b/skia-safe/src/effects/discrete_path_effect.rs
@@ -1,5 +1,6 @@
-use crate::core::{scalar, PathEffect};
-use skia_bindings::C_SkDiscretePathEffect_Make;
+use crate::prelude::*;
+use crate::{scalar, PathEffect};
+use skia_bindings::{C_SkDiscretePathEffect_Make, SkPathEffect};
 
 pub enum DiscretePathEffect {}
 
@@ -13,5 +14,15 @@ impl DiscretePathEffect {
         PathEffect::from_ptr(unsafe {
             C_SkDiscretePathEffect_Make(seg_length, dev, seed_assist.into().unwrap_or(0))
         })
+    }
+}
+
+impl RCHandle<SkPathEffect> {
+    pub fn discrete<SA: Into<Option<u32>>>(
+        seg_length: scalar,
+        dev: scalar,
+        seed_assist: SA,
+    ) -> Option<Self> {
+        DiscretePathEffect::new(seg_length, dev, seed_assist)
     }
 }

--- a/skia-safe/src/effects/displacement_map_effect.rs
+++ b/skia-safe/src/effects/displacement_map_effect.rs
@@ -1,0 +1,49 @@
+use crate::prelude::*;
+use crate::{scalar, ImageFilter, ImageFilterCropRect};
+use skia_bindings::{C_SkDisplacementMapEffect_Make, SkDisplacementMapEffect_ChannelSelectorType};
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[repr(i32)]
+pub enum DisplacementMapChannelSelector {
+    Unknown = SkDisplacementMapEffect_ChannelSelectorType::kUnknown_ChannelSelectorType as _,
+    R = SkDisplacementMapEffect_ChannelSelectorType::kR_ChannelSelectorType as _,
+    G = SkDisplacementMapEffect_ChannelSelectorType::kG_ChannelSelectorType as _,
+    B = SkDisplacementMapEffect_ChannelSelectorType::kB_ChannelSelectorType as _,
+    A = SkDisplacementMapEffect_ChannelSelectorType::kA_ChannelSelectorType as _,
+}
+
+impl NativeTransmutable<SkDisplacementMapEffect_ChannelSelectorType>
+    for DisplacementMapChannelSelector
+{
+}
+#[test]
+fn test_channel_selector_type_layout() {
+    DisplacementMapChannelSelector::test_layout();
+}
+
+pub enum DisplacementMapEffect {}
+
+impl DisplacementMapEffect {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        (x_channel_selector, y_channel_selector): (
+            DisplacementMapChannelSelector,
+            DisplacementMapChannelSelector,
+        ),
+        scale: scalar,
+        displacement: &ImageFilter,
+        color: &ImageFilter,
+        crop_rect: CR,
+    ) -> Option<ImageFilter> {
+        ImageFilter::from_ptr(unsafe {
+            C_SkDisplacementMapEffect_Make(
+                x_channel_selector.into_native(),
+                y_channel_selector.into_native(),
+                scale,
+                displacement.shared_native(),
+                color.shared_native(),
+                crop_rect.into().native_ptr_or_null(),
+            )
+        })
+    }
+}

--- a/skia-safe/src/effects/displacement_map_effect.rs
+++ b/skia-safe/src/effects/displacement_map_effect.rs
@@ -1,6 +1,8 @@
 use crate::prelude::*;
 use crate::{scalar, ImageFilter, ImageFilterCropRect};
-use skia_bindings::{C_SkDisplacementMapEffect_Make, SkDisplacementMapEffect_ChannelSelectorType};
+use skia_bindings::{
+    C_SkDisplacementMapEffect_Make, SkDisplacementMapEffect_ChannelSelectorType, SkImageFilter,
+};
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
@@ -45,5 +47,20 @@ impl DisplacementMapEffect {
                 crop_rect.into().native_ptr_or_null(),
             )
         })
+    }
+}
+
+impl RCHandle<SkImageFilter> {
+    pub fn displacement_map_effect<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        channel_selectors: (
+            DisplacementMapChannelSelector,
+            DisplacementMapChannelSelector,
+        ),
+        scale: scalar,
+        displacement: &ImageFilter,
+        color: &ImageFilter,
+        crop_rect: CR,
+    ) -> Option<Self> {
+        DisplacementMapEffect::new(channel_selectors, scale, displacement, color, crop_rect)
     }
 }

--- a/skia-safe/src/effects/drop_shadow_image_filter.rs
+++ b/skia-safe/src/effects/drop_shadow_image_filter.rs
@@ -1,6 +1,8 @@
 use crate::prelude::*;
 use crate::{scalar, Color, ImageFilter, ImageFilterCropRect};
-use skia_bindings::{C_SkDropShadowImageFilter_Make, SkDropShadowImageFilter_ShadowMode};
+use skia_bindings::{
+    C_SkDropShadowImageFilter_Make, SkDropShadowImageFilter_ShadowMode, SkImageFilter,
+};
 
 pub enum DropShadowImageFilter {}
 
@@ -40,5 +42,18 @@ impl DropShadowImageFilter {
                 crop_rect.into().native_ptr_or_null(),
             )
         })
+    }
+}
+
+impl RCHandle<SkImageFilter> {
+    pub fn drop_shadow<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        &self,
+        crop_rect: CR,
+        delta: (scalar, scalar),
+        sigma: (scalar, scalar),
+        color: Color,
+        shadow_mode: DropShadowImageFilterShadowMode,
+    ) -> Option<Self> {
+        DropShadowImageFilter::new(delta, sigma, color, shadow_mode, self, crop_rect)
     }
 }

--- a/skia-safe/src/effects/drop_shadow_image_filter.rs
+++ b/skia-safe/src/effects/drop_shadow_image_filter.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use crate::{scalar, Color, ImageFilter, ImageFilterCropRect};
+use crate::{scalar, Color, ImageFilter, ImageFilterCropRect, Vector};
 use skia_bindings::{
     C_SkDropShadowImageFilter_Make, SkDropShadowImageFilter_ShadowMode, SkImageFilter,
 };
@@ -22,18 +22,19 @@ fn test_shadow_mode_layout() {
 
 impl DropShadowImageFilter {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
-        (dx, dy): (scalar, scalar),
+    pub fn new<'a, IV: Into<Vector>, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        delta: IV,
         (sigma_x, sigma_y): (scalar, scalar),
         color: Color,
         shadow_mode: DropShadowImageFilterShadowMode,
         input: &ImageFilter,
         crop_rect: CR,
     ) -> Option<ImageFilter> {
+        let delta = delta.into();
         ImageFilter::from_ptr(unsafe {
             C_SkDropShadowImageFilter_Make(
-                dx,
-                dy,
+                delta.x,
+                delta.y,
                 sigma_x,
                 sigma_y,
                 color.into_native(),
@@ -46,10 +47,10 @@ impl DropShadowImageFilter {
 }
 
 impl RCHandle<SkImageFilter> {
-    pub fn drop_shadow<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
+    pub fn drop_shadow<'a, IV: Into<Vector>, CR: Into<Option<&'a ImageFilterCropRect>>>(
         &self,
         crop_rect: CR,
-        delta: (scalar, scalar),
+        delta: IV,
         sigma: (scalar, scalar),
         color: Color,
         shadow_mode: DropShadowImageFilterShadowMode,

--- a/skia-safe/src/effects/drop_shadow_image_filter.rs
+++ b/skia-safe/src/effects/drop_shadow_image_filter.rs
@@ -1,0 +1,44 @@
+use crate::prelude::*;
+use crate::{scalar, Color, ImageFilter, ImageFilterCropRect};
+use skia_bindings::{C_SkDropShadowImageFilter_Make, SkDropShadowImageFilter_ShadowMode};
+
+pub enum DropShadowImageFilter {}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[repr(i32)]
+pub enum DropShadowImageFilterShadowMode {
+    DrawShadowAndForeground =
+        SkDropShadowImageFilter_ShadowMode::kDrawShadowAndForeground_ShadowMode as _,
+    DrawShadowOnly = SkDropShadowImageFilter_ShadowMode::kDrawShadowOnly_ShadowMode as _,
+}
+
+impl NativeTransmutable<SkDropShadowImageFilter_ShadowMode> for DropShadowImageFilterShadowMode {}
+#[test]
+fn test_shadow_mode_layout() {
+    DropShadowImageFilterShadowMode::test_layout();
+}
+
+impl DropShadowImageFilter {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        (dx, dy): (scalar, scalar),
+        (sigma_x, sigma_y): (scalar, scalar),
+        color: Color,
+        shadow_mode: DropShadowImageFilterShadowMode,
+        input: &ImageFilter,
+        crop_rect: CR,
+    ) -> Option<ImageFilter> {
+        ImageFilter::from_ptr(unsafe {
+            C_SkDropShadowImageFilter_Make(
+                dx,
+                dy,
+                sigma_x,
+                sigma_y,
+                color.into_native(),
+                shadow_mode.into_native(),
+                input.shared_native(),
+                crop_rect.into().native_ptr_or_null(),
+            )
+        })
+    }
+}

--- a/skia-safe/src/effects/drop_shadow_image_filter.rs
+++ b/skia-safe/src/effects/drop_shadow_image_filter.rs
@@ -22,15 +22,16 @@ fn test_shadow_mode_layout() {
 
 impl DropShadowImageFilter {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new<'a, IV: Into<Vector>, CR: Into<Option<&'a ImageFilterCropRect>>>(
+    pub fn new<'a, IV: Into<Vector>, IC: Into<Color>, CR: Into<Option<&'a ImageFilterCropRect>>>(
         delta: IV,
         (sigma_x, sigma_y): (scalar, scalar),
-        color: Color,
+        color: IC,
         shadow_mode: DropShadowImageFilterShadowMode,
         input: &ImageFilter,
         crop_rect: CR,
     ) -> Option<ImageFilter> {
         let delta = delta.into();
+        let color = color.into();
         ImageFilter::from_ptr(unsafe {
             C_SkDropShadowImageFilter_Make(
                 delta.x,
@@ -47,12 +48,12 @@ impl DropShadowImageFilter {
 }
 
 impl RCHandle<SkImageFilter> {
-    pub fn drop_shadow<'a, IV: Into<Vector>, CR: Into<Option<&'a ImageFilterCropRect>>>(
+    pub fn drop_shadow<'a, IV: Into<Vector>, IC: Into<Color>, CR: Into<Option<&'a ImageFilterCropRect>>>(
         &self,
         crop_rect: CR,
         delta: IV,
         sigma: (scalar, scalar),
-        color: Color,
+        color: IC,
         shadow_mode: DropShadowImageFilterShadowMode,
     ) -> Option<Self> {
         DropShadowImageFilter::new(delta, sigma, color, shadow_mode, self, crop_rect)

--- a/skia-safe/src/effects/gradient_shader.rs
+++ b/skia-safe/src/effects/gradient_shader.rs
@@ -5,7 +5,7 @@ use skia_bindings::{
     C_SkGradientShader_MakeLinear, C_SkGradientShader_MakeLinear2, C_SkGradientShader_MakeRadial,
     C_SkGradientShader_MakeRadial2, C_SkGradientShader_MakeSweep, C_SkGradientShader_MakeSweep2,
     C_SkGradientShader_MakeTwoPointConical, C_SkGradientShader_MakeTwoPointConical2,
-    SkGradientShader_Flags_kInterpolateColorsInPremul_Flag,
+    SkGradientShader_Flags_kInterpolateColorsInPremul_Flag, SkShader,
 };
 
 pub enum GradientShader {}
@@ -285,5 +285,98 @@ impl<'a> From<&'a [Color]> for GradientShaderColors<'a> {
 impl<'a> From<(&'a [Color4f], &'a ColorSpace)> for GradientShaderColors<'a> {
     fn from(c: (&'a [Color4f], &'a ColorSpace)) -> Self {
         GradientShaderColors::<'a>::ColorsInSpace(c.0, c.1)
+    }
+}
+
+impl RCHandle<SkShader> {
+    pub fn linear_gradient<
+        'a,
+        P1: Into<Point>,
+        P2: Into<Point>,
+        C: Into<GradientShaderColors<'a>>,
+        POS: Into<Option<&'a [scalar]>>,
+        F: Into<Option<GradientShaderFlags>>,
+        LM: Into<Option<&'a Matrix>>,
+    >(
+        points: (P1, P2),
+        colors: C,
+        pos: POS,
+        mode: ShaderTileMode,
+        flags: F,
+        local_matrix: LM,
+    ) -> Option<Self> {
+        GradientShader::linear(points, colors, pos, mode, flags, local_matrix)
+    }
+
+    pub fn radial_gradient<
+        'a,
+        P: Into<Point>,
+        C: Into<GradientShaderColors<'a>>,
+        POS: Into<Option<&'a [scalar]>>,
+        F: Into<Option<GradientShaderFlags>>,
+        LM: Into<Option<&'a Matrix>>,
+    >(
+        center: P,
+        radius: scalar,
+        colors: C,
+        pos: POS,
+        mode: ShaderTileMode,
+        flags: F,
+        local_matrix: LM,
+    ) -> Option<Self> {
+        GradientShader::radial(center, radius, colors, pos, mode, flags, local_matrix)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn two_point_conical_gradient<
+        'a,
+        PS: Into<Point>,
+        PE: Into<Point>,
+        C: Into<GradientShaderColors<'a>>,
+        POS: Into<Option<&'a [scalar]>>,
+        F: Into<Option<GradientShaderFlags>>,
+        LM: Into<Option<&'a Matrix>>,
+    >(
+        start: PS,
+        start_radius: scalar,
+        end: PE,
+        end_radius: scalar,
+        colors: C,
+        pos: POS,
+        mode: ShaderTileMode,
+        flags: F,
+        local_matrix: LM,
+    ) -> Option<Self> {
+        GradientShader::two_point_conical(
+            start,
+            start_radius,
+            end,
+            end_radius,
+            colors,
+            pos,
+            mode,
+            flags,
+            local_matrix,
+        )
+    }
+
+    pub fn sweep_gradient<
+        'a,
+        P: Into<Point>,
+        C: Into<GradientShaderColors<'a>>,
+        POS: Into<Option<&'a [scalar]>>,
+        A: Into<Option<(scalar, scalar)>>,
+        F: Into<Option<GradientShaderFlags>>,
+        LM: Into<Option<&'a Matrix>>,
+    >(
+        center: P,
+        colors: C,
+        pos: POS,
+        mode: ShaderTileMode,
+        angles: A,
+        flags: F,
+        local_matrix: LM,
+    ) -> Option<Self> {
+        GradientShader::sweep(center, colors, pos, mode, angles, flags, local_matrix)
     }
 }

--- a/skia-safe/src/effects/image_source.rs
+++ b/skia-safe/src/effects/image_source.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::{FilterQuality, Image, ImageFilter, Rect};
-use skia_bindings::{C_SkImageSource_Make, C_SkImageSource_Make2};
+use skia_bindings::{C_SkImageSource_Make, C_SkImageSource_Make2, SkImage, SkImageFilter};
 
 pub enum ImageSource {}
 
@@ -24,5 +24,37 @@ impl ImageSource {
                 filter_quality.into_native(),
             )
         })
+    }
+}
+
+impl RCHandle<SkImageFilter> {
+    pub fn from_image(image: &Image) -> Option<Self> {
+        ImageSource::from_image(image)
+    }
+
+    // TODO: improve naming of that function?
+    pub fn from_image_partial<SR: AsRef<Rect>, DR: AsRef<Rect>>(
+        image: &Image,
+        src_rect: SR,
+        dst_rect: DR,
+        filter_quality: FilterQuality,
+    ) -> Option<Self> {
+        ImageSource::from_image_partial(image, src_rect, dst_rect, filter_quality)
+    }
+}
+
+impl RCHandle<SkImage> {
+    pub fn as_filter(&self) -> Option<ImageFilter> {
+        ImageSource::from_image(self)
+    }
+
+    // TODO: improve naming of that function?
+    pub fn as_filter_partial<SR: AsRef<Rect>, DR: AsRef<Rect>>(
+        &self,
+        src_rect: SR,
+        dst_rect: DR,
+        filter_quality: FilterQuality,
+    ) -> Option<ImageFilter> {
+        ImageSource::from_image_partial(self, src_rect, dst_rect, filter_quality)
     }
 }

--- a/skia-safe/src/effects/image_source.rs
+++ b/skia-safe/src/effects/image_source.rs
@@ -1,0 +1,28 @@
+use crate::prelude::*;
+use crate::{FilterQuality, Image, ImageFilter, Rect};
+use skia_bindings::{C_SkImageSource_Make, C_SkImageSource_Make2};
+
+pub enum ImageSource {}
+
+impl ImageSource {
+    pub fn from_image(image: &Image) -> Option<ImageFilter> {
+        ImageFilter::from_ptr(unsafe { C_SkImageSource_Make(image.shared_native()) })
+    }
+
+    // TODO: improve naming of that function?
+    pub fn from_image_partial<SR: AsRef<Rect>, DR: AsRef<Rect>>(
+        image: &Image,
+        src_rect: SR,
+        dst_rect: DR,
+        filter_quality: FilterQuality,
+    ) -> Option<ImageFilter> {
+        ImageFilter::from_ptr(unsafe {
+            C_SkImageSource_Make2(
+                image.shared_native(),
+                src_rect.as_ref().native(),
+                dst_rect.as_ref().native(),
+                filter_quality.into_native(),
+            )
+        })
+    }
+}

--- a/skia-safe/src/effects/image_source.rs
+++ b/skia-safe/src/effects/image_source.rs
@@ -9,8 +9,7 @@ impl ImageSource {
         ImageFilter::from_ptr(unsafe { C_SkImageSource_Make(image.shared_native()) })
     }
 
-    // TODO: improve naming of that function?
-    pub fn from_image_partial<SR: AsRef<Rect>, DR: AsRef<Rect>>(
+    pub fn from_image_rect<SR: AsRef<Rect>, DR: AsRef<Rect>>(
         image: &Image,
         src_rect: SR,
         dst_rect: DR,
@@ -32,14 +31,13 @@ impl RCHandle<SkImageFilter> {
         ImageSource::from_image(image)
     }
 
-    // TODO: improve naming of that function?
-    pub fn from_image_partial<SR: AsRef<Rect>, DR: AsRef<Rect>>(
+    pub fn from_image_rect<SR: AsRef<Rect>, DR: AsRef<Rect>>(
         image: &Image,
         src_rect: SR,
         dst_rect: DR,
         filter_quality: FilterQuality,
     ) -> Option<Self> {
-        ImageSource::from_image_partial(image, src_rect, dst_rect, filter_quality)
+        ImageSource::from_image_rect(image, src_rect, dst_rect, filter_quality)
     }
 }
 
@@ -48,13 +46,12 @@ impl RCHandle<SkImage> {
         ImageSource::from_image(self)
     }
 
-    // TODO: improve naming of that function?
-    pub fn as_filter_partial<SR: AsRef<Rect>, DR: AsRef<Rect>>(
+    pub fn as_filter_rect<SR: AsRef<Rect>, DR: AsRef<Rect>>(
         &self,
         src_rect: SR,
         dst_rect: DR,
         filter_quality: FilterQuality,
     ) -> Option<ImageFilter> {
-        ImageSource::from_image_partial(self, src_rect, dst_rect, filter_quality)
+        ImageSource::from_image_rect(self, src_rect, dst_rect, filter_quality)
     }
 }

--- a/skia-safe/src/effects/lighting_image_filter.rs
+++ b/skia-safe/src/effects/lighting_image_filter.rs
@@ -4,6 +4,7 @@ use skia_bindings::{
     C_SkLightingImageFilter_MakeDistantLitDiffuse, C_SkLightingImageFilter_MakeDistantLitSpecular,
     C_SkLightingImageFilter_MakePointLitDiffuse, C_SkLightingImageFilter_MakePointLitSpecular,
     C_SkLightingImageFilter_MakeSpotLitDiffuse, C_SkLightingImageFilter_MakeSpotLitSpecular,
+    SkImageFilter,
 };
 
 pub enum LightingImageFilter {}
@@ -179,5 +180,167 @@ impl LightingImageFilter {
                 crop_rect.into().native_ptr_or_null(),
             )
         })
+    }
+}
+
+impl RCHandle<SkImageFilter> {
+    pub fn distant_lit_diffuse_lighting<
+        'a,
+        IP3: Into<Point3>,
+        IC: Into<Color>,
+        CR: Into<Option<&'a ImageFilterCropRect>>,
+    >(
+        &self,
+        crop_rect: CR,
+        direction: IP3,
+        light_color: IC,
+        surface_scale: scalar,
+        kd: scalar,
+    ) -> Option<Self> {
+        LightingImageFilter::distant_lit_diffuse(
+            direction,
+            light_color,
+            surface_scale,
+            kd,
+            self,
+            crop_rect,
+        )
+    }
+
+    pub fn point_lit_diffuse_lighting<
+        'a,
+        IP3: Into<Point3>,
+        IC: Into<Color>,
+        CR: Into<Option<&'a ImageFilterCropRect>>,
+    >(
+        &self,
+        crop_rect: CR,
+        location: IP3,
+        light_color: IC,
+        surface_scale: scalar,
+        kd: scalar,
+    ) -> Option<Self> {
+        LightingImageFilter::point_lit_diffuse(
+            location,
+            light_color,
+            surface_scale,
+            kd,
+            self,
+            crop_rect,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn spot_lit_diffuse_lighting<
+        'a,
+        IP3L: Into<Point3>,
+        IP3T: Into<Point3>,
+        IC: Into<Color>,
+        CR: Into<Option<&'a ImageFilterCropRect>>,
+    >(
+        &self,
+        crop_rect: CR,
+        location: IP3L,
+        target: IP3T,
+        specular_exponent: scalar,
+        cutoff_angle: scalar,
+        light_color: IC,
+        surface_scale: scalar,
+        kd: scalar,
+    ) -> Option<Self> {
+        LightingImageFilter::spot_lit_diffuse(
+            location,
+            target,
+            specular_exponent,
+            cutoff_angle,
+            light_color,
+            surface_scale,
+            kd,
+            self,
+            crop_rect,
+        )
+    }
+
+    pub fn distant_lit_specular_lighting<
+        'a,
+        IP3: Into<Point3>,
+        IC: Into<Color>,
+        CR: Into<Option<&'a ImageFilterCropRect>>,
+    >(
+        &self,
+        crop_rect: CR,
+        direction: IP3,
+        light_color: IC,
+        surface_scale: scalar,
+        ks: scalar,
+        shininess: scalar,
+    ) -> Option<Self> {
+        LightingImageFilter::distant_lit_specular(
+            direction,
+            light_color,
+            surface_scale,
+            ks,
+            shininess,
+            self,
+            crop_rect,
+        )
+    }
+
+    pub fn point_lit_specular_lighting<
+        'a,
+        IP3: Into<Point3>,
+        IC: Into<Color>,
+        CR: Into<Option<&'a ImageFilterCropRect>>,
+    >(
+        &self,
+        crop_rect: CR,
+        location: IP3,
+        light_color: IC,
+        surface_scale: scalar,
+        ks: scalar,
+        shininess: scalar,
+    ) -> Option<Self> {
+        LightingImageFilter::point_lit_specular(
+            location,
+            light_color,
+            surface_scale,
+            ks,
+            shininess,
+            self,
+            crop_rect,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn spot_lit_specular_lighting<
+        'a,
+        IP3L: Into<Point3>,
+        IP3T: Into<Point3>,
+        IC: Into<Color>,
+        CR: Into<Option<&'a ImageFilterCropRect>>,
+    >(
+        &self,
+        crop_rect: CR,
+        location: IP3L,
+        target: IP3T,
+        specular_exponent: scalar,
+        cutoff_angle: scalar,
+        light_color: IC,
+        surface_scale: scalar,
+        ks: scalar,
+        shininess: scalar,
+    ) -> Option<Self> {
+        LightingImageFilter::spot_lit_specular(
+            location,
+            target,
+            specular_exponent,
+            cutoff_angle,
+            light_color,
+            surface_scale,
+            ks,
+            shininess,
+            self,
+            crop_rect,
+        )
     }
 }

--- a/skia-safe/src/effects/lighting_image_filter.rs
+++ b/skia-safe/src/effects/lighting_image_filter.rs
@@ -1,0 +1,183 @@
+use crate::prelude::*;
+use crate::{scalar, Color, ImageFilter, ImageFilterCropRect, Point3};
+use skia_bindings::{
+    C_SkLightingImageFilter_MakeDistantLitDiffuse, C_SkLightingImageFilter_MakeDistantLitSpecular,
+    C_SkLightingImageFilter_MakePointLitDiffuse, C_SkLightingImageFilter_MakePointLitSpecular,
+    C_SkLightingImageFilter_MakeSpotLitDiffuse, C_SkLightingImageFilter_MakeSpotLitSpecular,
+};
+
+pub enum LightingImageFilter {}
+
+impl LightingImageFilter {
+    pub fn distant_lit_diffuse<
+        'a,
+        IP3: Into<Point3>,
+        IC: Into<Color>,
+        CR: Into<Option<&'a ImageFilterCropRect>>,
+    >(
+        direction: IP3,
+        light_color: IC,
+        surface_scale: scalar,
+        kd: scalar,
+        input: &ImageFilter,
+        crop_rect: CR,
+    ) -> Option<ImageFilter> {
+        ImageFilter::from_ptr(unsafe {
+            C_SkLightingImageFilter_MakeDistantLitDiffuse(
+                direction.into().native(),
+                light_color.into().into_native(),
+                surface_scale,
+                kd,
+                input.shared_native(),
+                crop_rect.into().native_ptr_or_null(),
+            )
+        })
+    }
+
+    pub fn point_lit_diffuse<
+        'a,
+        IP3: Into<Point3>,
+        IC: Into<Color>,
+        CR: Into<Option<&'a ImageFilterCropRect>>,
+    >(
+        location: IP3,
+        light_color: IC,
+        surface_scale: scalar,
+        kd: scalar,
+        input: &ImageFilter,
+        crop_rect: CR,
+    ) -> Option<ImageFilter> {
+        ImageFilter::from_ptr(unsafe {
+            C_SkLightingImageFilter_MakePointLitDiffuse(
+                location.into().native(),
+                light_color.into().into_native(),
+                surface_scale,
+                kd,
+                input.shared_native(),
+                crop_rect.into().native_ptr_or_null(),
+            )
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn spot_lit_diffuse<
+        'a,
+        IP3L: Into<Point3>,
+        IP3T: Into<Point3>,
+        IC: Into<Color>,
+        CR: Into<Option<&'a ImageFilterCropRect>>,
+    >(
+        location: IP3L,
+        target: IP3T,
+        specular_exponent: scalar,
+        cutoff_angle: scalar,
+        light_color: IC,
+        surface_scale: scalar,
+        kd: scalar,
+        input: &ImageFilter,
+        crop_rect: CR,
+    ) -> Option<ImageFilter> {
+        ImageFilter::from_ptr(unsafe {
+            C_SkLightingImageFilter_MakeSpotLitDiffuse(
+                location.into().native(),
+                target.into().native(),
+                specular_exponent,
+                cutoff_angle,
+                light_color.into().into_native(),
+                surface_scale,
+                kd,
+                input.shared_native(),
+                crop_rect.into().native_ptr_or_null(),
+            )
+        })
+    }
+
+    pub fn distant_lit_specular<
+        'a,
+        IP3: Into<Point3>,
+        IC: Into<Color>,
+        CR: Into<Option<&'a ImageFilterCropRect>>,
+    >(
+        direction: IP3,
+        light_color: IC,
+        surface_scale: scalar,
+        ks: scalar,
+        shininess: scalar,
+        input: &ImageFilter,
+        crop_rect: CR,
+    ) -> Option<ImageFilter> {
+        ImageFilter::from_ptr(unsafe {
+            C_SkLightingImageFilter_MakeDistantLitSpecular(
+                direction.into().native(),
+                light_color.into().into_native(),
+                surface_scale,
+                ks,
+                shininess,
+                input.shared_native(),
+                crop_rect.into().native_ptr_or_null(),
+            )
+        })
+    }
+
+    pub fn point_lit_specular<
+        'a,
+        IP3: Into<Point3>,
+        IC: Into<Color>,
+        CR: Into<Option<&'a ImageFilterCropRect>>,
+    >(
+        location: IP3,
+        light_color: IC,
+        surface_scale: scalar,
+        ks: scalar,
+        shininess: scalar,
+        input: &ImageFilter,
+        crop_rect: CR,
+    ) -> Option<ImageFilter> {
+        ImageFilter::from_ptr(unsafe {
+            C_SkLightingImageFilter_MakePointLitSpecular(
+                location.into().native(),
+                light_color.into().into_native(),
+                surface_scale,
+                ks,
+                shininess,
+                input.shared_native(),
+                crop_rect.into().native_ptr_or_null(),
+            )
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn spot_lit_specular<
+        'a,
+        IP3L: Into<Point3>,
+        IP3T: Into<Point3>,
+        IC: Into<Color>,
+        CR: Into<Option<&'a ImageFilterCropRect>>,
+    >(
+        location: IP3L,
+        target: IP3T,
+        specular_exponent: scalar,
+        cutoff_angle: scalar,
+        light_color: IC,
+        surface_scale: scalar,
+        ks: scalar,
+        shininess: scalar,
+        input: &ImageFilter,
+        crop_rect: CR,
+    ) -> Option<ImageFilter> {
+        ImageFilter::from_ptr(unsafe {
+            C_SkLightingImageFilter_MakeSpotLitSpecular(
+                location.into().native(),
+                target.into().native(),
+                specular_exponent,
+                cutoff_angle,
+                light_color.into().into_native(),
+                surface_scale,
+                ks,
+                shininess,
+                input.shared_native(),
+                crop_rect.into().native_ptr_or_null(),
+            )
+        })
+    }
+}

--- a/skia-safe/src/effects/magnifier_image_filter.rs
+++ b/skia-safe/src/effects/magnifier_image_filter.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::{scalar, ImageFilter, ImageFilterCropRect, Rect};
-use skia_bindings::C_SkMagnifierImageFilter_Make;
+use skia_bindings::{C_SkMagnifierImageFilter_Make, SkImageFilter};
 
 pub enum MagnifierImageFilter {}
 
@@ -20,5 +20,16 @@ impl MagnifierImageFilter {
                 crop_rect.into().native_ptr_or_null(),
             )
         })
+    }
+}
+
+impl RCHandle<SkImageFilter> {
+    pub fn magnifier<'a, R: AsRef<Rect>, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        &self,
+        crop_rect: CR,
+        src_rect: R,
+        inset: scalar,
+    ) -> Option<Self> {
+        MagnifierImageFilter::new(src_rect, inset, self, crop_rect)
     }
 }

--- a/skia-safe/src/effects/magnifier_image_filter.rs
+++ b/skia-safe/src/effects/magnifier_image_filter.rs
@@ -1,0 +1,24 @@
+use crate::prelude::*;
+use crate::{scalar, ImageFilter, ImageFilterCropRect, Rect};
+use skia_bindings::C_SkMagnifierImageFilter_Make;
+
+pub enum MagnifierImageFilter {}
+
+impl MagnifierImageFilter {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new<'a, R: AsRef<Rect>, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        src_rect: R,
+        inset: scalar,
+        input: &ImageFilter,
+        crop_rect: CR,
+    ) -> Option<ImageFilter> {
+        ImageFilter::from_ptr(unsafe {
+            C_SkMagnifierImageFilter_Make(
+                src_rect.as_ref().native(),
+                inset,
+                input.shared_native(),
+                crop_rect.into().native_ptr_or_null(),
+            )
+        })
+    }
+}

--- a/skia-safe/src/effects/matrix_convolution_image_filter.rs
+++ b/skia-safe/src/effects/matrix_convolution_image_filter.rs
@@ -1,0 +1,56 @@
+use crate::prelude::*;
+use crate::{scalar, IPoint, ISize, ImageFilter, ImageFilterCropRect};
+use skia_bindings::{
+    C_SkMatrixConvolutionImageFilter_Make, SkMatrixConvolutionImageFilter_TileMode,
+};
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[repr(i32)]
+pub enum MatrixConvolutionImageFilterTileMode {
+    Clamp = SkMatrixConvolutionImageFilter_TileMode::kClamp_TileMode as _,
+    Repeat = SkMatrixConvolutionImageFilter_TileMode::kRepeat_TileMode as _,
+    ClampToBlack = SkMatrixConvolutionImageFilter_TileMode::kClampToBlack_TileMode as _,
+}
+
+impl NativeTransmutable<SkMatrixConvolutionImageFilter_TileMode>
+    for MatrixConvolutionImageFilterTileMode
+{
+}
+#[test]
+fn test_tile_mode_layout() {
+    MatrixConvolutionImageFilterTileMode::test_layout();
+}
+
+pub enum MatrixConvolutionImageFilter {}
+
+impl MatrixConvolutionImageFilter {
+    #[allow(clippy::new_ret_no_self)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new<'a, IS: Into<ISize>, IP: Into<IPoint>, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        kernel_size: IS,
+        kernel: &[scalar],
+        gain: scalar,
+        bias: scalar,
+        kernel_offset: IP,
+        tile_mode: MatrixConvolutionImageFilterTileMode,
+        convolve_alpha: bool,
+        input: &ImageFilter,
+        crop_rect: CR,
+    ) -> Option<ImageFilter> {
+        let kernel_size = kernel_size.into();
+        assert_eq!((kernel_size.width * kernel_size.height) as usize, kernel.len());
+        ImageFilter::from_ptr(unsafe {
+            C_SkMatrixConvolutionImageFilter_Make(
+                kernel_size.native(),
+                kernel.as_ptr(),
+                gain,
+                bias,
+                kernel_offset.into().native(),
+                tile_mode.into_native(),
+                convolve_alpha,
+                input.shared_native(),
+                crop_rect.into().native_ptr_or_null(),
+            )
+        })
+    }
+}

--- a/skia-safe/src/effects/matrix_convolution_image_filter.rs
+++ b/skia-safe/src/effects/matrix_convolution_image_filter.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use crate::{scalar, IPoint, ISize, ImageFilter, ImageFilterCropRect};
 use skia_bindings::{
-    C_SkMatrixConvolutionImageFilter_Make, SkMatrixConvolutionImageFilter_TileMode,
+    C_SkMatrixConvolutionImageFilter_Make, SkImageFilter, SkMatrixConvolutionImageFilter_TileMode,
 };
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -38,7 +38,10 @@ impl MatrixConvolutionImageFilter {
         crop_rect: CR,
     ) -> Option<ImageFilter> {
         let kernel_size = kernel_size.into();
-        assert_eq!((kernel_size.width * kernel_size.height) as usize, kernel.len());
+        assert_eq!(
+            (kernel_size.width * kernel_size.height) as usize,
+            kernel.len()
+        );
         ImageFilter::from_ptr(unsafe {
             C_SkMatrixConvolutionImageFilter_Make(
                 kernel_size.native(),
@@ -52,5 +55,37 @@ impl MatrixConvolutionImageFilter {
                 crop_rect.into().native_ptr_or_null(),
             )
         })
+    }
+}
+
+impl RCHandle<SkImageFilter> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn matrix_convolution<
+        'a,
+        IS: Into<ISize>,
+        IP: Into<IPoint>,
+        CR: Into<Option<&'a ImageFilterCropRect>>,
+    >(
+        &self,
+        crop_rect: CR,
+        kernel_size: IS,
+        kernel: &[scalar],
+        gain: scalar,
+        bias: scalar,
+        kernel_offset: IP,
+        tile_mode: MatrixConvolutionImageFilterTileMode,
+        convolve_alpha: bool,
+    ) -> Option<Self> {
+        MatrixConvolutionImageFilter::new(
+            kernel_size,
+            kernel,
+            gain,
+            bias,
+            kernel_offset,
+            tile_mode,
+            convolve_alpha,
+            self,
+            crop_rect,
+        )
     }
 }

--- a/skia-safe/src/effects/merge_image_filter.rs
+++ b/skia-safe/src/effects/merge_image_filter.rs
@@ -24,3 +24,12 @@ impl MergeImageFilter {
         })
     }
 }
+
+impl RCHandle<SkImageFilter> {
+    pub fn merge<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        filters: &[&Self],
+        crop_rect: CR,
+    ) -> Option<Self> {
+        MergeImageFilter::new(filters, crop_rect)
+    }
+}

--- a/skia-safe/src/effects/merge_image_filter.rs
+++ b/skia-safe/src/effects/merge_image_filter.rs
@@ -1,0 +1,26 @@
+use crate::prelude::*;
+use crate::{ImageFilter, ImageFilterCropRect};
+use skia_bindings::{C_SkMergeImageFilter_Make, SkImageFilter};
+use std::convert::TryInto;
+
+pub enum MergeImageFilter {}
+
+impl MergeImageFilter {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        filters: &[&ImageFilter],
+        crop_rect: CR,
+    ) -> Option<ImageFilter> {
+        let shared_filters: Vec<*const SkImageFilter> = filters
+            .iter()
+            .map(|f| f.shared_native() as *const _)
+            .collect();
+        ImageFilter::from_ptr(unsafe {
+            C_SkMergeImageFilter_Make(
+                shared_filters.as_ptr(),
+                shared_filters.len().try_into().unwrap(),
+                crop_rect.into().native_ptr_or_null(),
+            )
+        })
+    }
+}

--- a/skia-safe/src/effects/morphology_image_filter.rs
+++ b/skia-safe/src/effects/morphology_image_filter.rs
@@ -1,0 +1,43 @@
+use crate::prelude::*;
+use crate::{ImageFilter, ImageFilterCropRect};
+use skia_bindings::{C_SkDilateImageFilter_Make, C_SkErodeImageFilter_Make};
+
+pub enum DilateImageFilter {}
+
+impl DilateImageFilter {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        (radius_x, radius_y): (i32, i32),
+        input: &ImageFilter,
+        crop_rect: CR,
+    ) -> Option<ImageFilter> {
+        ImageFilter::from_ptr(unsafe {
+            C_SkDilateImageFilter_Make(
+                radius_x,
+                radius_y,
+                input.shared_native(),
+                crop_rect.into().native_ptr_or_null(),
+            )
+        })
+    }
+}
+
+pub enum ErodeImageFilter {}
+
+impl ErodeImageFilter {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        (radius_x, radius_y): (i32, i32),
+        input: &ImageFilter,
+        crop_rect: CR,
+    ) -> Option<ImageFilter> {
+        ImageFilter::from_ptr(unsafe {
+            C_SkErodeImageFilter_Make(
+                radius_x,
+                radius_y,
+                input.shared_native(),
+                crop_rect.into().native_ptr_or_null(),
+            )
+        })
+    }
+}

--- a/skia-safe/src/effects/morphology_image_filter.rs
+++ b/skia-safe/src/effects/morphology_image_filter.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::{ImageFilter, ImageFilterCropRect};
-use skia_bindings::{C_SkDilateImageFilter_Make, C_SkErodeImageFilter_Make};
+use skia_bindings::{C_SkDilateImageFilter_Make, C_SkErodeImageFilter_Make, SkImageFilter};
 
 pub enum DilateImageFilter {}
 
@@ -39,5 +39,23 @@ impl ErodeImageFilter {
                 crop_rect.into().native_ptr_or_null(),
             )
         })
+    }
+}
+
+impl RCHandle<SkImageFilter> {
+    pub fn dilate<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        &self,
+        crop_rect: CR,
+        radii: (i32, i32),
+    ) -> Option<Self> {
+        DilateImageFilter::new(radii, self, crop_rect)
+    }
+
+    pub fn erode<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        &self,
+        crop_rect: CR,
+        radii: (i32, i32),
+    ) -> Option<Self> {
+        ErodeImageFilter::new(radii, self, crop_rect)
     }
 }

--- a/skia-safe/src/effects/offset_image_filter.rs
+++ b/skia-safe/src/effects/offset_image_filter.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::{scalar, ImageFilter, ImageFilterCropRect};
-use skia_bindings::C_SkOffsetImageFilter_Make;
+use skia_bindings::{C_SkOffsetImageFilter_Make, SkImageFilter};
 
 pub enum OffsetImageFilter {}
 
@@ -19,5 +19,15 @@ impl OffsetImageFilter {
                 crop_rect.into().native_ptr_or_null(),
             )
         })
+    }
+}
+
+impl RCHandle<SkImageFilter> {
+    pub fn offset<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        &self,
+        crop_rect: CR,
+        delta: (scalar, scalar),
+    ) -> Option<Self> {
+        OffsetImageFilter::new(delta, self, crop_rect)
     }
 }

--- a/skia-safe/src/effects/offset_image_filter.rs
+++ b/skia-safe/src/effects/offset_image_filter.rs
@@ -1,20 +1,21 @@
 use crate::prelude::*;
-use crate::{scalar, ImageFilter, ImageFilterCropRect};
+use crate::{ImageFilter, ImageFilterCropRect, Vector};
 use skia_bindings::{C_SkOffsetImageFilter_Make, SkImageFilter};
 
 pub enum OffsetImageFilter {}
 
 impl OffsetImageFilter {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
-        (dx, dy): (scalar, scalar),
+    pub fn new<'a, IV: Into<Vector>, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        delta: IV,
         input: &ImageFilter,
         crop_rect: CR,
     ) -> Option<ImageFilter> {
+        let delta = delta.into();
         ImageFilter::from_ptr(unsafe {
             C_SkOffsetImageFilter_Make(
-                dx,
-                dy,
+                delta.x,
+                delta.y,
                 input.shared_native(),
                 crop_rect.into().native_ptr_or_null(),
             )
@@ -23,10 +24,10 @@ impl OffsetImageFilter {
 }
 
 impl RCHandle<SkImageFilter> {
-    pub fn offset<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
+    pub fn offset<'a, IV: Into<Vector>, CR: Into<Option<&'a ImageFilterCropRect>>>(
         &self,
         crop_rect: CR,
-        delta: (scalar, scalar),
+        delta: IV,
     ) -> Option<Self> {
         OffsetImageFilter::new(delta, self, crop_rect)
     }

--- a/skia-safe/src/effects/offset_image_filter.rs
+++ b/skia-safe/src/effects/offset_image_filter.rs
@@ -1,0 +1,23 @@
+use crate::prelude::*;
+use crate::{scalar, ImageFilter, ImageFilterCropRect};
+use skia_bindings::C_SkOffsetImageFilter_Make;
+
+pub enum OffsetImageFilter {}
+
+impl OffsetImageFilter {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        (dx, dy): (scalar, scalar),
+        input: &ImageFilter,
+        crop_rect: CR,
+    ) -> Option<ImageFilter> {
+        ImageFilter::from_ptr(unsafe {
+            C_SkOffsetImageFilter_Make(
+                dx,
+                dy,
+                input.shared_native(),
+                crop_rect.into().native_ptr_or_null(),
+            )
+        })
+    }
+}

--- a/skia-safe/src/effects/paint_image_filter.rs
+++ b/skia-safe/src/effects/paint_image_filter.rs
@@ -1,0 +1,16 @@
+use crate::prelude::*;
+use crate::{ImageFilter, ImageFilterCropRect, Paint};
+use skia_bindings::C_SkPaintImageFilter_Make;
+
+pub enum PaintImageFilter {}
+
+impl PaintImageFilter {
+    pub fn from_paint<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        paint: &Paint,
+        crop_rect: CR,
+    ) -> Option<ImageFilter> {
+        ImageFilter::from_ptr(unsafe {
+            C_SkPaintImageFilter_Make(paint.native(), crop_rect.into().native_ptr_or_null())
+        })
+    }
+}

--- a/skia-safe/src/effects/paint_image_filter.rs
+++ b/skia-safe/src/effects/paint_image_filter.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::{ImageFilter, ImageFilterCropRect, Paint};
-use skia_bindings::C_SkPaintImageFilter_Make;
+use skia_bindings::{C_SkPaintImageFilter_Make, SkImageFilter, SkPaint};
 
 pub enum PaintImageFilter {}
 
@@ -12,5 +12,23 @@ impl PaintImageFilter {
         ImageFilter::from_ptr(unsafe {
             C_SkPaintImageFilter_Make(paint.native(), crop_rect.into().native_ptr_or_null())
         })
+    }
+}
+
+impl RCHandle<SkImageFilter> {
+    pub fn from_paint<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        paint: &Paint,
+        crop_rect: CR,
+    ) -> Option<Self> {
+        PaintImageFilter::from_paint(paint, crop_rect)
+    }
+}
+
+impl Handle<SkPaint> {
+    pub fn as_image_filter<'a, CR: Into<Option<&'a ImageFilterCropRect>>>(
+        &self,
+        crop_rect: CR,
+    ) -> Option<ImageFilter> {
+        PaintImageFilter::from_paint(self, crop_rect)
     }
 }

--- a/skia-safe/src/effects/perlin_noise_shader.rs
+++ b/skia-safe/src/effects/perlin_noise_shader.rs
@@ -10,7 +10,7 @@ pub enum PerlinNoiseShader {}
 impl PerlinNoiseShader {
     pub fn fractal_noise<TS: Into<Option<ISize>>>(
         base_frequency: (scalar, scalar),
-        num_octaves: i32,
+        num_octaves: usize,
         seed: scalar,
         tile_size: TS,
     ) -> Option<Shader> {
@@ -18,7 +18,7 @@ impl PerlinNoiseShader {
             C_SkPerlinNoiseShader_MakeFractalNoise(
                 base_frequency.0,
                 base_frequency.1,
-                num_octaves,
+                num_octaves.try_into().unwrap(),
                 seed,
                 tile_size.into().native().as_ptr_or_null(),
             )
@@ -27,7 +27,7 @@ impl PerlinNoiseShader {
 
     pub fn turbulence<TS: Into<Option<ISize>>>(
         base_frequency: (scalar, scalar),
-        num_octaves: i32,
+        num_octaves: usize,
         seed: scalar,
         tile_size: TS,
     ) -> Option<Shader> {
@@ -35,7 +35,7 @@ impl PerlinNoiseShader {
             C_SkPerlinNoiseShader_MakeTurbulence(
                 base_frequency.0,
                 base_frequency.1,
-                num_octaves,
+                num_octaves.try_into().unwrap(),
                 seed,
                 tile_size.into().native().as_ptr_or_null(),
             )
@@ -44,14 +44,14 @@ impl PerlinNoiseShader {
 
     pub fn improved_noise(
         base_frequency: (scalar, scalar),
-        num_octaves: i32,
+        num_octaves: usize,
         z: scalar,
     ) -> Option<Shader> {
         Shader::from_ptr(unsafe {
             C_SkPerlinNoiseShader_MakeImprovedNoise(
                 base_frequency.0,
                 base_frequency.1,
-                num_octaves,
+                num_octaves.try_into().unwrap(),
                 z,
             )
         })
@@ -61,7 +61,7 @@ impl PerlinNoiseShader {
 impl RCHandle<SkShader> {
     pub fn fractal_perlin_noise<TS: Into<Option<ISize>>>(
         base_frequency: (scalar, scalar),
-        num_octaves: i32,
+        num_octaves: usize,
         seed: scalar,
         tile_size: TS,
     ) -> Option<Self> {
@@ -70,7 +70,7 @@ impl RCHandle<SkShader> {
 
     pub fn turbulence_perlin_noise<TS: Into<Option<ISize>>>(
         base_frequency: (scalar, scalar),
-        num_octaves: i32,
+        num_octaves: usize,
         seed: scalar,
         tile_size: TS,
     ) -> Option<Self> {
@@ -79,7 +79,7 @@ impl RCHandle<SkShader> {
 
     pub fn improved_perlin_noise(
         base_frequency: (scalar, scalar),
-        num_octaves: i32,
+        num_octaves: usize,
         z: scalar,
     ) -> Option<Self> {
         PerlinNoiseShader::improved_noise(base_frequency, num_octaves, z)

--- a/skia-safe/src/effects/perlin_noise_shader.rs
+++ b/skia-safe/src/effects/perlin_noise_shader.rs
@@ -2,7 +2,7 @@ use crate::core::{scalar, ISize, Shader};
 use crate::prelude::*;
 use skia_bindings::{
     C_SkPerlinNoiseShader_MakeFractalNoise, C_SkPerlinNoiseShader_MakeImprovedNoise,
-    C_SkPerlinNoiseShader_MakeTurbulence,
+    C_SkPerlinNoiseShader_MakeTurbulence, SkShader,
 };
 
 pub enum PerlinNoiseShader {}
@@ -55,5 +55,33 @@ impl PerlinNoiseShader {
                 z,
             )
         })
+    }
+}
+
+impl RCHandle<SkShader> {
+    pub fn fractal_perlin_noise<TS: Into<Option<ISize>>>(
+        base_frequency: (scalar, scalar),
+        num_octaves: i32,
+        seed: scalar,
+        tile_size: TS,
+    ) -> Option<Self> {
+        PerlinNoiseShader::fractal_noise(base_frequency, num_octaves, seed, tile_size)
+    }
+
+    pub fn turbulence_perlin_noise<TS: Into<Option<ISize>>>(
+        base_frequency: (scalar, scalar),
+        num_octaves: i32,
+        seed: scalar,
+        tile_size: TS,
+    ) -> Option<Self> {
+        PerlinNoiseShader::turbulence(base_frequency, num, seed, tile_size)
+    }
+
+    pub fn improved_perlin_noise(
+        base_frequency: (scalar, scalar),
+        num_octaves: i32,
+        z: scalar,
+    ) -> Option<Self> {
+        PerlinNoiseShader::improved_noise(base_frequency, num_octaves, z)
     }
 }

--- a/skia-safe/src/effects/perlin_noise_shader.rs
+++ b/skia-safe/src/effects/perlin_noise_shader.rs
@@ -74,7 +74,7 @@ impl RCHandle<SkShader> {
         seed: scalar,
         tile_size: TS,
     ) -> Option<Self> {
-        PerlinNoiseShader::turbulence(base_frequency, num, seed, tile_size)
+        PerlinNoiseShader::turbulence(base_frequency, num_octaves, seed, tile_size)
     }
 
     pub fn improved_perlin_noise(

--- a/skia-safe/src/effects/picture_image_filter.rs
+++ b/skia-safe/src/effects/picture_image_filter.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::{ImageFilter, Picture, Rect};
-use skia_bindings::C_SkPictureImageFilter_Make;
+use skia_bindings::{C_SkPictureImageFilter_Make, SkImageFilter, SkPicture};
 
 pub enum PictureImageFilter {}
 
@@ -12,8 +12,26 @@ impl PictureImageFilter {
         ImageFilter::from_ptr(unsafe {
             C_SkPictureImageFilter_Make(
                 picture.shared_native(),
-                crop_rect.into().native_ptr_or_null()
+                crop_rect.into().native_ptr_or_null(),
             )
         })
+    }
+}
+
+impl RCHandle<SkImageFilter> {
+    pub fn from_picture<'a, CR: Into<Option<&'a Rect>>>(
+        picture: &Picture,
+        crop_rect: CR,
+    ) -> Option<Self> {
+        PictureImageFilter::from_picture(picture, crop_rect)
+    }
+}
+
+impl RCHandle<SkPicture> {
+    pub fn as_image_filter<'a, CR: Into<Option<&'a Rect>>>(
+        &self,
+        crop_rect: CR,
+    ) -> Option<ImageFilter> {
+        PictureImageFilter::from_picture(self, crop_rect)
     }
 }

--- a/skia-safe/src/effects/picture_image_filter.rs
+++ b/skia-safe/src/effects/picture_image_filter.rs
@@ -1,0 +1,19 @@
+use crate::prelude::*;
+use crate::{ImageFilter, Picture, Rect};
+use skia_bindings::C_SkPictureImageFilter_Make;
+
+pub enum PictureImageFilter {}
+
+impl PictureImageFilter {
+    pub fn from_picture<'a, CR: Into<Option<&Rect>>>(
+        picture: &Picture,
+        crop_rect: CR,
+    ) -> Option<ImageFilter> {
+        ImageFilter::from_ptr(unsafe {
+            C_SkPictureImageFilter_Make(
+                picture.shared_native(),
+                crop_rect.into().native_ptr_or_null()
+            )
+        })
+    }
+}

--- a/skia-safe/src/effects/picture_image_filter.rs
+++ b/skia-safe/src/effects/picture_image_filter.rs
@@ -5,7 +5,7 @@ use skia_bindings::C_SkPictureImageFilter_Make;
 pub enum PictureImageFilter {}
 
 impl PictureImageFilter {
-    pub fn from_picture<'a, CR: Into<Option<&Rect>>>(
+    pub fn from_picture<'a, CR: Into<Option<&'a Rect>>>(
         picture: &Picture,
         crop_rect: CR,
     ) -> Option<ImageFilter> {

--- a/skia-safe/src/effects/table_color_filter.rs
+++ b/skia-safe/src/effects/table_color_filter.rs
@@ -1,6 +1,6 @@
-use crate::core::ColorFilter;
 use crate::prelude::*;
-use skia_bindings::{C_SkTableColorFilter_Make, C_SkTableColorFilter_MakeARGB};
+use crate::ColorFilter;
+use skia_bindings::{C_SkTableColorFilter_Make, C_SkTableColorFilter_MakeARGB, SkColorFilter};
 
 pub enum TableColorFilter {}
 
@@ -25,5 +25,20 @@ impl TableColorFilter {
             )
         })
         .unwrap()
+    }
+}
+
+impl RCHandle<SkColorFilter> {
+    pub fn from_table(table: &[u8; 256]) -> Self {
+        TableColorFilter::from_table(table)
+    }
+
+    pub fn from_argb(
+        table_a: Option<&[u8; 256]>,
+        table_r: Option<&[u8; 256]>,
+        table_g: Option<&[u8; 256]>,
+        table_b: Option<&[u8; 256]>,
+    ) -> Self {
+        TableColorFilter::from_argb(table_a, table_r, table_g, table_b)
     }
 }

--- a/skia-safe/src/effects/tile_image_filter.rs
+++ b/skia-safe/src/effects/tile_image_filter.rs
@@ -1,0 +1,22 @@
+use crate::prelude::*;
+use crate::{ImageFilter, Rect};
+use skia_bindings::C_SkTileImageFilter_Make;
+
+pub enum TileImageFilter {}
+
+impl TileImageFilter {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new<SR: AsRef<Rect>, DR: AsRef<Rect>>(
+        src: SR,
+        dst: DR,
+        input: &ImageFilter,
+    ) -> Option<ImageFilter> {
+        ImageFilter::from_ptr(unsafe {
+            C_SkTileImageFilter_Make(
+                src.as_ref().native(),
+                dst.as_ref().native(),
+                input.shared_native(),
+            )
+        })
+    }
+}

--- a/skia-safe/src/effects/tile_image_filter.rs
+++ b/skia-safe/src/effects/tile_image_filter.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::{ImageFilter, Rect};
-use skia_bindings::C_SkTileImageFilter_Make;
+use skia_bindings::{C_SkTileImageFilter_Make, SkImageFilter};
 
 pub enum TileImageFilter {}
 
@@ -18,5 +18,11 @@ impl TileImageFilter {
                 input.shared_native(),
             )
         })
+    }
+}
+
+impl RCHandle<SkImageFilter> {
+    pub fn tile<SR: AsRef<Rect>, DR: AsRef<Rect>>(&self, src: SR, dst: DR) -> Option<Self> {
+        TileImageFilter::new(src, dst, self)
     }
 }

--- a/skia-safe/src/effects/xfer_mode_image_filter.rs
+++ b/skia-safe/src/effects/xfer_mode_image_filter.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::{BlendMode, ImageFilter, ImageFilterCropRect};
-use skia_bindings::C_SkXfermodeImageFilter_Make;
+use skia_bindings::{C_SkXfermodeImageFilter_Make, SkImageFilter};
 
 pub enum XferModeImageFilter {}
 
@@ -20,5 +20,16 @@ impl XferModeImageFilter {
                 crop_rect.into().native_ptr_or_null(),
             )
         })
+    }
+}
+
+impl RCHandle<SkImageFilter> {
+    pub fn xfer_mode<'a, CR: Into<Option<&'a ImageFilterCropRect>>, FI: Into<Option<&'a ImageFilter>>>(
+        blend_mode: BlendMode,
+        background: &ImageFilter,
+        foreground: FI,
+        crop_rect: CR,
+    ) -> Option<Self> {
+        XferModeImageFilter::new(blend_mode, background, foreground, crop_rect)
     }
 }

--- a/skia-safe/src/effects/xfer_mode_image_filter.rs
+++ b/skia-safe/src/effects/xfer_mode_image_filter.rs
@@ -1,0 +1,24 @@
+use crate::prelude::*;
+use crate::{BlendMode, ImageFilter, ImageFilterCropRect};
+use skia_bindings::C_SkXfermodeImageFilter_Make;
+
+pub enum XferModeImageFilter {}
+
+impl XferModeImageFilter {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new<'a, CR: Into<Option<&'a ImageFilterCropRect>>, FI: Into<Option<&'a ImageFilter>>>(
+        blend_mode: BlendMode,
+        background: &ImageFilter,
+        foreground: FI,
+        crop_rect: CR,
+    ) -> Option<ImageFilter> {
+        ImageFilter::from_ptr(unsafe {
+            C_SkXfermodeImageFilter_Make(
+                blend_mode.into_native(),
+                background.shared_native(),
+                foreground.into().shared_ptr(),
+                crop_rect.into().native_ptr_or_null(),
+            )
+        })
+    }
+}

--- a/skia-safe/src/prelude.rs
+++ b/skia-safe/src/prelude.rs
@@ -367,16 +367,22 @@ impl<N: NativeRefCounted> RCHandle<N> {
     /// and returns a reference to it.
     #[inline]
     pub fn shared_native(&self) -> &N {
-        (unsafe { &*self.0 })._ref();
-        unsafe { &mut *self.0 }
+        unsafe {
+            let r = &*self.0;
+            r._ref();
+            r
+        }
     }
 
     /// Increases the reference counter of the native type
     /// and returns a reference to it.
     #[inline]
     pub fn shared_native_mut(&mut self) -> &mut N {
-        (unsafe { &*self.0 })._ref();
-        unsafe { &mut *self.0 }
+        unsafe {
+            let r = &mut *self.0;
+            r._ref();
+            r
+        }
     }
 
     /// Creates an RCHandle from a pointer.


### PR DESCRIPTION
- [x] Complete wrapper for SkImageFilter
- [x] SkAlphaThresholdFilter
- [x] SkArithmeticImageFilter
- [x] SkBlurImageFilter
- [x] SkColorFilterImageFilter
- [x] SkComposeImageFilter
- [x] SkDisplacementMapEffect
- [x] SkDropShadowImageFilter
- [x] SkImageSource
- [x] SkLightingImageFilter
- [x] SkMagnifierImageFilter
- [x] SkMatrixConvultionImageFilter
- [x] SkMergeImageFilter
- [x] SkMorphologyImageFilter
  - [x] SkDilateImageFilter
  - [x] SkErodeImageFilter
- [x] SkOffsetImageFilter
- [x] SkPaintImageFilter
- [x] SkPictureImageFilter
- [x] SkTileImageFilter
- [x] SkXfermodeImageFilter

