### PR TITLE
Support feature "shaper": Text shaping using HarfBuzz and ICU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,4 +5,4 @@ project (skia-bindings)
 
 include_directories(skia-bindings/skia)
 
-add_library(skiabindings skia-bindings/src/bindings.cpp)
+add_library(skiabindings skia-bindings/src/bindings.cpp skia-bindings/src/shaper.cpp)

--- a/README.md
+++ b/README.md
@@ -29,16 +29,18 @@ An official crate is not yet available on [crates.io](<https://crates.io/>) but 
 
 We wrapped most part of the public Skia C++ APIs. To see what's missing, take a look at the [API Complete Milestone](<https://github.com/rust-skia/rust-skia/milestone/2>).
 
-- [x] Vector Graphics: Matrix, Rect, Point, Size, etc.
+- [x] Vector Geometry: Matrix, Rect, Point, Size, etc.
 - [x] Most drawing related classes and functions: Surface, Canvas, Paint, Path.
 - [x] [Almost all](<https://github.com/rust-skia/rust-skia/issues/99>) Effects and Shaders.
 - [x] Utility classes we think are useful.
-- [x] PDF
-- [x] SVG
-- [ ] Animation
-- [x] Vulkan
-- [x] OpenGL
-- [ ] Metal
+- [x] PDF & SVG rendering
+- [ ] Skia Modules
+  - [x] Text shaping with [Harfbuzz](https://www.freedesktop.org/wiki/Software/HarfBuzz/) and [ICU](http://site.icu-project.org/home).
+  - [ ] Animation via [Skottie](https://skia.org/user/modules/skottie)
+- [ ] GPU Backends
+  - [x] Vulkan
+  - [x] OpenGL
+  - [ ] Metal
 
 Wrappers for functions that take callbacks and virtual classes are not supported right now. While we think they should be wrapped, the use cases related seem to be rather special, so we postponed that for now.
 
@@ -139,6 +141,12 @@ Note that crate packages _will_ try to download prebuilt binaries from [skia-bin
 Vulkan support can be enabled by setting the Cargo feature `default = ["vulkan"]` in `skia-safe/Cargo.toml`, which will cause a rebuild of Skia. To render the examples with Vulkan use `cargo run --example skia-org -- [OUTPUT_DIR] --driver vulkan`.
 
 Note that Vulkan drivers need to be available. On Windows, they are most likely available already, on Linux [this article on linuxconfig.org](<https://linuxconfig.org/install-and-test-vulkan-on-linux>) might get you started, and on macOS with Metal support, [install the Vulkan SDK](<https://vulkan.lunarg.com/sdk/home>) for Mac and configure MoltenVK by setting the `DYLD_LIBRARY_PATH`, `VK_LAYER_PATH`, and `VK_ICD_FILENAMES` environment variables as described in `Documentation/getting_started_macos.html`.
+
+### Feature `shaper`
+
+The Cargo feature `shaper` enables text shaping with Harfbuzz and ICU. 
+
+On **Windows**, the file `icudtl.dat` must be available in your executable's directory. To provide the data file, either copy it from the build's output directory (shown when skia-bindings is compiled with `cargo build -vv | grep "ninja: Entering directory"`), or - if your executable directory is writable - invoke the function `skia_bindings::icu::init()` before creating the `Shaper` object.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ Note that Vulkan drivers need to be available. On Windows, they are most likely 
 
 The Cargo feature `shaper` enables text shaping with Harfbuzz and ICU. 
 
-On **Windows**, the file `icudtl.dat` must be available in your executable's directory. To provide the data file, either copy it from the build's output directory (shown when skia-bindings is compiled with `cargo build -vv | grep "ninja: Entering directory"`), or - if your executable directory is writable - invoke the function `skia_bindings::icu::init()` before creating the `Shaper` object.
+On **Windows**, the file `icudtl.dat` must be available in your executable's directory. To provide the data file, either copy it from the build's output directory (shown when skia-bindings is compiled with `cargo build -vv | grep "ninja: Entering directory"`), or - if your executable directory is writable - invoke the function `skia_safe::icu::init()` before creating the `skia_safe::Shaper` object. 
+
+A simple example can be found [in the skia-org command line application](skia-safe/examples/skia-org/skshaper_example.rs).
 
 ## Examples
 

--- a/azure-pipelines-build-target.yml
+++ b/azure-pipelines-build-target.yml
@@ -34,7 +34,7 @@ steps:
       displayName: 'Clippy skia-bindings and skia-safe'
 
   - ${{ if eq(parameters.runBinaries, True) }}:
-    - script: cd skia-safe && cargo test --release --features "$(features)" --target ${{ parameters.target }} -vv
+    - script: cd skia-safe && cargo test --release --features "$(features)" --target ${{ parameters.target }} -vv -- --test-threads=1 --nocapture
       displayName: Test skia-safe
 
     - ${{ if ne(parameters.exampleArgs, '') }}:

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -23,6 +23,10 @@ jobs:
         toolchain: stable
         features: 'svg'
         exampleArgs: '--driver svg'
+      stable-shaper:
+        toolchain: stable
+        features: 'shaper'
+        exampleArgs: ''
 
   variables:
     platform: ${{ parameters.platform }}

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/rust-skia/rust-skia"
 repository = "https://github.com/rust-skia/rust-skia"
 license = "MIT"
 
-version = "0.14.0"
+version = "0.14.1"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org
 edition = "2018"
 build = "build.rs"
 links = "skia"
-include = [ "Cargo.toml", "build.rs", "build_support.rs", "build_support/**/*.rs", "src/**/*.cpp", "src/lib.rs" ]
+include = [ "Cargo.toml", "build.rs", "build_support.rs", "build_support/**/*.rs", "src/**/*.cpp", "src/lib.rs", "src/icu.rs" ]
 
 [features]
 default = []

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -19,6 +19,7 @@ include = [ "Cargo.toml", "build.rs", "build_support.rs", "build_support/**/*.rs
 default = []
 vulkan = []
 svg = []
+shaper = []
 
 [dependencies]
 

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -517,6 +517,7 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
         .whitelist_type("SkTextUtils")
         // modules/skshaper/
         .whitelist_type("SkShaper")
+        .whitelist_type("RustRunHandler")
         // misc
         .whitelist_var("SK_Color.*")
         .whitelist_var("kAll_GrBackendState")

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -581,7 +581,7 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
         _ => {}
     }
 
-    println!("COMPILING BINDINGS: {}", bindings_source);
+    println!("COMPILING BINDINGS: {:?}", build.binding_sources);
     cc_build.compile(BINDINGS_LIB_NAME);
 
     println!("GENERATING BINDINGS");

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -34,6 +34,7 @@ impl Default for BuildConfiguration {
             keep_inline_functions: true,
             feature_vulkan: cfg!(feature = "vulkan"),
             feature_svg: cfg!(feature = "svg"),
+            feature_shaper: cfg!(feature = "shaper"),
             feature_animation: false,
             feature_dng: false,
             feature_particles: false,
@@ -62,6 +63,9 @@ pub struct BuildConfiguration {
     /// Build with SVG support?
     feature_svg: bool,
 
+    /// Builds the skshaper module, compiles harfbuzz & icu support.
+    feature_shaper: bool,
+
     /// Build with animation support (yet unsupported, no wrappers).
     feature_animation: bool,
 
@@ -72,7 +76,7 @@ pub struct BuildConfiguration {
     feature_particles: bool,
 
     /// As of M74, There is a bug in the Skia macOS build
-    /// that requires all libraries to be built, otherwise the build would fail.
+    /// that requires all libraries to be built, otherwise the build will fail.
     all_skia_libs: bool,
 
     /// Additional preprocessor definitions that will override predefined ones.
@@ -109,7 +113,6 @@ impl FinalBuildConfiguration {
                     "is_official_build",
                     if build.skia_release { yes() } else { no() },
                 ),
-                ("skia_use_icu", no()),
                 ("skia_use_system_libjpeg_turbo", no()),
                 ("skia_use_system_libpng", no()),
                 ("skia_use_libwebp", no()),
@@ -147,6 +150,17 @@ impl FinalBuildConfiguration {
                 args.push(("skia_enable_vulkan_debug_layers", no()));
                 args.push(("skia_use_libheif", no()));
                 args.push(("skia_use_lua", no()));
+            }
+
+            if build.feature_shaper {
+                args.push(("skia_enable_skshaper", yes()));
+                args.push(("skia_use_icu", yes()));
+                args.push(("skia_use_system_icu", no()));
+                args.push(("skia_use_harfbuzz", yes()));
+                args.push(("skia_use_system_harfbuzz", no()));
+                args.push(("skia_use_sfntly", no()));
+            } else {
+                args.push(("skia_use_icu", no()));
             }
 
             if build.feature_vulkan {

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -545,13 +545,6 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
     builder = builder.clang_arg(format!("-I{}", include_path.display()));
     cc_build.include(include_path);
 
-    {
-        // SkShaper.h
-        let include_path = current_dir.join(Path::new("skia/modules/skshaper/include"));
-        builder = builder.clang_arg(format!("-I{}", include_path.display()));
-        cc_build.include(include_path);
-    }
-
     let definitions = {
         let skia_definitions = {
             let ninja_file = output_directory.join("obj").join("skia.ninja");

--- a/skia-bindings/src/icu.rs
+++ b/skia-bindings/src/icu.rs
@@ -1,0 +1,26 @@
+/// This function writes the file `icudtl.dat` into the current's executable directory
+/// making sure that it's available when text shaping is used in Skia.
+///
+/// If your executable directory can not be written to, make sure that `icudtl.dat` is
+/// available.
+///
+/// It's currently not possible to load `icudtl.dat` from another location.
+#[cfg(windows)]
+pub fn init() {
+    use std::{env, fs};
+
+    let path = env::current_exe()
+        .expect("failed to resolve the current executable's path")
+        .parent()
+        .expect("current executable's path does not point to a directory")
+        .join("icudtl.dat");
+    if path.exists() {
+        return;
+    };
+    let icu_dtl = include_bytes!(concat!(env!("OUT_DIR"), "/skia/icudtl.dat"));
+    fs::write(path, &icu_dtl[..])
+        .expect("failed to write icudtl.dat into the current executable's directory");
+}
+
+#[cfg(not(windows))]
+pub fn init() {}

--- a/skia-bindings/src/icu.rs
+++ b/skia-bindings/src/icu.rs
@@ -1,10 +1,3 @@
-/// This function writes the file `icudtl.dat` into the current's executable directory
-/// making sure that it's available when text shaping is used in Skia.
-///
-/// If your executable directory can not be written to, make sure that `icudtl.dat` is
-/// available.
-///
-/// It's currently not possible to load `icudtl.dat` from another location.
 #[cfg(windows)]
 pub fn init() {
     use std::{env, fs};

--- a/skia-bindings/src/lib.rs
+++ b/skia-bindings/src/lib.rs
@@ -4,3 +4,6 @@
 
 mod bindings;
 pub use bindings::*;
+
+#[cfg(feature = "shaper")]
+pub mod icu;

--- a/skia-bindings/src/shaper.cpp
+++ b/skia-bindings/src/shaper.cpp
@@ -1,8 +1,8 @@
 // We always compile SkShaper.h with HARFBUZZ & ICU for now.
 #define SK_SHAPER_HARFBUZZ_AVAILABLE
 
-#include "SkShaper.h"
-#include "SkFontMgr.h"
+#include "modules/skshaper/include/SkShaper.h"
+#include "include/core/SkFontMgr.h"
 
 extern "C" SkShaper* C_SkShaper_MakePrimitive() {
     return SkShaper::MakePrimitive().release();

--- a/skia-bindings/src/shaper.cpp
+++ b/skia-bindings/src/shaper.cpp
@@ -1,0 +1,79 @@
+// We always compile SkShaper.h with HARFBUZZ & ICU for now.
+#define SK_SHAPER_HARFBUZZ_AVAILABLE
+
+#include "SkShaper.h"
+#include "SkFontMgr.h"
+
+extern "C" SkShaper* C_SkShaper_MakePrimitive() {
+    return SkShaper::MakePrimitive().release();
+}
+
+extern "C" SkShaper* C_SkShaper_MakeShaperDrivenWrapper() {
+    return SkShaper::MakeShaperDrivenWrapper().release();
+}
+
+extern "C" SkShaper* C_SkShaper_MakeShapeThenWrap() {
+    return SkShaper::MakeShapeThenWrap().release();
+}
+
+extern "C" SkShaper* C_SkShaper_Make() {
+    return SkShaper::Make().release();
+}
+
+extern "C" void C_SkShaper_delete(SkShaper* self) {
+    delete self;
+}
+
+extern "C" void C_SkShaper_RunIterator_delete(SkShaper::RunIterator* self) {
+    delete self;
+}
+
+extern "C" size_t C_SkShaper_RunIterator_endOfCurrentRun(const SkShaper::RunIterator* self) {
+    return self->endOfCurrentRun();
+}
+
+extern "C" bool C_SkShaper_RunIterator_atEnd(const SkShaper::RunIterator* self) {
+    return self->atEnd();
+}
+
+extern "C" const SkFont* C_SkShaper_FontRunIterator_currentFont(const SkShaper::FontRunIterator* self) {
+    return &self->currentFont();
+}
+
+extern "C" SkShaper::FontRunIterator* C_SkShaper_MakeFontMgrRunIterator(const char* utf8, size_t utf8Bytes, const SkFont* font, SkFontMgr* fallback) {
+    return SkShaper::MakeFontMgrRunIterator(utf8, utf8Bytes, *font, sk_sp<SkFontMgr>(fallback)).release();
+}
+
+extern "C" size_t C_SkShaper_BiDiRunIterator_currentLevel(const SkShaper::BiDiRunIterator* self) {
+    return self->currentLevel();
+}
+
+extern "C" SkShaper::BiDiRunIterator* C_SkShaper_MakeIcuBidiRunIterator(const char* utf8, size_t utf8Bytes, uint8_t bidiLevel) {
+    return SkShaper::MakeIcuBiDiRunIterator(utf8, utf8Bytes, bidiLevel).release();
+}
+
+extern "C" SkFourByteTag C_SkShaper_ScriptRunIterator_currentScript(const SkShaper::ScriptRunIterator* self) {
+    return self->currentScript();
+}
+
+extern "C" SkShaper::ScriptRunIterator* C_SkShaper_MakeHbIcuScriptRunIterator(const char* utf8, size_t utf8Bytes) {
+    return SkShaper::MakeHbIcuScriptRunIterator(utf8, utf8Bytes).release();
+}
+
+extern "C" const char* C_SkShaper_LanguageRunIterator_currentLanguage(const SkShaper::LanguageRunIterator* self) {
+    return self->currentLanguage();
+}
+
+extern "C" SkShaper::LanguageRunIterator* C_SkShaper_MakeStdLanguageRunIterator(const char* utf8, size_t utf8Bytes) {
+    return SkShaper::MakeStdLanguageRunIterator(utf8, utf8Bytes).release();
+}
+
+extern "C" void C_SkShaper_RunHandler_delete(SkShaper::RunHandler* self) {
+    delete self;
+}
+
+// TODO: support RunHandler
+
+extern "C" SkTextBlob* C_SkTextBlobBuilderRunHandler_makeBlob(SkTextBlobBuilderRunHandler* self) {
+    return self->makeBlob().release();
+}

--- a/skia-bindings/src/shaper.cpp
+++ b/skia-bindings/src/shaper.cpp
@@ -28,6 +28,10 @@ extern "C" void C_SkShaper_RunIterator_delete(SkShaper::RunIterator* self) {
     delete self;
 }
 
+extern "C" void C_SkShaper_RunIterator_consume(SkShaper::RunIterator* self)  {
+    self->consume();
+}
+
 extern "C" size_t C_SkShaper_RunIterator_endOfCurrentRun(const SkShaper::RunIterator* self) {
     return self->endOfCurrentRun();
 }
@@ -44,7 +48,7 @@ extern "C" SkShaper::FontRunIterator* C_SkShaper_MakeFontMgrRunIterator(const ch
     return SkShaper::MakeFontMgrRunIterator(utf8, utf8Bytes, *font, sk_sp<SkFontMgr>(fallback)).release();
 }
 
-extern "C" size_t C_SkShaper_BiDiRunIterator_currentLevel(const SkShaper::BiDiRunIterator* self) {
+extern "C" uint8_t C_SkShaper_BiDiRunIterator_currentLevel(const SkShaper::BiDiRunIterator* self) {
     return self->currentLevel();
 }
 

--- a/skia-bindings/src/shaper.cpp
+++ b/skia-bindings/src/shaper.cpp
@@ -157,6 +157,14 @@ C_SkShaper_shape2(const SkShaper *self, const char *utf8, size_t utf8Bytes, SkSh
                 runHandler);
 }
 
+extern "C" void C_SkTextBlobBuilderRunHandler_construct(SkTextBlobBuilderRunHandler* uninitialized, const char* utf8Text, const SkPoint* offset) {
+    new(uninitialized)SkTextBlobBuilderRunHandler(utf8Text, *offset);
+}
+
 extern "C" SkTextBlob* C_SkTextBlobBuilderRunHandler_makeBlob(SkTextBlobBuilderRunHandler* self) {
     return self->makeBlob().release();
+}
+
+extern "C" SkPoint C_SkTextBlobBuilderRunHandler_endPoint(SkTextBlobBuilderRunHandler* self) {
+    return self->endPoint();
 }

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 default = []
 vulkan = ["skia-bindings/vulkan"]
 svg = ["skia-bindings/svg"]
+shaper = ["skia-bindings/shaper"]
 
 [dependencies]
 bitflags = "1.0.4"

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/rust-skia/rust-skia"
 repository = "https://github.com/rust-skia/rust-skia"
 license = "MIT"
 
-version = "0.14.0"
+version = "0.14.1"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -19,7 +19,7 @@ shaper = ["skia-bindings/shaper"]
 
 [dependencies]
 bitflags = "1.0.4"
-skia-bindings = { version = "0.14.0", path = "../skia-bindings" }
+skia-bindings = { version = "0.14.1", path = "../skia-bindings" }
 # TODO: 1.3 breaks offscreen_gl_context
 lazy_static = "=1.2"
 

--- a/skia-safe/examples/skia-org/main.rs
+++ b/skia-safe/examples/skia-org/main.rs
@@ -21,6 +21,8 @@ mod drivers;
 mod skcanvas_overview;
 mod skpaint_overview;
 mod skpath_overview;
+#[cfg(feature = "shaper")]
+mod skshaper_example;
 
 pub(crate) mod artifact {
     use skia_safe::gpu;
@@ -304,6 +306,9 @@ fn main() {
         skcanvas_overview::draw::<Driver>(&out_path);
         skpath_overview::draw::<Driver>(&out_path);
         skpaint_overview::draw::<Driver>(&out_path);
+
+        #[cfg(feature = "shaper")]
+        skshaper_example::draw::<Driver>(&out_path);
     }
 }
 

--- a/skia-safe/examples/skia-org/skshaper_example.rs
+++ b/skia-safe/examples/skia-org/skshaper_example.rs
@@ -1,0 +1,43 @@
+use crate::artifact::DrawingDriver;
+use skia_safe::{icu, Canvas, Font, Paint, Point, Shaper, Typeface};
+use std::path::PathBuf;
+
+pub fn draw<Driver: DrawingDriver>(path: &PathBuf) {
+    let path = path.join("SkShaper-Example");
+
+    icu::init();
+
+    Driver::draw_image_256(&path, "rtl-shaped", draw_rtl_shaped);
+    Driver::draw_image_256(&path, "rtl-unshaped", draw_rtl_unshaped);
+}
+
+const RTL_TEXT: &str = "العربية";
+const TEXT_POS: Point = Point::new(0.0, 64.0);
+
+fn draw_rtl_shaped(canvas: &mut Canvas) {
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+
+    let font = &Font::from_typeface(&Typeface::default(), 64.0);
+
+    let shaper = Shaper::new();
+    if let Some((blob, _)) =
+        shaper.shape_text_blob(RTL_TEXT, font, false, 10000.0, Point::default())
+    {
+        canvas.draw_text_blob(&blob, TEXT_POS, &paint)
+    }
+}
+
+fn draw_rtl_unshaped(canvas: &mut Canvas) {
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+
+    let font = &Font::from_typeface(&Typeface::default(), 64.0);
+
+    let shaper = Shaper::new_primitive();
+    if let Some((blob, _)) =
+        shaper.shape_text_blob(RTL_TEXT, font, false, 10000.0, Point::default())
+    {
+        canvas.draw_text_blob(&blob, TEXT_POS, &paint)
+    }
+}

--- a/skia-safe/src/core/point.rs
+++ b/skia-safe/src/core/point.rs
@@ -82,7 +82,7 @@ impl SubAssign<ISize> for IPoint {
 }
 
 impl IPoint {
-    pub fn new(x: i32, y: i32) -> IPoint {
+    pub const fn new(x: i32, y: i32) -> Self {
         IPoint { x, y }
     }
 
@@ -195,7 +195,7 @@ impl MulAssign<scalar> for Point {
 }
 
 impl Point {
-    pub fn new(x: scalar, y: scalar) -> Self {
+    pub const fn new(x: scalar, y: scalar) -> Self {
         Self { x, y }
     }
 

--- a/skia-safe/src/core/point3.rs
+++ b/skia-safe/src/core/point3.rs
@@ -61,7 +61,7 @@ impl SubAssign for Point3 {
 }
 
 impl Point3 {
-    pub fn new(x: scalar, y: scalar, z: scalar) -> Self {
+    pub const fn new(x: scalar, y: scalar, z: scalar) -> Self {
         Self { x, y, z }
     }
 

--- a/skia-safe/src/core/size.rs
+++ b/skia-safe/src/core/size.rs
@@ -17,7 +17,7 @@ fn test_isize_layout() {
 }
 
 impl ISize {
-    pub fn new(w: i32, h: i32) -> ISize {
+    pub const fn new(w: i32, h: i32) -> ISize {
         ISize {
             width: w,
             height: h,
@@ -66,7 +66,7 @@ fn test_size_layout() {
 }
 
 impl Size {
-    pub fn new(w: scalar, h: scalar) -> Size {
+    pub const fn new(w: scalar, h: scalar) -> Size {
         Size {
             width: w,
             height: h,

--- a/skia-safe/src/lib.rs
+++ b/skia-safe/src/lib.rs
@@ -4,6 +4,7 @@ mod docs;
 mod effects;
 pub mod gpu;
 mod interop;
+mod modules;
 mod pathops;
 mod prelude;
 #[cfg(feature = "svg")]
@@ -24,6 +25,7 @@ pub use crate::codec::*;
 pub use crate::core::*;
 pub use crate::docs::*;
 pub use crate::effects::*;
+pub use crate::modules::*;
 pub use crate::pathops::*;
 
 #[cfg(test)]

--- a/skia-safe/src/modules.rs
+++ b/skia-safe/src/modules.rs
@@ -1,0 +1,2 @@
+pub mod shaper;
+pub use shaper::Shaper;

--- a/skia-safe/src/modules.rs
+++ b/skia-safe/src/modules.rs
@@ -1,4 +1,4 @@
 #[cfg(feature = "shaper")]
 pub mod shaper;
 #[cfg(feature = "shaper")]
-pub use shaper::Shaper;
+pub use shaper::{icu, Shaper};

--- a/skia-safe/src/modules.rs
+++ b/skia-safe/src/modules.rs
@@ -1,2 +1,4 @@
+#[cfg(feature = "shaper")]
 pub mod shaper;
+#[cfg(feature = "shaper")]
 pub use shaper::Shaper;

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -422,8 +422,7 @@ impl Shaper {
         let bytes = utf8.as_ref().as_bytes();
 
         unsafe {
-            let mut run_handler = mem::zeroed();
-            C_RustRunHandler_construct(&mut run_handler, &param);
+            let mut run_handler = construct(|rh| C_RustRunHandler_construct(rh, &param));
 
             C_SkShaper_shape(
                 self.native(),
@@ -459,10 +458,9 @@ impl TextBlobBuilderRunHandler {
         TextBlobBuilderRunHandler(c_string, unsafe {
             SkTextBlobBuilderRunHandler::new(ptr, offset.into().into_native())
         }) */
-        let mut run_handler = unsafe { mem::zeroed() };
-        unsafe {
-            C_SkTextBlobBuilderRunHandler_construct(&mut run_handler, ptr, offset.into().native())
-        };
+        let run_handler = construct(|rh| unsafe {
+            C_SkTextBlobBuilderRunHandler_construct(rh, ptr, offset.into().native())
+        });
         TextBlobBuilderRunHandler(c_string, run_handler)
     }
 

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -37,6 +37,12 @@ impl Drop for Shaper {
     }
 }
 
+impl Default for Shaper {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Shaper {
     pub fn new_primitive() -> Self {
         unsafe { C_SkShaper_MakePrimitive() }
@@ -126,7 +132,7 @@ impl FontRunIterator {
 }
 
 impl Shaper {
-    pub fn new_font_mgr_run_iterator<'a>(
+    pub fn new_font_mgr_run_iterator(
         utf8: &str,
         font: &Font,
         mut fallback: Option<&mut FontMgr>,

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::shaper::run_handler::RunInfo;
-use crate::{scalar, Font, FontMgr, FourByteTag, Point, TextBlob, Vector};
+use crate::{scalar, Font, FontMgr, FourByteTag};
 pub use run_handler::RunHandler;
 use skia_bindings::{
     C_RustRunHandler_construct, C_SkShaper_BiDiRunIterator_currentLevel,
@@ -10,10 +10,10 @@ use skia_bindings::{
     C_SkShaper_MakeShaperDrivenWrapper, C_SkShaper_MakeStdLanguageRunIterator,
     C_SkShaper_RunIterator_atEnd, C_SkShaper_RunIterator_consume, C_SkShaper_RunIterator_delete,
     C_SkShaper_RunIterator_endOfCurrentRun, C_SkShaper_ScriptRunIterator_currentScript,
-    C_SkShaper_delete, C_SkShaper_shape, C_SkTextBlobBuilderRunHandler_makeBlob, RustRunHandler,
-    RustRunHandler_Param, SkShaper, SkShaper_BiDiRunIterator, SkShaper_FontRunIterator,
-    SkShaper_LanguageRunIterator, SkShaper_RunHandler_Buffer, SkShaper_RunHandler_RunInfo,
-    SkShaper_RunIterator, SkShaper_ScriptRunIterator, SkTextBlobBuilderRunHandler, TraitObject,
+    C_SkShaper_delete, C_SkShaper_shape, RustRunHandler_Param, SkShaper, SkShaper_BiDiRunIterator,
+    SkShaper_FontRunIterator, SkShaper_LanguageRunIterator, SkShaper_RunHandler_Buffer,
+    SkShaper_RunHandler_RunInfo, SkShaper_RunIterator, SkShaper_ScriptRunIterator,
+    SkTextBlobBuilderRunHandler, TraitObject,
 };
 use std::ffi::{CStr, CString};
 use std::mem;

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -535,7 +535,7 @@ mod tests {
     fn test_rtl_text_shaping() {
         skia_bindings::icu::init();
 
-        let shaper = Shaper::new().unwrap();
+        let shaper = Shaper::new();
         shaper.shape(
             "العربية",
             &Font::default(),
@@ -544,5 +544,4 @@ mod tests {
             &mut DebugRunHandler::default(),
         );
     }
-
 }

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -294,22 +294,6 @@ mod run_handler {
         fn commit_line(&mut self);
     }
 
-    /*
-        #[repr(C)]
-        #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default, Debug)]
-        pub struct Range {
-            begin: usize,
-            size: usize,
-        }
-
-    impl NativeTransmutable<SkShaper_RunHandler_Range> for Range {}
-
-    #[test]
-    fn test_range_layout() {
-        Range::test_layout();
-    }
-    */
-
     pub struct RunInfo<'a> {
         pub font: &'a Font,
         pub bidi_level: u8,

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -527,6 +527,8 @@ mod tests {
 
     #[test]
     fn test_rtl_text_shaping() {
+        skia_bindings::icu::init();
+
         let shaper = Shaper::new_shape_then_wrap().unwrap();
         shaper.shape(
             "العربية",
@@ -536,4 +538,5 @@ mod tests {
             &mut DebugRunHandler::default(),
         );
     }
+
 }

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -535,7 +535,7 @@ mod tests {
     fn test_rtl_text_shaping() {
         skia_bindings::icu::init();
 
-        let shaper = Shaper::new_shape_then_wrap().unwrap();
+        let shaper = Shaper::new().unwrap();
         shaper.shape(
             "العربية",
             &Font::default(),

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -1,0 +1,271 @@
+//! TODO: Implement iterator traits if possible.
+use crate::prelude::*;
+use crate::{Font, FontMgr, FourByteTag};
+use skia_bindings::{
+    C_SkShaper_BiDiRunIterator_currentLevel, C_SkShaper_FontRunIterator_currentFont,
+    C_SkShaper_LanguageRunIterator_currentLanguage, C_SkShaper_Make,
+    C_SkShaper_MakeFontMgrRunIterator, C_SkShaper_MakeHbIcuScriptRunIterator,
+    C_SkShaper_MakeIcuBidiRunIterator, C_SkShaper_MakePrimitive, C_SkShaper_MakeShapeThenWrap,
+    C_SkShaper_MakeShaperDrivenWrapper, C_SkShaper_MakeStdLanguageRunIterator,
+    C_SkShaper_RunIterator_atEnd, C_SkShaper_RunIterator_consume, C_SkShaper_RunIterator_delete,
+    C_SkShaper_RunIterator_endOfCurrentRun, C_SkShaper_ScriptRunIterator_currentScript,
+    C_SkShaper_delete, SkShaper, SkShaper_BiDiRunIterator, SkShaper_FontRunIterator,
+    SkShaper_LanguageRunIterator, SkShaper_RunIterator, SkShaper_ScriptRunIterator,
+};
+use std::ffi::CStr;
+
+pub struct Shaper(*mut SkShaper);
+
+impl NativeAccess<SkShaper> for Shaper {
+    fn native(&self) -> &SkShaper {
+        unsafe { &*self.0 }
+    }
+
+    fn native_mut(&mut self) -> &mut SkShaper {
+        unsafe { &mut *self.0 }
+    }
+}
+
+impl Drop for Shaper {
+    fn drop(&mut self) {
+        unsafe { C_SkShaper_delete(self.0) }
+    }
+}
+
+impl Shaper {
+    pub fn new_primitive() -> Self {
+        unsafe { C_SkShaper_MakePrimitive() }
+            .to_option()
+            .map(Shaper)
+            .unwrap()
+    }
+
+    pub fn new_shaper_driven_wrapper() -> Option<Self> {
+        unsafe { C_SkShaper_MakeShaperDrivenWrapper() }
+            .to_option()
+            .map(Shaper)
+    }
+
+    pub fn new_shape_then_wrap() -> Option<Self> {
+        unsafe { C_SkShaper_MakeShapeThenWrap() }
+            .to_option()
+            .map(Shaper)
+    }
+
+    pub fn new() -> Self {
+        unsafe { C_SkShaper_Make() }
+            .to_option()
+            .map(Shaper)
+            .unwrap()
+    }
+}
+
+pub trait RunIteratorNativeAccess {
+    fn access_run_iterator(&self) -> &SkShaper_RunIterator;
+    fn access_run_iterator_mut(&mut self) -> &mut SkShaper_RunIterator;
+}
+
+pub trait RunIterator {
+    fn consume(&mut self);
+    fn end_of_current_run(&self) -> usize;
+    fn at_end(&self) -> bool;
+}
+
+impl<T> RunIterator for T
+where
+    T: RunIteratorNativeAccess,
+{
+    fn consume(&mut self) {
+        unsafe { C_SkShaper_RunIterator_consume(self.access_run_iterator_mut()) }
+    }
+
+    fn end_of_current_run(&self) -> usize {
+        unsafe { C_SkShaper_RunIterator_endOfCurrentRun(self.access_run_iterator()) }
+    }
+
+    fn at_end(&self) -> bool {
+        unsafe { C_SkShaper_RunIterator_atEnd(self.access_run_iterator()) }
+    }
+}
+
+pub struct FontRunIterator(*mut SkShaper_FontRunIterator);
+
+impl Drop for FontRunIterator {
+    fn drop(&mut self) {
+        unsafe { C_SkShaper_RunIterator_delete(self.access_run_iterator_mut()) }
+    }
+}
+
+impl NativeAccess<SkShaper_FontRunIterator> for FontRunIterator {
+    fn native(&self) -> &SkShaper_FontRunIterator {
+        unsafe { &*self.0 }
+    }
+    fn native_mut(&mut self) -> &mut SkShaper_FontRunIterator {
+        unsafe { &mut *self.0 }
+    }
+}
+
+impl RunIteratorNativeAccess for FontRunIterator {
+    fn access_run_iterator(&self) -> &SkShaper_RunIterator {
+        &self.native()._base
+    }
+    fn access_run_iterator_mut(&mut self) -> &mut SkShaper_RunIterator {
+        &mut self.native_mut()._base
+    }
+}
+
+impl FontRunIterator {
+    pub fn current_font(&self) -> &Font {
+        Font::from_native_ref(unsafe { &*C_SkShaper_FontRunIterator_currentFont(self.native()) })
+    }
+}
+
+impl Shaper {
+    pub fn new_font_mgr_run_iterator<'a>(
+        utf8: &str,
+        font: &Font,
+        mut fallback: Option<&mut FontMgr>,
+    ) -> FontRunIterator {
+        let bytes = utf8.as_bytes();
+        FontRunIterator(unsafe {
+            C_SkShaper_MakeFontMgrRunIterator(
+                bytes.as_ptr() as _,
+                bytes.len(),
+                font.native(),
+                fallback.shared_ptr_mut(),
+            )
+        })
+    }
+}
+
+pub struct BiDiRunIterator(*mut SkShaper_BiDiRunIterator);
+
+impl Drop for BiDiRunIterator {
+    fn drop(&mut self) {
+        unsafe { C_SkShaper_RunIterator_delete(self.access_run_iterator_mut()) }
+    }
+}
+
+impl NativeAccess<SkShaper_BiDiRunIterator> for BiDiRunIterator {
+    fn native(&self) -> &SkShaper_BiDiRunIterator {
+        unsafe { &*self.0 }
+    }
+    fn native_mut(&mut self) -> &mut SkShaper_BiDiRunIterator {
+        unsafe { &mut *self.0 }
+    }
+}
+
+impl RunIteratorNativeAccess for BiDiRunIterator {
+    fn access_run_iterator(&self) -> &SkShaper_RunIterator {
+        &self.native()._base
+    }
+    fn access_run_iterator_mut(&mut self) -> &mut SkShaper_RunIterator {
+        &mut self.native_mut()._base
+    }
+}
+
+impl BiDiRunIterator {
+    pub fn current_level(&self) -> u8 {
+        unsafe { C_SkShaper_BiDiRunIterator_currentLevel(self.native()) }
+    }
+}
+
+impl Shaper {
+    pub fn new_icu_bidi_run_iterator(utf8: &str, level: u8) -> Option<BiDiRunIterator> {
+        let bytes = utf8.as_bytes();
+        unsafe { C_SkShaper_MakeIcuBidiRunIterator(bytes.as_ptr() as _, bytes.len(), level) }
+            .to_option()
+            .map(BiDiRunIterator)
+    }
+}
+
+pub struct ScriptRunIterator(*mut SkShaper_ScriptRunIterator);
+
+impl Drop for ScriptRunIterator {
+    fn drop(&mut self) {
+        unsafe { C_SkShaper_RunIterator_delete(self.access_run_iterator_mut()) }
+    }
+}
+
+impl NativeAccess<SkShaper_ScriptRunIterator> for ScriptRunIterator {
+    fn native(&self) -> &SkShaper_ScriptRunIterator {
+        unsafe { &*self.0 }
+    }
+    fn native_mut(&mut self) -> &mut SkShaper_ScriptRunIterator {
+        unsafe { &mut *self.0 }
+    }
+}
+
+impl RunIteratorNativeAccess for ScriptRunIterator {
+    fn access_run_iterator(&self) -> &SkShaper_RunIterator {
+        &self.native()._base
+    }
+    fn access_run_iterator_mut(&mut self) -> &mut SkShaper_RunIterator {
+        &mut self.native_mut()._base
+    }
+}
+
+impl ScriptRunIterator {
+    pub fn current_script(&self) -> FourByteTag {
+        FourByteTag::from_native(unsafe {
+            C_SkShaper_ScriptRunIterator_currentScript(self.native())
+        })
+    }
+}
+
+impl Shaper {
+    pub fn new_hb_icu_script_run_iterator(utf8: &str) -> ScriptRunIterator {
+        let bytes = utf8.as_bytes();
+        unsafe { C_SkShaper_MakeHbIcuScriptRunIterator(bytes.as_ptr() as _, bytes.len()) }
+            .to_option()
+            .map(ScriptRunIterator)
+            .unwrap()
+    }
+}
+
+pub struct LanguageRunIterator(*mut SkShaper_LanguageRunIterator);
+
+impl Drop for LanguageRunIterator {
+    fn drop(&mut self) {
+        unsafe { C_SkShaper_RunIterator_delete(self.access_run_iterator_mut()) }
+    }
+}
+
+impl NativeAccess<SkShaper_LanguageRunIterator> for LanguageRunIterator {
+    fn native(&self) -> &SkShaper_LanguageRunIterator {
+        unsafe { &*self.0 }
+    }
+    fn native_mut(&mut self) -> &mut SkShaper_LanguageRunIterator {
+        unsafe { &mut *self.0 }
+    }
+}
+
+impl RunIteratorNativeAccess for LanguageRunIterator {
+    fn access_run_iterator(&self) -> &SkShaper_RunIterator {
+        &self.native()._base
+    }
+    fn access_run_iterator_mut(&mut self) -> &mut SkShaper_RunIterator {
+        &mut self.native_mut()._base
+    }
+}
+
+impl LanguageRunIterator {
+    pub fn current_language(&self) -> &CStr {
+        unsafe {
+            CStr::from_ptr(C_SkShaper_LanguageRunIterator_currentLanguage(
+                self.native(),
+            ))
+        }
+    }
+}
+
+impl Shaper {
+    pub fn new_std_language_run_iterator(utf8: &str) -> Option<LanguageRunIterator> {
+        let bytes = utf8.as_bytes();
+        unsafe { C_SkShaper_MakeStdLanguageRunIterator(bytes.as_ptr() as _, bytes.len()) }
+            .to_option()
+            .map(LanguageRunIterator)
+    }
+}
+
+// TODO: RunHandler


### PR DESCRIPTION
This PR attempts to wrap Skia's text shaping support.

TODO:

- [x] Compiles on Windows, macOS, and Linux.
- [x] Wrap SkShaper.h
- [x] Add an example.
- [x] Update readme ([rendered](https://github.com/rust-skia/rust-skia/blob/text-shaping/README.md)).
- [x] Bump Versions (14.1).