### PR TITLE
Resolve all preprocessor definitions from the skia generated ninja files

### DIFF
--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/rust-skia/rust-skia"
 repository = "https://github.com/rust-skia/rust-skia"
 license = "MIT"
 
-version = "0.12.1"
+version = "0.12.3"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -632,7 +632,7 @@ pub(crate) mod definitions {
 
     /// A preprocessor definition.
     pub type Definition = (String, Option<String>);
-    /// A contianer for a number fo preprocessor definitions.
+    /// A container for a number of preprocessor definitions.
     pub type Definitions = Vec<Definition>;
 
     /// Parse a defines = line from a ninja build file.

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/rust-skia/rust-skia"
 repository = "https://github.com/rust-skia/rust-skia"
 license = "MIT"
 
-version = "0.12.2"
+version = "0.12.3"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -18,7 +18,7 @@ svg = ["skia-bindings/svg"]
 
 [dependencies]
 bitflags = "1.0.4"
-skia-bindings = { version = "0.12.1", path = "../skia-bindings" }
+skia-bindings = { version = "0.12.3", path = "../skia-bindings" }
 lazy_static = "1.3.0"
 
 [dev-dependencies]


### PR DESCRIPTION
This PR resolves all preprocessor defines for compiling `skia-bindings/src/bindings.cpp` and for the generation of `bindings.rs` directly from what the skia configuration tool gn generates.

Related to #124.