### PR TITLE
CI: Disable package verification of skia-bindings

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,9 +43,16 @@ stages:
         cargo -V
       displayName: 'Print versions'
 
+    # skia-bindings gets packaged without verification, because the build process modifies the src directory.
+    # TODO: reenable package verification as soon CLion and rust-analyzer supports !include macros.
     - bash: |
         set -e
-        cd skia-bindings && cargo package -vv --target-dir "$(Build.ArtifactStagingDirectory)"
+        (cd skia-bindings && cargo package -vv --no-verify --target-dir /tmp/)
+        mkdir -p "$(Build.ArtifactStagingDirectory)/package/"
+        cp /tmp/package/skia-bindings-*.crate "$(Build.ArtifactStagingDirectory)/package/"
+        # pseudo-verification:
+        (cd /tmp/package && tar xzf skia-bindings-*.crate && rm skia-bindings-*.crate)
+        (cd /tmp/package/skia-bindings-* && cargo build -vv --release)
       displayName: 'Package and Verify skia-bindings'
 
     # TODO: why does this fail with


### PR DESCRIPTION
The current master fails to verify the skia-bindings package with 
```
Source directory was modified by build.rs during cargo publish. Build scripts should not modify anything outside of OUT_DIR.
```

This PR removes the verification and then unpacks and builds the package afterwards to test the binary downloading mechanism.

The cause of the failure is because the `bindings.rs` file is written into the `src/` directory to support code completion. I consider this absolutely necessary, which means that the packages cannot be verified until IDEs expand `include!` macros.
