### PR TITLE
Azure: force a rebuild of skia-bindings when the build target is changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ ANDROID_NDK=~/path/to/android-ndk-r18b PATH=$PATH:/tmp/ndk/bin cargo build --tar
 _Notes:_
 
 - It doesn't work for the latest 19 NDK, because Skia doesn't support it yet.
+- Rebuilding skia-bindings with a different target may cause linker errors, in that case `touch skia-bindings/build.rs` will force a rebuild (https://github.com/rust-skia/rust-skia/issues/10).
 
 ### Skia
 

--- a/azure-pipelines-build-target.yml
+++ b/azure-pipelines-build-target.yml
@@ -10,9 +10,11 @@ steps:
     displayName: 'Install target ${{ parameters.target }}'
 
   # Note: features are ignored when set in the workspace. This is a known bug in cargo (#5015), so cd into skia-safe instead.
+  # Also be sure that the bindings.rs file is rebuilt (https://github.com/rust-skia/rust-skia/issues/10)
   - bash: |
       set -e
-      cd skia-safe && cargo build --release --features "$(features)" --all-targets --target ${{ parameters.target }} -vv
+      touch skia-bindings/build.rs
+      (cd skia-safe && cargo build --release --features "$(features)" --all-targets --target ${{ parameters.target }} -vv)
       export SKIA_BINARIES_TAG=$(cat "$(Build.ArtifactStagingDirectory)/skia-binaries/tag.txt")
       export SKIA_BINARIES_KEY=$(cat "$(Build.ArtifactStagingDirectory)/skia-binaries/key.txt")
       echo "##vso[task.setvariable variable=SKIA_BINARIES_TAG;]${SKIA_BINARIES_TAG}"


### PR DESCRIPTION
The latest azure builds caused all macOS jobs to fail because the bindings.rs file wasn't regenerated when the build target was changed to `aarch64-linux-android`. For more information: https://github.com/rust-skia/rust-skia/issues/10#issuecomment-507961743.

This PR updates the azure script to force a rebuild of the bindings file and updates the readme.