### PR TITLE
Support to build Android aarch64 on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ ANDROID_NDK=~/path/to/android-ndk-r18b PATH=$PATH:/tmp/ndk/bin cargo build --tar
 _Notes:_
 
 - It doesn't work for the latest 19 NDK, because Skia doesn't support it yet.
-- Rebuilding skia-bindings with a different target may cause linker errors, in that case `touch skia-bindings/build.rs` will force a rebuild (https://github.com/rust-skia/rust-skia/issues/10).
+- Rebuilding skia-bindings with a different target may cause linker errors, in that case `touch skia-bindings/build.rs` will force a rebuild ([#10](https://github.com/rust-skia/rust-skia/issues/10)).
 
 ### Skia
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ An official crate is not yet available on [crates.io](<https://crates.io/>) but 
 - [x] Windows
 - [x] Linux Ubuntu 16 (18 should work, too).
 - [x] macOS
-- [x] Android (macOS | Linux -> aarm64, contributed by [@DenisKolodin](https://github.com/DenisKolodin))
+- [x] Android (macOS | Linux -> aarch64, contributed by [@DenisKolodin](https://github.com/DenisKolodin))
 - [ ] WebAssembly: [#42](https://github.com/rust-skia/rust-skia/pull/42) (help wanted).
 - [ ] iOS
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ An official crate is not yet available on [crates.io](<https://crates.io/>) but 
 - [x] Windows
 - [x] Linux Ubuntu 16 (18 should work, too).
 - [x] macOS
-- [x] Android (macOS -> aarm64, contributed by [@DenisKolodin](https://github.com/DenisKolodin))
+- [x] Android (macOS | Linux -> aarm64, contributed by [@DenisKolodin](https://github.com/DenisKolodin))
 - [ ] WebAssembly: [#42](https://github.com/rust-skia/rust-skia/pull/42) (help wanted).
 - [ ] iOS
 

--- a/azure-pipelines-build-target.yml
+++ b/azure-pipelines-build-target.yml
@@ -2,6 +2,7 @@ parameters:
   # defaults:
   runBinaries: false
   runClippy: false
+  releaseBinaries: false
   exampleArgs: ''
 
 steps:
@@ -45,26 +46,27 @@ steps:
           pathtoPublish: '$(Build.ArtifactStagingDirectory)/skia-org'
           artifactName: 'skia-org-examples-$(platform)-$(toolchain)'
 
-  - task: ArchiveFiles@2
-    condition: and(succeeded(), eq(variables['toolchain'], 'stable'), eq(variables['Build.SourceBranchName'], variables['release_branch']))
-    displayName: 'Archive binaries (${{ parameters.target }})'
-    inputs:
-      rootFolderOrFile: '$(Build.ArtifactStagingDirectory)/skia-binaries'
-      archiveType: 'tar'
-      tarCompression: 'gz'
-      archiveFile: '$(Build.ArtifactStagingDirectory)/skia-binaries-$(SKIA_BINARIES_KEY).tar.gz'
+  - ${{ if eq(parameters.releaseBinaries, True) }}:
+    - task: ArchiveFiles@2
+      condition: and(succeeded(), eq(variables['toolchain'], 'stable'), eq(variables['Build.SourceBranchName'], variables['release_branch']))
+      displayName: 'Archive binaries (${{ parameters.target }})'
+      inputs:
+        rootFolderOrFile: '$(Build.ArtifactStagingDirectory)/skia-binaries'
+        archiveType: 'tar'
+        tarCompression: 'gz'
+        archiveFile: '$(Build.ArtifactStagingDirectory)/skia-binaries-$(SKIA_BINARIES_KEY).tar.gz'
 
-  - task: GithubRelease@0
-    condition: and(succeeded(), eq(variables['toolchain'], 'stable'), eq(variables['Build.SourceBranchName'], variables['release_branch']))
-    displayName: 'Release to GitHub rust-skia/skia-binaries (${{ parameters.target }})'
-    inputs:
-      action: 'edit'
-      gitHubConnection: 'rust-skia-github-connection'
-      repositoryName: 'rust-skia/skia-binaries'
-      tagSource: 'manual'
-      target: 'master'
-      tag: '$(SKIA_BINARIES_TAG)'
-      assets: '$(Build.ArtifactStagingDirectory)/skia-binaries-$(SKIA_BINARIES_KEY).tar.gz'
-      assetUploadMode: 'replace'
-      isPreRelease: true
-      addChangeLog: false
+    - task: GithubRelease@0
+      condition: and(succeeded(), eq(variables['toolchain'], 'stable'), eq(variables['Build.SourceBranchName'], variables['release_branch']))
+      displayName: 'Release to GitHub rust-skia/skia-binaries (${{ parameters.target }})'
+      inputs:
+        action: 'edit'
+        gitHubConnection: 'rust-skia-github-connection'
+        repositoryName: 'rust-skia/skia-binaries'
+        tagSource: 'manual'
+        target: 'master'
+        tag: '$(SKIA_BINARIES_TAG)'
+        assets: '$(Build.ArtifactStagingDirectory)/skia-binaries-$(SKIA_BINARIES_KEY).tar.gz'
+        assetUploadMode: 'replace'
+        isPreRelease: true
+        addChangeLog: false

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -106,8 +106,15 @@ jobs:
       ${{ if ne(parameters.platform, 'Windows') }}:
         runClippy: true
       runBinaries: true
+      releaseBinaries: true
 
   - ${{ if eq(parameters.platform, 'macOS') }}:
+    - template: 'azure-pipelines-build-target.yml'
+      parameters:
+        target: 'aarch64-linux-android'
+        releaseBinaries: true
+
+  - ${{ if eq(parameters.platform, 'Linux') }}:
     - template: 'azure-pipelines-build-target.yml'
       parameters:
         target: 'aarch64-linux-android'

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -1,3 +1,7 @@
+parameters:
+  # defaults:
+  androidNDK: ''
+
 jobs:
 - job: "${{ parameters.platform }}"
 
@@ -80,11 +84,11 @@ jobs:
         "C:/Program Files/LLVM/bin/clang.exe" --version
       displayName: LLVM/Clang Version
 
-  - ${{ if eq(parameters.platform, 'macOS') }}:
-    # Android NDK (macOS only for now)
+  - ${{ if ne(parameters.androidNDK, '') }}:
+    # Android NDK
     - bash: |
         set -e
-        (cd /tmp && curl -sSf -o android-ndk.zip https://dl.google.com/android/repository/android-ndk-r18b-darwin-x86_64.zip)
+        (cd /tmp && curl -sSf -o android-ndk.zip https://dl.google.com/android/repository/android-ndk-$(androidNDK).zip)
         (cd /tmp && unzip android-ndk.zip)
         (cd /tmp/android-ndk-r18b && build/tools/make_standalone_toolchain.py --arch arm64 --install-dir /tmp/ndk)
         echo "##vso[task.setvariable variable=PATH;]${PATH}:/tmp/ndk/bin"

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -28,6 +28,7 @@ jobs:
     platform: ${{ parameters.platform }}
     platformTarget: ${{ parameters.platformTarget }}
     image: ${{ parameters.image }}
+    androidNDK: ${{ parameters.androidNDK }}
     rust_backtrace: 1
     release_branch: 'release'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,12 +6,14 @@ stages:
     parameters:
       platform: 'Linux'
       platformTarget: 'x86_64-unknown-linux-gnu'
+      androidNDK: 'r18b-linux-x86_64'
       image: 'ubuntu-16.04'
 
   - template: 'azure-pipelines-template.yml'
     parameters:
       platform: 'macOS'
       platformTarget: 'x86_64-apple-darwin'
+      androidNDK: 'r18b-darwin-x86_64'
       image: 'macOS-10.14'
 
   - template: 'azure-pipelines-template.yml'

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -529,6 +529,7 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
         cc_build.target(&arch);
         builder = builder
             .clang_arg(format!("--sysroot={}/sysroot", ndk))
+            .clang_arg(format!("-I{}/sysroot/usr/include/{}", ndk, arch))
             .clang_arg(format!(
                 "-isystem{}/sources/cxx-stl/llvm-libc++/include",
                 ndk


### PR DESCRIPTION
This PR enables targeting `aarch64-linux-android` on Linux platforms.