### PR TITLE
have Typeface::from_data return the constructed instance

### DIFF
--- a/skia-safe/src/core/typeface.rs
+++ b/skia-safe/src/core/typeface.rs
@@ -131,13 +131,13 @@ impl RCHandle<SkTypeface> {
 
     // TODO: MakeFromStream()?
 
-    pub fn from_data(data: &Data, index: impl Into<Option<usize>>) {
+    pub fn from_data(data: &Data, index: impl Into<Option<usize>>) -> Typeface {
         Typeface::from_ptr(unsafe {
             C_SkTypeface_MakeFromData(
                 data.shared_native(),
                 index.into().unwrap_or_default().try_into().unwrap(),
             )
-        });
+        })
     }
 
     pub fn clone_with_arguments(&self, arguments: &FontArguments) -> Option<Typeface> {

--- a/skia-safe/src/core/typeface.rs
+++ b/skia-safe/src/core/typeface.rs
@@ -131,7 +131,7 @@ impl RCHandle<SkTypeface> {
 
     // TODO: MakeFromStream()?
 
-    pub fn from_data(data: &Data, index: impl Into<Option<usize>>) -> Typeface {
+    pub fn from_data(data: &Data, index: impl Into<Option<usize>>) -> Option<Typeface> {
         Typeface::from_ptr(unsafe {
             C_SkTypeface_MakeFromData(
                 data.shared_native(),


### PR DESCRIPTION
I don't see why it shouldn't...