### PR TITLE
Bindgen downgrade.

### DIFF
--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -24,7 +24,7 @@ svg = []
 
 [build-dependencies]
 cc = "1.0.35"
-bindgen = "=0.49.2"
+bindgen = "0.49.0"
 
 # for downloading and extracting prebuilt binaries:
 reqwest = "0.9.16"

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -24,7 +24,7 @@ svg = []
 
 [build-dependencies]
 cc = "1.0.35"
-bindgen = "=0.49.3"
+bindgen = "=0.49.2"
 
 # for downloading and extracting prebuilt binaries:
 reqwest = "0.9.16"

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -375,9 +375,7 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
         //       a customized test run that ignores failures skia-safe
         //       works around.
         .layout_tests(false)
-        .default_enum_style(EnumVariation::Rust {
-            non_exhaustive: false,
-        })
+        .default_enum_style(EnumVariation::Rust)
         .constified_enum(".*Mask")
         .constified_enum(".*Flags")
         .constified_enum(".*Bits")


### PR DESCRIPTION
bindgen version 0.49.3 was yanked breaking our build jobs, so we have to downgrade to version 0.49.2