### PR TITLE
Improve the conversion of font_style::Weight and font_style::Width from and to i32.

### DIFF
--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/rust-skia/rust-skia"
 repository = "https://github.com/rust-skia/rust-skia"
 license = "MIT"
 
-version = "0.12.1"
+version = "0.12.2"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 

--- a/skia-safe/src/core/font_style.rs
+++ b/skia-safe/src/core/font_style.rs
@@ -36,17 +36,40 @@ impl Deref for Weight {
 
 #[allow(non_upper_case_globals)]
 impl Weight {
+    #[deprecated(note = "use INVISIBLE")]
     pub const Invisible: Self = Self(SkFontStyle_Weight::kInvisible_Weight as _);
+    #[deprecated(note = "use THIN")]
     pub const Thin: Self = Self(SkFontStyle_Weight::kThin_Weight as _);
+    #[deprecated(note = "use EXTRA_LIGHT")]
     pub const ExtraLight: Self = Self(SkFontStyle_Weight::kExtraLight_Weight as _);
+    #[deprecated(note = "use LIGHT")]
     pub const Light: Self = Self(SkFontStyle_Weight::kLight_Weight as _);
+    #[deprecated(note = "use NORMAL")]
     pub const Normal: Self = Self(SkFontStyle_Weight::kNormal_Weight as _);
+    #[deprecated(note = "use MEDIUM")]
     pub const Medium: Self = Self(SkFontStyle_Weight::kMedium_Weight as _);
+    #[deprecated(note = "use SEMI_BOLD")]
     pub const SemiBold: Self = Self(SkFontStyle_Weight::kSemiBold_Weight as _);
+    #[deprecated(note = "use BOLD")]
     pub const Bold: Self = Self(SkFontStyle_Weight::kBold_Weight as _);
+    #[deprecated(note = "use EXTRA_BOLD")]
     pub const ExtraBold: Self = Self(SkFontStyle_Weight::kExtraBold_Weight as _);
+    #[deprecated(note = "use BLACK")]
     pub const Black: Self = Self(SkFontStyle_Weight::kBlack_Weight as _);
+    #[deprecated(note = "use EXTRA_BLACK")]
     pub const ExtraBlack: Self = Self(SkFontStyle_Weight::kExtraBlack_Weight as _);
+
+    pub const INVISIBLE: Self = Self(SkFontStyle_Weight::kInvisible_Weight as _);
+    pub const THIN: Self = Self(SkFontStyle_Weight::kThin_Weight as _);
+    pub const EXTRA_LIGHT: Self = Self(SkFontStyle_Weight::kExtraLight_Weight as _);
+    pub const LIGHT: Self = Self(SkFontStyle_Weight::kLight_Weight as _);
+    pub const NORMAL: Self = Self(SkFontStyle_Weight::kNormal_Weight as _);
+    pub const MEDIUM: Self = Self(SkFontStyle_Weight::kMedium_Weight as _);
+    pub const SEMI_BOLD: Self = Self(SkFontStyle_Weight::kSemiBold_Weight as _);
+    pub const BOLD: Self = Self(SkFontStyle_Weight::kBold_Weight as _);
+    pub const EXTRA_BOLD: Self = Self(SkFontStyle_Weight::kExtraBold_Weight as _);
+    pub const BLACK: Self = Self(SkFontStyle_Weight::kBlack_Weight as _);
+    pub const EXTRA_BLACK: Self = Self(SkFontStyle_Weight::kExtraBlack_Weight as _);
 }
 
 /// Wrapper type for the width of a font.
@@ -79,15 +102,34 @@ impl Deref for Width {
 
 #[allow(non_upper_case_globals)]
 impl Width {
+    #[deprecated(note = "use ULTRA_CONDENSED")]
     pub const UltraCondensed: Self = Self(SkFontStyle_Width::kUltraCondensed_Width as _);
+    #[deprecated(note = "use EXTRA_CONDENSED")]
     pub const ExtraCondensed: Self = Self(SkFontStyle_Width::kExtraCondensed_Width as _);
+    #[deprecated(note = "use CONDENSED")]
     pub const Condensed: Self = Self(SkFontStyle_Width::kCondensed_Width as _);
+    #[deprecated(note = "use SEMI_CONDENSED")]
     pub const SemiCondensed: Self = Self(SkFontStyle_Width::kSemiCondensed_Width as _);
+    #[deprecated(note = "use NORMAL")]
     pub const Normal: Self = Self(SkFontStyle_Width::kNormal_Width as _);
+    #[deprecated(note = "use SEMI_EXPANDED")]
     pub const SemiExpanded: Self = Self(SkFontStyle_Width::kSemiExpanded_Width as _);
+    #[deprecated(note = "use EXPANDED")]
     pub const Expanded: Self = Self(SkFontStyle_Width::kExpanded_Width as _);
+    #[deprecated(note = "use EXTRA_EXPANDED")]
     pub const ExtraExpanded: Self = Self(SkFontStyle_Width::kExtraExpanded_Width as _);
+    #[deprecated(note = "use ULTRA_EXPANDED")]
     pub const UltraExpanded: Self = Self(SkFontStyle_Width::kUltraExpanded_Width as _);
+
+    pub const ULTRA_CONDENSED: Self = Self(SkFontStyle_Width::kUltraCondensed_Width as _);
+    pub const EXTRA_CONDENSED: Self = Self(SkFontStyle_Width::kExtraCondensed_Width as _);
+    pub const CONDENSED: Self = Self(SkFontStyle_Width::kCondensed_Width as _);
+    pub const SEMI_CONDENSED: Self = Self(SkFontStyle_Width::kSemiCondensed_Width as _);
+    pub const NORMAL: Self = Self(SkFontStyle_Width::kNormal_Width as _);
+    pub const SEMI_EXPANDED: Self = Self(SkFontStyle_Width::kSemiExpanded_Width as _);
+    pub const EXPANDED: Self = Self(SkFontStyle_Width::kExpanded_Width as _);
+    pub const EXTRA_EXPANDED: Self = Self(SkFontStyle_Width::kExtraExpanded_Width as _);
+    pub const ULTRA_EXPANDED: Self = Self(SkFontStyle_Width::kUltraExpanded_Width as _);
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -175,13 +217,13 @@ mod font_style_static {
 
     lazy_static! {
         pub static ref NORMAL: FontStyle =
-            FontStyle::new(Weight::Normal, Width::Normal, Slant::Upright);
+            FontStyle::new(Weight::NORMAL, Width::NORMAL, Slant::Upright);
         pub static ref BOLD: FontStyle =
-            FontStyle::new(Weight::Bold, Width::Normal, Slant::Upright);
+            FontStyle::new(Weight::BOLD, Width::NORMAL, Slant::Upright);
         pub static ref ITALIC: FontStyle =
-            FontStyle::new(Weight::Normal, Width::Normal, Slant::Italic);
+            FontStyle::new(Weight::NORMAL, Width::NORMAL, Slant::Italic);
         pub static ref BOLD_ITALIC: FontStyle =
-            FontStyle::new(Weight::Bold, Width::Normal, Slant::Italic);
+            FontStyle::new(Weight::BOLD, Width::NORMAL, Slant::Italic);
     }
 }
 

--- a/skia-safe/src/core/font_style.rs
+++ b/skia-safe/src/core/font_style.rs
@@ -4,9 +4,14 @@ use skia_bindings::{
     SkFontStyle_Weight, SkFontStyle_Width,
 };
 use std::mem;
+use std::ops::Deref;
 
-#[repr(transparent)]
+/// Wrapper type of a font weight.
+///
+/// Use Weight::from() to create a weight from an i32.
+/// Use *weight to pull out the wrapped value of the Weight.
 #[derive(Copy, Clone, PartialEq, PartialOrd)]
+#[repr(transparent)]
 pub struct Weight(i32);
 
 impl NativeTransmutable<i32> for Weight {}
@@ -14,6 +19,19 @@ impl NativeTransmutable<i32> for Weight {}
 #[test]
 fn test_weight_layout() {
     Weight::test_layout()
+}
+
+impl From<i32> for Weight {
+    fn from(weight: i32) -> Self {
+        Weight(weight)
+    }
+}
+
+impl Deref for Weight {
+    type Target = i32;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 #[allow(non_upper_case_globals)]
@@ -31,8 +49,12 @@ impl Weight {
     pub const ExtraBlack: Self = Self(SkFontStyle_Weight::kExtraBlack_Weight as _);
 }
 
-#[repr(transparent)]
+/// Wrapper type for the width of a font.
+///
+/// To create a width of a font from an i32, use Width::from().
+/// To access the underlying value of the font weight, dereference *weight.
 #[derive(Copy, Clone, PartialEq, PartialOrd)]
+#[repr(transparent)]
 pub struct Width(i32);
 
 impl NativeTransmutable<i32> for Width {}
@@ -40,6 +62,19 @@ impl NativeTransmutable<i32> for Width {}
 #[test]
 fn test_width_layout() {
     Width::test_layout()
+}
+
+impl From<i32> for Width {
+    fn from(width: i32) -> Self {
+        Width(width)
+    }
+}
+
+impl Deref for Width {
+    type Target = i32;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 #[allow(non_upper_case_globals)]


### PR DESCRIPTION
Just noticed that it wasn't possible to create a `font_style::Weight` and `font_style::Width` from an integer without going through some nasty indirection with `::from_native()`. 

This PR adds a implementations of `From<i32>` and a `Deref` making the interopability somewhat less dramatic which is useful for interfacing with code that uses the same weight constants.

In addition to that, I've renamed the related constants to uppercase so that these types don't look like disguised enums.