### PR TITLE
Fix color type names

### DIFF
--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skia-safe"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 

--- a/skia-safe/src/core/image_info.rs
+++ b/skia-safe/src/core/image_info.rs
@@ -40,11 +40,11 @@ pub enum ColorType {
     ARGB4444 = SkColorType::kARGB_4444_SkColorType as _,
     RGBA8888 = SkColorType::kRGBA_8888_SkColorType as _,
     RGB888x = SkColorType::kRGB_888x_SkColorType as _,
-    BRGA8888 = SkColorType::kBGRA_8888_SkColorType as _,
+    BGRA8888 = SkColorType::kBGRA_8888_SkColorType as _,
     RGBA1010102 = SkColorType::kRGBA_1010102_SkColorType as _,
     RGB101010x = SkColorType::kRGB_101010x_SkColorType as _,
     Gray8 = SkColorType::kGray_8_SkColorType as _,
-    F16Norm = SkColorType::kRGBA_F16Norm_SkColorType as _,
+    RGBAF16Norm = SkColorType::kRGBA_F16Norm_SkColorType as _,
     RGBAF16 = SkColorType::kRGBA_F16_SkColorType as _,
     RGBAF32 = SkColorType::kRGBA_F32_SkColorType as _,
 }


### PR DESCRIPTION
`BRGA8888` was just wrong causing some colored confusion, and while reviewing I noticed that the `RGBA` prefix was missing in Rust.