### PR TITLE
Support to build Skia with VS2019 only.

### DIFF
--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/rust-skia/rust-skia"
 repository = "https://github.com/rust-skia/rust-skia"
 license = "MIT"
 
-version = "0.12.3"
+version = "0.12.4"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"

--- a/skia-bindings/build_support.rs
+++ b/skia-bindings/build_support.rs
@@ -5,3 +5,4 @@ pub mod binaries;
 pub mod cargo;
 pub mod git;
 pub mod skia;
+pub mod vs;

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -1,6 +1,6 @@
 //! Full build support for the Skia library, SkiaBindings library and bindings.rs file.
 
-use crate::build_support::cargo;
+use crate::build_support::{cargo, vs};
 use bindgen::EnumVariation;
 use cc::Build;
 use std::env;
@@ -168,6 +168,17 @@ impl FinalBuildConfiguration {
                 // Tell Skia's build system where LLVM is supposed to be located.
                 // TODO: this should be checked as a prerequisite.
                 args.push(("clang_win", quote("C:/Program Files/LLVM")));
+            }
+
+            // target specific gn args.
+
+            match cargo::target().as_strs() {
+                (_, _, "windows", Some("msvc")) => {
+                    if let Some(win_vc) = vs::resolve_win_vc() {
+                        args.push(("win_vc", quote(win_vc.to_str().unwrap())))
+                    }
+                }
+                _ => {}
             }
 
             if build.keep_inline_functions {

--- a/skia-bindings/build_support/vs.rs
+++ b/skia-bindings/build_support/vs.rs
@@ -1,0 +1,16 @@
+//! Additional VS detection support for Skia.
+//! TODO: sophisticate this: https://github.com/alexcrichton/cc-rs/blob/master/src/windows_registry.rs
+
+use std::path::PathBuf;
+
+pub fn resolve_win_vc() -> Option<PathBuf> {
+    [
+        "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC",
+        "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Professional\\VC",
+        "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC",
+        "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\VC",
+    ]
+    .into_iter()
+    .map(|s| PathBuf::from(s))
+    .find(|pb| pb.exists())
+}

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/rust-skia/rust-skia"
 repository = "https://github.com/rust-skia/rust-skia"
 license = "MIT"
 
-version = "0.12.3"
+version = "0.12.4"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -18,7 +18,7 @@ svg = ["skia-bindings/svg"]
 
 [dependencies]
 bitflags = "1.0.4"
-skia-bindings = { version = "0.12.3", path = "../skia-bindings" }
+skia-bindings = { version = "0.12.4", path = "../skia-bindings" }
 lazy_static = "1.3.0"
 
 [dev-dependencies]


### PR DESCRIPTION
This PR sets the gn arg `win_vc` when a Visual Studio 2019 instance is found in one of the default installation paths and so makes it possible to build rust-skia on Windows Systems where only VS2019 is installed.