### PR TITLE
Prevent expat warning for non-SVG builds

### DIFF
--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -110,11 +110,6 @@ impl FinalBuildConfiguration {
                     "is_official_build",
                     if build.skia_release { yes() } else { no() },
                 ),
-                (
-                    "skia_use_expat",
-                    if build.feature_svg { yes() } else { no() },
-                ),
-                ("skia_use_system_expat", no()),
                 ("skia_use_icu", no()),
                 ("skia_use_system_libjpeg_turbo", no()),
                 ("skia_use_system_libpng", no()),
@@ -144,6 +139,13 @@ impl FinalBuildConfiguration {
                 ("cc", quote("clang")),
                 ("cxx", quote("clang++")),
             ];
+
+            if build.feature_svg {
+                args.push(("skia_use_expat", yes()));
+                args.push(("skia_use_system_expat", no()));
+            } else {
+                args.push(("skia_use_expat", no()));
+            }
 
             let target = cargo::target();
             if target.system == "android" {


### PR DESCRIPTION
A small PR that fixes the following expat warning:

```
[skia-bindings 0.12.10] The variable "skia_use_system_expat" was set as a build argument
[skia-bindings 0.12.10] but never appeared in a declare_args() block in any buildfile.
```