### PR TITLE
Add Android support

### DIFF
--- a/skia-bindings/build_support.rs
+++ b/skia-bindings/build_support.rs
@@ -1,5 +1,6 @@
 //! Build support functions for the Rust-Skia library.
 
+pub mod android;
 pub mod azure;
 pub mod binaries;
 pub mod cargo;

--- a/skia-bindings/build_support/android.rs
+++ b/skia-bindings/build_support/android.rs
@@ -1,0 +1,5 @@
+use std::env;
+
+pub fn ndk() -> String {
+    env::var("ANDROID_NDK").expect("ANDROID_NDK variable not set")
+}


### PR DESCRIPTION
Hi! I've added minimal support of **Android** platform :tada:
And tested! It works for my `aarch64` with r18b Android NDK. To use it you have to:

1. Download r18b NDK here: https://developer.android.com/ndk/downloads/older_releases.html
2. Create toolchain for compilation: `build/tools/make_standalone_toolchain.py --arch arm64 --install-dir /tmp/ndk`
3. Set `ANDROID_NDK` to r18b folder for `skia` and `bindgen`
4. Compile your code for `aarch64-linux-android` target with:

```
ANDROID_NDK=~/path/to/android-ndk-r18b PATH=$PATH:/tmp/ndk/bin cargo build --target aarch64-linux-android
```


_Notes:_

- It doesn't work for the latest 19 NDK, because Skia doesn't support it yet.
- This PR doesn't cover all cases, but it's the first step toward that.