### PR TITLE
Try to build Android binaries on the CI and update Readme.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.aarch64-linux-android]
+linker = "aarch64-linux-android-clang"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ An official crate is not yet available on [crates.io](<https://crates.io/>) but 
 - [x] Windows
 - [x] Linux Ubuntu 16 (18 should work, too).
 - [x] macOS
-- [x] Android
+- [x] Android (macOS -> aarm64, contributed by [@DenisKolodin](https://github.com/DenisKolodin))
 - [ ] WebAssembly: [#42](https://github.com/rust-skia/rust-skia/pull/42) (help wanted).
 - [ ] iOS
 
@@ -96,6 +96,22 @@ On Linux, OpenGL libraries _may_ be missing, if that is the case, install OpenGL
 
 Please share your build experience so that we can try to automate the build and get to the point where `cargo build` _is_ sufficient to build the bindings _including_ Skia, and if that is not possible, clearly prompts to what's missing.
 
+### Android
+
+Cross compilation to Android is supported on macOS hosts for targeting 64 bit ARM architectures (`aarch64`):
+
+1. Download the r18b NDK from: https://developer.android.com/ndk/downloads/older_releases.html
+2. Create a toolchain for the compilation:
+   `build/tools/make_standalone_toolchain.py --arch arm64 --install-dir /tmp/ndk`
+3. Compile your code for the `aarch64-linux-android` target with:
+
+```bash
+ANDROID_NDK=~/path/to/android-ndk-r18b PATH=$PATH:/tmp/ndk/bin cargo build --target aarch64-linux-android
+```
+_Notes:_
+
+- It doesn't work for the latest 19 NDK, because Skia doesn't support it yet.
+
 ### Skia
 
 For situations in which Skia does not build or needs to be configured differently, we support some customization support in `skia-bindings/build.rs`. For more details about how to customize Skia builds, take a look at the [README of the skia-bindings package](skia-bindings/README.md).
@@ -144,8 +160,8 @@ If you'd like to help with the bindings, take a look at the [Wiki](https://githu
 
 ## Maintainers
 
-- LongYinan (@Brooooooklyn)
-- Armin (@pragmatrix)
+- LongYinan ([@Brooooooklyn](https://github.com/Brooooooklyn))
+- Armin ([@pragmatrix](https://github.com/pragmatrix))
 
 ## License
 

--- a/azure-pipelines-build-target.yml
+++ b/azure-pipelines-build-target.yml
@@ -1,0 +1,67 @@
+parameters:
+  # defaults:
+  runBinaries: false
+  runClippy: false
+  exampleArgs: ''
+
+steps:
+  - bash: |
+      rustup target add ${{ parameters.target }}
+    displayName: 'Install target ${{ parameters.target }}'
+
+  # Note: features are ignored when set in the workspace. This is a known bug in cargo (#5015), so cd into skia-safe instead.
+  - bash: |
+      set -e
+      cd skia-safe && cargo build --release --features "$(features)" --all-targets --target ${{ parameters.target }} -vv
+      export SKIA_BINARIES_TAG=$(cat "$(Build.ArtifactStagingDirectory)/skia-binaries/tag.txt")
+      export SKIA_BINARIES_KEY=$(cat "$(Build.ArtifactStagingDirectory)/skia-binaries/key.txt")
+      echo "##vso[task.setvariable variable=SKIA_BINARIES_TAG;]${SKIA_BINARIES_TAG}"
+      echo "##vso[task.setvariable variable=SKIA_BINARIES_KEY;]${SKIA_BINARIES_KEY}"
+    displayName: 'Build all targets in skia-safe for ${{ parameters.target }}'
+
+  # Note: Clippy freshness check is independent from the freshness check of the build.
+  # So we check the skia-bindings with the regular set of checks and skia-safe with warnings as errors after that.
+  # Also: Windows is disabled for now, because the clippy freshness
+  # check does seems to _always_ pick up skia-bindings when we want to check skia-safe with -D warnings.
+  - ${{ if eq(parameters.runClippy, True) }}:
+    - bash: |
+        set -e
+        (cd skia-bindings && cargo clippy --release --features "$(features)" --target ${{ parameters.target }})
+        (cd skia-safe && cargo clippy --release --features "$(features)" --all-targets --target ${{ parameters.target }} -- -D warnings)
+      displayName: 'Clippy skia-bindings and skia-safe'
+
+  - ${{ if eq(parameters.runBinaries, True) }}:
+    - script: cd skia-safe && cargo test --release --features "$(features)" --target ${{ parameters.target }} -vv
+      displayName: Test skia-safe
+
+    - script: cd skia-safe && cargo run --release --features "$(features)" --target ${{ parameters.target }} --example skia-org "$(Build.ArtifactStagingDirectory)/skia-org" ${{ parameters.exampleArgs }}
+      displayName: 'Generate skia-org example images'
+
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathtoPublish: '$(Build.ArtifactStagingDirectory)/skia-org'
+        artifactName: 'skia-org-examples-$(platform)-$(toolchain)'
+
+  - task: ArchiveFiles@2
+    condition: and(succeeded(), eq(variables['toolchain'], 'stable'), eq(variables['Build.SourceBranchName'], variables['release_branch']))
+    displayName: 'Archive binaries (${{ parameters.target }})'
+    inputs:
+      rootFolderOrFile: '$(Build.ArtifactStagingDirectory)/skia-binaries'
+      archiveType: 'tar'
+      tarCompression: 'gz'
+      archiveFile: '$(Build.ArtifactStagingDirectory)/skia-binaries-$(SKIA_BINARIES_KEY).tar.gz'
+
+  - task: GithubRelease@0
+    condition: and(succeeded(), eq(variables['toolchain'], 'stable'), eq(variables['Build.SourceBranchName'], variables['release_branch']))
+    displayName: 'Release to GitHub rust-skia/skia-binaries (${{ parameters.target }})'
+    inputs:
+      action: 'edit'
+      gitHubConnection: 'rust-skia-github-connection'
+      repositoryName: 'rust-skia/skia-binaries'
+      tagSource: 'manual'
+      target: 'master'
+      tag: '$(SKIA_BINARIES_TAG)'
+      assets: '$(Build.ArtifactStagingDirectory)/skia-binaries-$(SKIA_BINARIES_KEY).tar.gz'
+      assetUploadMode: 'replace'
+      isPreRelease: true
+      addChangeLog: false

--- a/azure-pipelines-build-target.yml
+++ b/azure-pipelines-build-target.yml
@@ -34,13 +34,14 @@ steps:
     - script: cd skia-safe && cargo test --release --features "$(features)" --target ${{ parameters.target }} -vv
       displayName: Test skia-safe
 
-    - script: cd skia-safe && cargo run --release --features "$(features)" --target ${{ parameters.target }} --example skia-org "$(Build.ArtifactStagingDirectory)/skia-org" ${{ parameters.exampleArgs }}
-      displayName: 'Generate skia-org example images'
+    - ${{ if ne(parameters.exampleArgs, '') }}:
+      - script: cd skia-safe && cargo run --release --features "$(features)" --target ${{ parameters.target }} --example skia-org "$(Build.ArtifactStagingDirectory)/skia-org" ${{ parameters.exampleArgs }}
+        displayName: 'Generate skia-org example images'
 
-    - task: PublishBuildArtifacts@1
-      inputs:
-        pathtoPublish: '$(Build.ArtifactStagingDirectory)/skia-org'
-        artifactName: 'skia-org-examples-$(platform)-$(toolchain)'
+      - task: PublishBuildArtifacts@1
+        inputs:
+          pathtoPublish: '$(Build.ArtifactStagingDirectory)/skia-org'
+          artifactName: 'skia-org-examples-$(platform)-$(toolchain)'
 
   - task: ArchiveFiles@2
     condition: and(succeeded(), eq(variables['toolchain'], 'stable'), eq(variables['Build.SourceBranchName'], variables['release_branch']))

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -1,5 +1,5 @@
 jobs:
-- job: ${{ parameters.platform }}
+- job: "${{ parameters.name }}"
   strategy:
     matrix:
       stable:
@@ -19,6 +19,8 @@ jobs:
   variables:
     platform: ${{ parameters.platform }}
     image: ${{ parameters.image }}
+    target: ${{ parameters.target }}
+    runBinaries: ${{ parameters.runBinaries }}
     rust_backtrace: 1
     release_branch: 'release'
   pool:
@@ -43,6 +45,7 @@ jobs:
         curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $TOOLCHAIN
         $HOME/.cargo/bin/rustup component add rustfmt --toolchain $TOOLCHAIN
         $HOME/.cargo/bin/rustup component add clippy --toolchain $TOOLCHAIN
+        $HOME/.cargo/bin/rustup target add $TARGET
         echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
       displayName: Install Rust, Rustfmt, and Clippy
 
@@ -74,6 +77,17 @@ jobs:
         "C:/Program Files/LLVM/bin/clang.exe" --version
       displayName: LLVM/Clang Version
 
+  - ${{ if eq(parameters.target, 'aarch64-linux-android') }}:
+    # Android NDK (macOS only for now)
+    - bash: |
+        set -e
+        (cd /tmp && curl -sSf -o android-ndk.zip https://dl.google.com/android/repository/android-ndk-r18b-darwin-x86_64.zip)
+        (cd /tmp && unzip android-ndk.zip)
+        (cd /tmp/android-ndk-r18b && build/tools/make_standalone_toolchain.py --arch arm64 --install-dir /tmp/ndk)
+        echo "##vso[task.setvariable variable=PATH;]${PATH}:/tmp/ndk/bin"
+        echo "##vso[task.setvariable variable=ANDROID_NDK;]/tmp/android-ndk-r18b"
+      displayName: 'Install Android NDK'
+
   # Note: support to ignore specific rust files and directories is unstable yet: https://github.com/rust-lang/rustfmt/pull/2522
   - bash: |
       set -e
@@ -85,7 +99,7 @@ jobs:
   # Note: features are ignored when set in the workspace. This is a known bug in cargo (#5015), so cd into skia-safe instead.
   - bash: |
       set -e
-      cd skia-safe && cargo build --release --features "$(features)" --all-targets -vv
+      cd skia-safe && cargo build --release --features "$(features)" --all-targets --target $(target) -vv
       export SKIA_BINARIES_TAG=$(cat "$(Build.ArtifactStagingDirectory)/skia-binaries/tag.txt")
       export SKIA_BINARIES_KEY=$(cat "$(Build.ArtifactStagingDirectory)/skia-binaries/key.txt")
       echo "##vso[task.setvariable variable=SKIA_BINARIES_TAG;]${SKIA_BINARIES_TAG}"
@@ -99,22 +113,23 @@ jobs:
   - ${{ if ne(parameters.platform, 'Windows') }}:
     - bash: |
         set -e
-        (cd skia-bindings && cargo clippy --release --features "$(features)")
-        (cd skia-safe && cargo clippy --release --features "$(features)" --all-targets -- -D warnings)
+        (cd skia-bindings && cargo clippy --release --features "$(features)" --target $(target))
+        (cd skia-safe && cargo clippy --release --features "$(features)" --all-targets --target $(target) -- -D warnings)
       displayName: Clippy skia-bindings and skia-safe
 
-  - script: cd skia-safe && cargo test --release --features "$(features)" -vv
+  - script: cd skia-safe && cargo test --release --features "$(features)" --target $(target) -vv
     displayName: Test skia-safe
+    condition: and(succeeded(), variables['runBinaries'])
 
-  - script: cd skia-safe && cargo run --release --features "$(features)" --example skia-org "$(Build.ArtifactStagingDirectory)/skia-org" $(exampleArgs)
+  - script: cd skia-safe && cargo run --release --features "$(features)" --target $(target) --example skia-org "$(Build.ArtifactStagingDirectory)/skia-org" $(exampleArgs)
     displayName: Generate skia-org Example Images
-    condition: and(succeeded(), ne(variables['exampleArgs'], ''))
+    condition: and(succeeded(), ne(variables['exampleArgs'], ''), variables['runBinaries'])
 
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)/skia-org'
       artifactName: 'skia-org-examples-$(platform)-$(toolchain)'
-    condition: and(succeeded(), ne(variables['exampleArgs'], ''))
+    condition: and(succeeded(), ne(variables['exampleArgs'], ''), variables['runBinaries'])
 
   - task: ArchiveFiles@2
     condition: and(succeeded(), eq(variables['toolchain'], 'stable'), eq(variables['Build.SourceBranchName'], variables['release_branch']))

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -119,17 +119,17 @@ jobs:
 
   - script: cd skia-safe && cargo test --release --features "$(features)" --target $(target) -vv
     displayName: Test skia-safe
-    condition: and(succeeded(), variables['runBinaries'])
+    condition: and(succeeded(), eq(variables['runBinaries'], True))
 
   - script: cd skia-safe && cargo run --release --features "$(features)" --target $(target) --example skia-org "$(Build.ArtifactStagingDirectory)/skia-org" $(exampleArgs)
     displayName: Generate skia-org Example Images
-    condition: and(succeeded(), ne(variables['exampleArgs'], ''), variables['runBinaries'])
+    condition: and(succeeded(), ne(variables['exampleArgs'], ''), eq(variables['runBinaries'], True))
 
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)/skia-org'
       artifactName: 'skia-org-examples-$(platform)-$(toolchain)'
-    condition: and(succeeded(), ne(variables['exampleArgs'], ''), variables['runBinaries'])
+    condition: and(succeeded(), ne(variables['exampleArgs'], ''), eq(variables['runBinaries'], True))
 
   - task: ArchiveFiles@2
     condition: and(succeeded(), eq(variables['toolchain'], 'stable'), eq(variables['Build.SourceBranchName'], variables['release_branch']))

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -1,5 +1,5 @@
 jobs:
-- job: "${{ parameters.name }}"
+- job: "${{ parameters.platform }}"
 
   strategy:
     matrix:

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -10,9 +10,11 @@ jobs:
       beta:
         toolchain: beta
         features: ''
+        exampleArgs: ''
       stable-vulkan:
         toolchain: stable
         features: 'vulkan'
+        exampleArgs: ''
       stable-svg:
         toolchain: stable
         features: 'svg'
@@ -99,8 +101,8 @@ jobs:
 
   - template: 'azure-pipelines-build-target.yml'
     parameters:
-      target: $(platformTarget)
-      exampleArgs: $(exampleArgs)
+      target: '$(platformTarget)'
+      exampleArgs: '$(exampleArgs)'
       ${{ if ne(parameters.platform, 'Windows') }}:
         runClippy: true
       runBinaries: true

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -101,7 +101,8 @@ jobs:
     parameters:
       target: $(platformTarget)
       exampleArgs: $(exampleArgs)
-      runClippy: true
+      ${{ if ne(parameters.platform, 'Windows') }}:
+        runClippy: true
       runBinaries: true
 
   - ${{ if eq(parameters.platform, 'macOS') }}:

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -1,5 +1,6 @@
 jobs:
 - job: "${{ parameters.name }}"
+
   strategy:
     matrix:
       stable:
@@ -16,13 +17,14 @@ jobs:
         toolchain: stable
         features: 'svg'
         exampleArgs: '--driver svg'
+
   variables:
     platform: ${{ parameters.platform }}
+    platformTarget: ${{ parameters.platformTarget }}
     image: ${{ parameters.image }}
-    target: ${{ parameters.target }}
-    runBinaries: ${{ parameters.runBinaries }}
     rust_backtrace: 1
     release_branch: 'release'
+
   pool:
     vmImage: $(image)
 
@@ -45,7 +47,6 @@ jobs:
         curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $TOOLCHAIN
         $HOME/.cargo/bin/rustup component add rustfmt --toolchain $TOOLCHAIN
         $HOME/.cargo/bin/rustup component add clippy --toolchain $TOOLCHAIN
-        $HOME/.cargo/bin/rustup target add $TARGET
         echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
       displayName: Install Rust, Rustfmt, and Clippy
 
@@ -77,7 +78,7 @@ jobs:
         "C:/Program Files/LLVM/bin/clang.exe" --version
       displayName: LLVM/Clang Version
 
-  - ${{ if eq(parameters.target, 'aarch64-linux-android') }}:
+  - ${{ if eq(parameters.platform, 'macOS') }}:
     # Android NDK (macOS only for now)
     - bash: |
         set -e
@@ -96,61 +97,14 @@ jobs:
       rm skia-bindings/src/bindings.rs
     displayName: Check Rust formatting
 
-  # Note: features are ignored when set in the workspace. This is a known bug in cargo (#5015), so cd into skia-safe instead.
-  - bash: |
-      set -e
-      cd skia-safe && cargo build --release --features "$(features)" --all-targets --target $(target) -vv
-      export SKIA_BINARIES_TAG=$(cat "$(Build.ArtifactStagingDirectory)/skia-binaries/tag.txt")
-      export SKIA_BINARIES_KEY=$(cat "$(Build.ArtifactStagingDirectory)/skia-binaries/key.txt")
-      echo "##vso[task.setvariable variable=SKIA_BINARIES_TAG;]${SKIA_BINARIES_TAG}"
-      echo "##vso[task.setvariable variable=SKIA_BINARIES_KEY;]${SKIA_BINARIES_KEY}"
-    displayName: Build all targets in skia-safe
+  - template: 'azure-pipelines-build-target.yml'
+    parameters:
+      target: $(platformTarget)
+      exampleArgs: $(exampleArgs)
+      runClippy: true
+      runBinaries: true
 
-  # Note: Clippy freshness check is independent from the freshness check of the build.
-  # So we check the skia-bindings with the regular set of checks and skia-safe with warnings as errors after that.
-  # Also: Windows is disabled for now, because the clippy freshness
-  # check does seems to _always_ pick up skia-bindings when we want to check skia-safe with -D warnings.
-  - ${{ if ne(parameters.platform, 'Windows') }}:
-    - bash: |
-        set -e
-        (cd skia-bindings && cargo clippy --release --features "$(features)" --target $(target))
-        (cd skia-safe && cargo clippy --release --features "$(features)" --all-targets --target $(target) -- -D warnings)
-      displayName: Clippy skia-bindings and skia-safe
-
-  - script: cd skia-safe && cargo test --release --features "$(features)" --target $(target) -vv
-    displayName: Test skia-safe
-    condition: and(succeeded(), eq(variables['runBinaries'], True))
-
-  - script: cd skia-safe && cargo run --release --features "$(features)" --target $(target) --example skia-org "$(Build.ArtifactStagingDirectory)/skia-org" $(exampleArgs)
-    displayName: Generate skia-org Example Images
-    condition: and(succeeded(), ne(variables['exampleArgs'], ''), eq(variables['runBinaries'], True))
-
-  - task: PublishBuildArtifacts@1
-    inputs:
-      pathtoPublish: '$(Build.ArtifactStagingDirectory)/skia-org'
-      artifactName: 'skia-org-examples-$(platform)-$(toolchain)'
-    condition: and(succeeded(), ne(variables['exampleArgs'], ''), eq(variables['runBinaries'], True))
-
-  - task: ArchiveFiles@2
-    condition: and(succeeded(), eq(variables['toolchain'], 'stable'), eq(variables['Build.SourceBranchName'], variables['release_branch']))
-    displayName: 'Archive binaries'
-    inputs:
-      rootFolderOrFile: '$(Build.ArtifactStagingDirectory)/skia-binaries'
-      archiveType: 'tar'
-      tarCompression: 'gz'
-      archiveFile: '$(Build.ArtifactStagingDirectory)/skia-binaries-$(SKIA_BINARIES_KEY).tar.gz'
-
-  - task: GithubRelease@0
-    condition: and(succeeded(), eq(variables['toolchain'], 'stable'), eq(variables['Build.SourceBranchName'], variables['release_branch']))
-    displayName: 'Release to GitHub rust-skia/skia-binaries'
-    inputs:
-      action: 'edit'
-      gitHubConnection: 'rust-skia-github-connection'
-      repositoryName: 'rust-skia/skia-binaries'
-      tagSource: 'manual'
-      target: 'master'
-      tag: '$(SKIA_BINARIES_TAG)'
-      assets: '$(Build.ArtifactStagingDirectory)/skia-binaries-$(SKIA_BINARIES_KEY).tar.gz'
-      assetUploadMode: 'replace'
-      isPreRelease: true
-      addChangeLog: false
+  - ${{ if eq(parameters.platform, 'macOS') }}:
+    - template: 'azure-pipelines-build-target.yml'
+      parameters:
+        target: 'aarch64-linux-android'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,31 +8,18 @@ stages:
 #      platform: 'Linux'
 #      image: 'ubuntu-16.04'
 #      target: 'x86_64-unknown-linux-gnu'
-#      runBinaries: true
-
-#  - template: 'azure-pipelines-template.yml'
-#    parameters:
-#      name: 'macOS'
-#      platform: 'macOS'
-#      image: 'macOS-10.14'
-#      target: 'x86_64-apple-darwin'
-#      runBinaries: true
-
-#  - template: 'azure-pipelines-template.yml'
-#    parameters:
-#      name: 'Windows'
-#      platform: 'Windows'
-#      image: 'windows-2019'
-#      target: 'x86_64-pc-windows-msvc'
-#      runBinaries: true
 
   - template: 'azure-pipelines-template.yml'
     parameters:
-      name: 'macOS_Android'
       platform: 'macOS'
+      platformTarget: 'x86_64-apple-darwin'
       image: 'macOS-10.14'
-      target: 'aarch64-linux-android'
-      runBinaries: false
+
+#  - template: 'azure-pipelines-template.yml'
+#    parameters:
+#      platform: 'Windows'
+#      image: 'windows-2019'
+#      target: 'x86_64-pc-windows-msvc'
 
 - stage: 'Package'
   condition: and(succeeded(), eq(variables['build.SourceBranchName'], 'release'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,20 +2,37 @@ stages:
 
 - stage: 'Build'
   jobs:
-  - template: 'azure-pipelines-template.yml'
-    parameters:
-      platform: 'Linux'
-      image: 'ubuntu-16.04'
+#  - template: 'azure-pipelines-template.yml'
+#    parameters:
+#      name: 'Linux'
+#      platform: 'Linux'
+#      image: 'ubuntu-16.04'
+#      target: 'x86_64-unknown-linux-gnu'
+#      runBinaries: true
+
+#  - template: 'azure-pipelines-template.yml'
+#    parameters:
+#      name: 'macOS'
+#      platform: 'macOS'
+#      image: 'macOS-10.14'
+#      target: 'x86_64-apple-darwin'
+#      runBinaries: true
+
+#  - template: 'azure-pipelines-template.yml'
+#    parameters:
+#      name: 'Windows'
+#      platform: 'Windows'
+#      image: 'windows-2019'
+#      target: 'x86_64-pc-windows-msvc'
+#      runBinaries: true
 
   - template: 'azure-pipelines-template.yml'
     parameters:
+      name: 'macOS_Android'
       platform: 'macOS'
       image: 'macOS-10.14'
-
-  - template: 'azure-pipelines-template.yml'
-    parameters:
-      platform: 'Windows'
-      image: 'windows-2019'
+      target: 'aarch64-linux-android'
+      runBinaries: false
 
 - stage: 'Package'
   condition: and(succeeded(), eq(variables['build.SourceBranchName'], 'release'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,10 +4,9 @@ stages:
   jobs:
   - template: 'azure-pipelines-template.yml'
     parameters:
-      name: 'Linux'
       platform: 'Linux'
+      platformTarget: 'x86_64-unknown-linux-gnu'
       image: 'ubuntu-16.04'
-      target: 'x86_64-unknown-linux-gnu'
 
   - template: 'azure-pipelines-template.yml'
     parameters:
@@ -18,8 +17,8 @@ stages:
   - template: 'azure-pipelines-template.yml'
     parameters:
       platform: 'Windows'
+      platformTarget: 'x86_64-pc-windows-msvc'
       image: 'windows-2019'
-      target: 'x86_64-pc-windows-msvc'
 
 - stage: 'Package'
   condition: and(succeeded(), eq(variables['build.SourceBranchName'], 'release'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,12 +2,12 @@ stages:
 
 - stage: 'Build'
   jobs:
-#  - template: 'azure-pipelines-template.yml'
-#    parameters:
-#      name: 'Linux'
-#      platform: 'Linux'
-#      image: 'ubuntu-16.04'
-#      target: 'x86_64-unknown-linux-gnu'
+  - template: 'azure-pipelines-template.yml'
+    parameters:
+      name: 'Linux'
+      platform: 'Linux'
+      image: 'ubuntu-16.04'
+      target: 'x86_64-unknown-linux-gnu'
 
   - template: 'azure-pipelines-template.yml'
     parameters:
@@ -15,11 +15,11 @@ stages:
       platformTarget: 'x86_64-apple-darwin'
       image: 'macOS-10.14'
 
-#  - template: 'azure-pipelines-template.yml'
-#    parameters:
-#      platform: 'Windows'
-#      image: 'windows-2019'
-#      target: 'x86_64-pc-windows-msvc'
+  - template: 'azure-pipelines-template.yml'
+    parameters:
+      platform: 'Windows'
+      image: 'windows-2019'
+      target: 'x86_64-pc-windows-msvc'
 
 - stage: 'Package'
   condition: and(succeeded(), eq(variables['build.SourceBranchName'], 'release'))

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/rust-skia/rust-skia"
 repository = "https://github.com/rust-skia/rust-skia"
 license = "MIT"
 
-version = "0.12.7"
+version = "0.12.8"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -146,11 +146,8 @@ impl FinalBuildConfiguration {
 
             let target = cargo::target();
             if target.system == "android" {
-                // TODO Not remove, but tweak skia parameters above
-                // for android
-                args.clear();
-                args.push(("cc", quote("clang")));
-                args.push(("cxx", quote("clang++")));
+                args.push(("skia_use_system_freetype2", no()));
+                args.push(("skia_enable_fontmgr_android", yes()));
             }
 
             // further flags that limit the components of Skia debug builds.

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/rust-skia/rust-skia"
 repository = "https://github.com/rust-skia/rust-skia"
 license = "MIT"
 
-version = "0.12.7"
+version = "0.12.8"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -18,7 +18,7 @@ svg = ["skia-bindings/svg"]
 
 [dependencies]
 bitflags = "1.0.4"
-skia-bindings = { version = "0.12.7", path = "../skia-bindings" }
+skia-bindings = { version = "0.12.8", path = "../skia-bindings" }
 lazy_static = "1.3.0"
 
 [dev-dependencies]

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -19,7 +19,8 @@ svg = ["skia-bindings/svg"]
 [dependencies]
 bitflags = "1.0.4"
 skia-bindings = { version = "0.12.8", path = "../skia-bindings" }
-lazy_static = "1.3.0"
+# TODO: 1.3 breaks offscreen_gl_context
+lazy_static = "=1.2"
 
 [dev-dependencies]
 # for skia-org

--- a/skia-safe/examples/skia-org/drivers/skia_ash.rs
+++ b/skia-safe/examples/skia-org/drivers/skia_ash.rs
@@ -4,6 +4,7 @@ use ash::vk::Handle;
 use ash::{Entry, Instance};
 use skia_safe::gpu;
 use std::ffi::{c_void, CString};
+use std::os::raw;
 
 pub struct AshGraphics {
     pub entry: Entry,
@@ -60,7 +61,7 @@ impl AshGraphics {
                 .engine_version(0)
                 .api_version(api_version);
 
-            let layers_names_raw: Vec<*const i8> = layer_names
+            let layers_names_raw: Vec<*const raw::c_char> = layer_names
                 .iter()
                 .map(|raw_name| raw_name.as_ptr())
                 .collect();


### PR DESCRIPTION
Following up on #129, this PR attempts to build the Android target on the CI.

- [x] Successfully build & link a release version of Skia.
- [x] Build Android target on the CI with macOS ~~(and try other host platforms?)~~.
- [x] ~~Is it possible to test skia-safe and run the skia-org example with the Android emulator?~~ (postponed)
- [x] Update README with build instructions for Android.
- [x] Add credits to the README.
- [x] Finalization: reenable the platforms that were disabled.

/cc @DenisKolodin 