### PR TITLE
LLVM 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,13 @@ This project attempts to provide _up to date_ safe bindings that bridge idiomati
 
 Note that the information in this section is preliminary. Please open an issue for any build problem.
 
+### Prerequisites
+
 This project requires LLVM, Python 2, and git to build.
 
-To test if LLVM is installed with the correct version, use `clang --version`. Currently, version 8 is recommended, and at least 7 needs to be available, or - on macOS X - Apple LLVM version 10 should do, too.
+To see which version of LLVM/Clang is available, use `clang --version`. 
+
+We recommend version 8, but also had successes to build Skia with 6.0.1 and 7.0.1, and - on macOS - Apple LLVM version 10. So it's probably best to use the preinstalled version or install version 8 if LLVM is not available on your platform by default.
 
 For Python, at least version 2.7 _should_ be available! Use `python --version` to see what's there.
 
@@ -36,7 +40,7 @@ For Python, at least version 2.7 _should_ be available! Use `python --version` t
 
   otherwise the Skia build _may_ fail to build `SkJpegUtility.cpp` and the binding generation _will_ fail with  `'TargetConditionals.h' file not found` . Also note that the command line developer tools _and_ SDK headers _should_ be reinstalled after an update of XCode.
 
-- As an alternative to Apple LLVM 10, install LLVM 8 or 7 via `brew install llvm` or `brew install llvm@7` and then set `PATH`, `CPPFLAGS`, and `LDFLAGS` like instructed.
+- As an alternative to Apple LLVM 10, install LLVM via `brew install llvm` or `brew install llvm@7` and then set `PATH`, `CPPFLAGS`, and `LDFLAGS` like instructed.
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Note that the information in this section is preliminary. Please open an issue f
 
 This project requires LLVM, Python 2, and git to build.
 
-To test if LLVM is installed with the correct version, use `clang --version`. Currently, version 7.0.1 is required, or - on macOS X - Apple LLVM version 10 should do, too.
+To test if LLVM is installed with the correct version, use `clang --version`. Currently, version 8 is recommended, and at least 7 needs to be available, or - on macOS X - Apple LLVM version 10 should do, too.
 
 For Python, at least version 2.7 _should_ be available! Use `python --version` to see what's there.
 
@@ -36,12 +36,12 @@ For Python, at least version 2.7 _should_ be available! Use `python --version` t
 
   otherwise the Skia build _may_ fail to build `SkJpegUtility.cpp` and the binding generation _will_ fail with  `'TargetConditionals.h' file not found` . Also note that the command line developer tools _and_ SDK headers _should_ be reinstalled after an update of XCode.
 
-- As an alternative to Apple LLVM 10, install LLVM 7.0.1 via `brew install llvm@7` and then set `PATH`, `CPPFLAGS`, and `LDFLAGS` like instructed.
+- As an alternative to Apple LLVM 10, install LLVM 8 or 7 via `brew install llvm` or `brew install llvm@7` and then set `PATH`, `CPPFLAGS`, and `LDFLAGS` like instructed.
 
 ### Windows
 
 - Be sure the `git` command line tool is installed.
-- Install the [official LLVM 7.0.1](http://releases.llvm.org/download.html) distribution.
+- Install the [official LLVM 8](http://releases.llvm.org/download.html) distribution.
 - msys:
   - Install one of the Python2 packages, for example `mingw-w64-x86_64-python2`.
   - LLVM is _always_ picked up from `C:/Program Files/LLVM`, so be sure it's available from there.
@@ -50,7 +50,7 @@ For Python, at least version 2.7 _should_ be available! Use `python --version` t
 
 ### Linux
 
-- LLVM should be installed out of the box, if not, install version 7.0.1.
+- LLVM should be installed out of the box, if not, install version 8.
 
 Then use:
 

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -61,10 +61,10 @@ jobs:
     displayName: Rust & Cargo Versions
 
   - ${{ if ne(parameters.platform, 'Windows') }}:
-      # Linux and macOS.
-      - script: |
-          clang --version
-        displayName: LLVM/Clang Version
+    # Linux and macOS.
+    - script: |
+        clang --version
+      displayName: LLVM/Clang Version
 
   - ${{ if eq(parameters.platform, 'Windows') }}:
     # Windows.

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -35,7 +35,6 @@ jobs:
     # macOS
     - script: |
         sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
-        brew update && brew install llvm@7
       displayName: Install SDK Headers & LLVM
 
   - ${{ if ne(parameters.platform, 'Windows') }}:
@@ -52,7 +51,7 @@ jobs:
         rustup-init.exe -y --default-toolchain %TOOLCHAIN%
         set PATH=%PATH%;%USERPROFILE%\.cargo\bin
         echo "##vso[task.setvariable variable=PATH;]%PATH%;%USERPROFILE%\.cargo\bin"
-        choco install llvm --version 7.0.1
+        choco install llvm --version 8.0.0
       displayName: Install Rust on Windows
 
   # All platforms.

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -35,7 +35,7 @@ jobs:
     # macOS
     - script: |
         sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
-      displayName: Install SDK Headers & LLVM
+      displayName: Install SDK Headers
 
   - ${{ if ne(parameters.platform, 'Windows') }}:
     # Linux and macOS.
@@ -52,13 +52,25 @@ jobs:
         set PATH=%PATH%;%USERPROFILE%\.cargo\bin
         echo "##vso[task.setvariable variable=PATH;]%PATH%;%USERPROFILE%\.cargo\bin"
         choco install llvm --version 8.0.0
-      displayName: Install Rust on Windows
+      displayName: Install Rust and LLVM on Windows
 
   # All platforms.
   - script: |
         rustc -Vv
         cargo -V
-    displayName: Print versions
+    displayName: Rust & Cargo Versions
+
+  - ${{ if ne(parameters.platform, 'Windows') }}:
+      # Linux and macOS.
+      - script: |
+          clang --version
+        displayName: LLVM/Clang Version
+
+  - ${{ if eq(parameters.platform, 'Windows') }}:
+    # Windows.
+    - script: |
+        "C:/Program Files/LLVM/bin/clang.exe" --version
+      displayName: LLVM/Clang Version
 
   # Note: features are ignored when set in the workspace. This is a known bug in cargo (#5015), so cd into skia-safe instead.
   - bash: |

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -427,7 +427,9 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
         .whitelist_var("kAll_GrBackendState")
         //
         .use_core()
-        .clang_arg("-std=c++14");
+        .clang_arg("-std=c++14")
+        // required for macOS LLVM 8 to pick up C++ headers:
+        .clang_args(&["-x", "c++"]);
 
     let mut cc_build = Build::new();
 


### PR DESCRIPTION
The Azure Linux and macOS images seem to have LLVM 8 preinstalled and recent builds went fine. So I think we can remove the additional installation steps and recommend LLVM 8 in the readme ([rendered](https://github.com/rust-skia/rust-skia/blob/llvm-8/README.md)).

**Update**: No, Ubuntu builds with 6.0.1 and macOS with Apple LLVM 10. I was confused because of the version output of rustc which prints the LLVM version itself was built with, so I've added the output of `clang --version` as a pipelines step to this PR.

Closes #65 