### PR TITLE
Support for iOS targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ An official crate is not yet available on [crates.io](<https://crates.io/>) but 
 - [x] Linux Ubuntu 16 (18 should work, too).
 - [x] macOS
 - [x] Android (macOS | Linux -> aarch64, contributed by [@DenisKolodin](https://github.com/DenisKolodin))
+- [x] iOS
 - [ ] WebAssembly: [#42](https://github.com/rust-skia/rust-skia/pull/42) (help wanted).
-- [ ] iOS
 
 ### Bindings & Wrappers
 
@@ -112,6 +112,10 @@ _Notes:_
 
 - It doesn't work for the latest 19 NDK, because Skia doesn't support it yet.
 - Rebuilding skia-bindings with a different target may cause linker errors, in that case `touch skia-bindings/build.rs` will force a rebuild ([#10](https://github.com/rust-skia/rust-skia/issues/10)).
+
+### iOS
+
+Compilation to iOS is supported on macOS targeting the iOS simulator (`--target x86_64-apple-ios`) and 64 bit ARM devices (`--target aarch64-apple-ios`).
 
 ### Skia
 

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -119,6 +119,11 @@ jobs:
         target: 'aarch64-linux-android'
         releaseBinaries: true
 
+    - template: 'azure-pipelines-build-target.yml'
+      parameters:
+        target: 'aarch64-apple-ios'
+        releaseBinaries: true
+
   - ${{ if eq(parameters.platform, 'Linux') }}:
     - template: 'azure-pipelines-build-target.yml'
       parameters:

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -124,6 +124,11 @@ jobs:
         target: 'aarch64-apple-ios'
         releaseBinaries: true
 
+    - template: 'azure-pipelines-build-target.yml'
+      parameters:
+        target: 'x86_64-apple-ios'
+        releaseBinaries: true
+
   - ${{ if eq(parameters.platform, 'Linux') }}:
     - template: 'azure-pipelines-build-target.yml'
       parameters:

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/rust-skia/rust-skia"
 repository = "https://github.com/rust-skia/rust-skia"
 license = "MIT"
 
-version = "0.12.9"
+version = "0.12.10"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"

--- a/skia-bindings/build_support.rs
+++ b/skia-bindings/build_support.rs
@@ -4,6 +4,7 @@ pub mod android;
 pub mod azure;
 pub mod binaries;
 pub mod cargo;
+pub mod clang;
 pub mod git;
 pub mod ios;
 pub mod skia;

--- a/skia-bindings/build_support.rs
+++ b/skia-bindings/build_support.rs
@@ -5,5 +5,6 @@ pub mod azure;
 pub mod binaries;
 pub mod cargo;
 pub mod git;
+pub mod ios;
 pub mod skia;
 pub mod vs;

--- a/skia-bindings/build_support/clang.rs
+++ b/skia-bindings/build_support/clang.rs
@@ -1,0 +1,8 @@
+/// Convert a Rust target architecture identifier to a clang target architecture identifier.
+pub fn target_arch(arch: &str) -> &str {
+    if arch == "aarch64" {
+        "arm64"
+    } else {
+        arch
+    }
+}

--- a/skia-bindings/build_support/ios.rs
+++ b/skia-bindings/build_support/ios.rs
@@ -1,0 +1,16 @@
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+pub fn sdk_path() -> PathBuf {
+    let sdk_path = Command::new("xcrun")
+        .arg("--show-sdk-path")
+        .arg("--sdk")
+        .arg("iphoneos")
+        .stderr(Stdio::inherit())
+        .output()
+        .expect("failed to invoke xcrun")
+        .stdout;
+
+    let string = String::from_utf8(sdk_path).expect("failed to resolve iOS SDK path");
+    PathBuf::from(string.trim())
+}

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -1,6 +1,6 @@
 //! Full build support for the Skia library, SkiaBindings library and bindings.rs file.
 
-use crate::build_support::{android, cargo, vs};
+use crate::build_support::{android, cargo, ios, vs};
 use bindgen::EnumVariation;
 use cc::Build;
 use std::env;
@@ -553,11 +553,12 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
                 .clang_arg(format!("--target={}", target));
         }
         (arch, "apple", "ios", _) => {
+            let sdk_path = ios::sdk_path();
             builder = builder
                 .clang_arg("-miphoneos-version-min=7.0")
                 .clang_arg("-fembed-bitcode")
                 .clang_args(&["-arch", clang::target_arch(arch)])
-                .clang_args(&["-isysroot", "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk"]);
+                .clang_args(&["-isysroot", sdk_path.to_str().unwrap()]);
         }
         _ => {}
     }

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -541,11 +541,11 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
     match target.as_strs() {
         (_, "linux", "android", _) => {
             let ndk = android::ndk();
-            let arch = target.to_string();
-            cc_build.target(&arch);
+            let target = target.to_string();
+            cc_build.target(&target);
             builder = builder
                 .clang_arg(format!("--sysroot={}/sysroot", ndk))
-                .clang_arg(format!("-I{}/sysroot/usr/include/{}", ndk, arch))
+                .clang_arg(format!("-I{}/sysroot/usr/include/{}", ndk, target))
                 .clang_arg(format!(
                     "-isystem{}/sources/cxx-stl/llvm-libc++/include",
                     ndk
@@ -556,7 +556,7 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
             builder = builder
                 .clang_arg("-miphoneos-version-min=7.0")
                 .clang_arg("-fembed-bitcode")
-                .clang_args(&["-arch", clang::target_arch(arch)]
+                .clang_args(&["-arch", clang::target_arch(arch)])
                 .clang_args(&["-isysroot", "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk"]);
         }
         _ => {}

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/rust-skia/rust-skia"
 repository = "https://github.com/rust-skia/rust-skia"
 license = "MIT"
 
-version = "0.12.9"
+version = "0.12.10"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -18,7 +18,7 @@ svg = ["skia-bindings/svg"]
 
 [dependencies]
 bitflags = "1.0.4"
-skia-bindings = { version = "0.12.9", path = "../skia-bindings" }
+skia-bindings = { version = "0.12.10", path = "../skia-bindings" }
 # TODO: 1.3 breaks offscreen_gl_context
 lazy_static = "=1.2"
 


### PR DESCRIPTION
This PR builds Skia for iOS and links the examples.

TODO:
- [x] Build and distribute binaries on Azure.
- [x] Automatically resolve the iOS SDK path like cc_rs does.
- [x] Support ios simulator targets.
- [x] Update README.md.
- [x] Bump Versions.
