### PR TITLE
Modernize native object initializations.

### DIFF
--- a/skia-safe/src/core/bitmap.rs
+++ b/skia-safe/src/core/bitmap.rs
@@ -30,7 +30,7 @@ impl NativeClone for SkBitmap {
 
 impl Handle<SkBitmap> {
     pub fn new() -> Self {
-        Self::construct_c(C_SkBitmap_Construct)
+        Self::construct(|bitmap| unsafe { C_SkBitmap_Construct(bitmap) })
     }
 
     pub fn swap(&mut self, other: &mut Self) {

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -19,7 +19,7 @@ use std::convert::TryInto;
 use std::ffi::CString;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
-use std::{mem, slice};
+use std::slice;
 
 pub use lattice::Lattice;
 
@@ -1211,13 +1211,11 @@ impl AutoCanvasRestore {
     // Note: Can't use AsMut here for the canvas, because it would break
     //       the lifetime dependency.
     pub fn guard(canvas: &mut Canvas, do_save: bool) -> AutoRestoredCanvas {
-        let restore = unsafe {
-            // does not link on Linux
-            // SkAutoCanvasRestore::new(canvas.native_mut(), do_save)
-            let mut acr: SkAutoCanvasRestore = mem::zeroed();
-            C_SkAutoCanvasRestore_Construct(&mut acr, canvas.native_mut(), do_save);
-            acr
-        };
+        // does not link on Linux
+        // SkAutoCanvasRestore::new(canvas.native_mut(), do_save)
+        let restore = construct(|acr| unsafe {
+            C_SkAutoCanvasRestore_Construct(acr, canvas.native_mut(), do_save)
+        });
 
         AutoRestoredCanvas { canvas, restore }
     }

--- a/skia-safe/src/core/font.rs
+++ b/skia-safe/src/core/font.rs
@@ -8,7 +8,7 @@ use skia_bindings::{
     C_SkFont_ConstructFromTypefaceWithSizeScaleAndSkew, C_SkFont_Equals, C_SkFont_destruct,
     C_SkFont_makeWithSize, C_SkFont_setTypeface, SkFont, SkFont_Edging,
 };
-use std::{mem, ptr};
+use std::ptr;
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
@@ -431,9 +431,10 @@ impl Handle<SkFont> {
     // TODO: getPaths() (needs a function to be passed, but supports a context).
 
     pub fn metrics(&self) -> (scalar, FontMetrics) {
-        let mut fm = unsafe { mem::zeroed() };
-        let line_spacing = unsafe { self.native().getMetrics(&mut fm) };
-        (line_spacing, FontMetrics::from_native(fm))
+        let mut line_spacing = 0.0;
+        let fm =
+            FontMetrics::construct(|fm| line_spacing = unsafe { self.native().getMetrics(fm) });
+        (line_spacing, fm)
     }
 
     pub fn spacing(&self) -> scalar {

--- a/skia-safe/src/core/font_arguments.rs
+++ b/skia-safe/src/core/font_arguments.rs
@@ -58,12 +58,10 @@ impl<'a> Default for FontArguments<'a> {
 
 impl<'a> FontArguments<'a> {
     pub fn new() -> Self {
-        Self::from_native(unsafe {
-            // does not link under Linux / macOS
-            // SkFontArguments::new()
-            let mut font_arguments = mem::zeroed();
-            C_SkFontArguments_construct(&mut font_arguments);
-            font_arguments
+        // does not link under Linux / macOS
+        // SkFontArguments::new()
+        Self::construct(|fa| unsafe {
+            C_SkFontArguments_construct(fa);
         })
     }
 

--- a/skia-safe/src/core/font_style.rs
+++ b/skia-safe/src/core/font_style.rs
@@ -3,7 +3,6 @@ use skia_bindings::{
     C_SkFontStyle_Construct, C_SkFontStyle_Equals, SkFontStyle, SkFontStyle_Slant,
     SkFontStyle_Weight, SkFontStyle_Width,
 };
-use std::mem;
 use std::ops::Deref;
 
 /// Wrapper type of a font weight.
@@ -168,11 +167,7 @@ impl Default for FontStyle {
     fn default() -> Self {
         // does not link under Linux:
         // unsafe { SkFontStyle::new1() }
-        FontStyle::from_native(unsafe {
-            let mut font_style = mem::uninitialized();
-            C_SkFontStyle_Construct(&mut font_style);
-            font_style
-        })
+        FontStyle::construct(|fs| unsafe { C_SkFontStyle_Construct(fs) })
     }
 }
 

--- a/skia-safe/src/core/image_info.rs
+++ b/skia-safe/src/core/image_info.rs
@@ -138,7 +138,7 @@ impl NativePartialEq for SkImageInfo {
 impl Default for Handle<SkImageInfo> {
     fn default() -> Self {
         // note SkImageInfo::new() does not link under Linux.
-        Self::construct_c(C_SkImageInfo_Construct)
+        Self::construct(|image_info| unsafe { C_SkImageInfo_Construct(image_info) })
     }
 }
 

--- a/skia-safe/src/core/image_info.rs
+++ b/skia-safe/src/core/image_info.rs
@@ -5,7 +5,6 @@ use skia_bindings::{
     C_SkImageInfo_gammaCloseToSRGB, C_SkImageInfo_reset, SkAlphaType, SkColorType, SkImageInfo,
     SkYUVColorSpace,
 };
-use std::mem;
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
@@ -120,12 +119,12 @@ impl NativeDrop for SkImageInfo {
 
 impl NativeClone for SkImageInfo {
     fn clone(&self) -> Self {
+        // SkImageInfo::new() does not link under Linux.
         unsafe {
-            let mut image_info = mem::zeroed();
-            // note SkImageInfo::new() does not link under Linux.
-            C_SkImageInfo_Construct(&mut image_info);
-            C_SkImageInfo_Copy(self, &mut image_info);
-            image_info
+            construct(|image_info| {
+                C_SkImageInfo_Construct(image_info);
+                C_SkImageInfo_Copy(self, image_info);
+            })
         }
     }
 }

--- a/skia-safe/src/core/matrix44.rs
+++ b/skia-safe/src/core/matrix44.rs
@@ -4,7 +4,7 @@ use skia_bindings::{
     C_SkMatrix44_ConstructIdentity, C_SkMatrix44_Equals, C_SkMatrix44_Mul, C_SkMatrix44_MulV4,
     C_SkMatrix44_SkMatrix, SkMatrix44, SkVector4,
 };
-use std::{mem, ops};
+use std::ops;
 
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -136,10 +136,8 @@ impl Matrix44 {
     pub const COLUMNS: usize = 4;
 
     pub fn new_identity() -> Self {
-        Matrix44::from_native(unsafe {
-            let mut matrix: SkMatrix44 = mem::zeroed();
-            C_SkMatrix44_ConstructIdentity(&mut matrix);
-            matrix
+        Matrix44::construct(|matrix| unsafe {
+            C_SkMatrix44_ConstructIdentity(matrix);
         })
     }
 

--- a/skia-safe/src/core/path_effect.rs
+++ b/skia-safe/src/core/path_effect.rs
@@ -7,7 +7,7 @@ use skia_bindings::{
     SkRefCntBase,
 };
 use std::os::raw;
-use std::{mem, slice};
+use std::slice;
 
 #[repr(C)]
 pub struct PointData {
@@ -44,13 +44,9 @@ impl Drop for PointData {
 
 impl Default for PointData {
     fn default() -> Self {
-        PointData::from_native(unsafe {
-            // does not link under Linux:
-            // SkPathEffect_PointData::new()
-            let mut point_data = mem::uninitialized();
-            C_SkPathEffect_PointData_Construct(&mut point_data);
-            point_data
-        })
+        // does not link under Linux:
+        // SkPathEffect_PointData::new()
+        PointData::construct(|point_data| unsafe { C_SkPathEffect_PointData_Construct(point_data) })
     }
 }
 

--- a/skia-safe/src/core/region.rs
+++ b/skia-safe/src/core/region.rs
@@ -355,12 +355,10 @@ fn test_iterator_layout() {
 
 impl<'a> Iterator<'a> {
     pub fn new_empty() -> Iterator<'a> {
-        Iterator::from_native(unsafe {
-            // does not link:
-            // SkRegion_Iterator::new()
-            let mut iterator = mem::zeroed();
-            C_SkRegion_Iterator_Construct(&mut iterator);
-            iterator
+        // does not link:
+        // SkRegion_Iterator::new()
+        Iterator::construct(|iterator| unsafe {
+            C_SkRegion_Iterator_Construct(iterator);
         })
     }
 

--- a/skia-safe/src/core/shader.rs
+++ b/skia-safe/src/core/shader.rs
@@ -83,7 +83,7 @@ impl RCHandle<SkShader> {
     pub fn image(&self) -> Option<(Image, Matrix, (TileMode, TileMode))> {
         unsafe {
             let mut matrix = Matrix::default();
-            let mut tile_mode: [TileMode; 2] = mem::zeroed();
+            let mut tile_mode = [TileMode::default(); 2];
             let image = Image::from_unshared_ptr(
                 self.native()
                     .isAImage(matrix.native_mut(), tile_mode.native_mut().as_mut_ptr()),

--- a/skia-safe/src/docs/pdf_document.rs
+++ b/skia-safe/src/docs/pdf_document.rs
@@ -77,7 +77,7 @@ pub mod pdf {
 
     impl Default for Handle<SkPDF_Metadata> {
         fn default() -> Self {
-            Self::construct_c(C_SkPDF_Metadata_Construct)
+            Self::construct(|pdf_md| unsafe { C_SkPDF_Metadata_Construct(pdf_md) })
         }
     }
 

--- a/skia-safe/src/effects/color_matrix.rs
+++ b/skia-safe/src/effects/color_matrix.rs
@@ -3,7 +3,6 @@ use skia_bindings::{
     C_SkColorMatrix_equals, C_SkColorMatrix_get20, C_SkColorMatrix_set20, SkColorMatrix,
     SkColorMatrix_Axis,
 };
-use std::mem;
 
 pub type ColorMatrix = Handle<SkColorMatrix>;
 
@@ -19,11 +18,7 @@ impl NativePartialEq for SkColorMatrix {
 
 impl Default for Handle<SkColorMatrix> {
     fn default() -> Self {
-        unsafe {
-            let mut matrix = ColorMatrix::from_native(mem::zeroed());
-            matrix.set_identity();
-            matrix
-        }
+        ColorMatrix::construct(|cm| unsafe { (*cm).setIdentity() })
     }
 }
 

--- a/skia-safe/src/gpu/backend_drawable_info.rs
+++ b/skia-safe/src/gpu/backend_drawable_info.rs
@@ -20,11 +20,7 @@ impl Handle<GrBackendDrawableInfo> {
     pub fn new() -> BackendDrawableInfo {
         // does not link:
         // Self::from_native(unsafe { GrBackendDrawableInfo::new() })
-        Self::from_native(unsafe {
-            let mut di = mem::zeroed();
-            C_GrBackendDrawableInfo_construct(&mut di);
-            di
-        })
+        Self::construct(|di| unsafe { C_GrBackendDrawableInfo_construct(di) })
     }
 
     #[cfg(feature = "vulkan")]

--- a/skia-safe/src/gpu/backend_drawable_info.rs
+++ b/skia-safe/src/gpu/backend_drawable_info.rs
@@ -6,7 +6,6 @@ use skia_bindings::{
     C_GrBackendDrawableInfo_backend, C_GrBackendDrawableInfo_construct,
     C_GrBackendDrawableInfo_destruct, C_GrBackendDrawableInfo_isValid, GrBackendDrawableInfo,
 };
-use std::mem;
 
 pub type BackendDrawableInfo = Handle<GrBackendDrawableInfo>;
 
@@ -42,6 +41,7 @@ impl Handle<GrBackendDrawableInfo> {
 
     #[cfg(feature = "vulkan")]
     pub fn get_vk_drawable_info(&self) -> Option<vk::DrawableInfo> {
+        use std::mem;
         unsafe {
             let mut di: vk::DrawableInfo = mem::zeroed();
             skia_bindings::C_GrBackendDrawableInfo_getVkDrawableInfo(self.native(), di.native_mut())

--- a/skia-safe/src/gpu/vk/types.rs
+++ b/skia-safe/src/gpu/vk/types.rs
@@ -107,7 +107,7 @@ impl YcbcrConversionInfo {
         x_chroma_offset: ChromaLocation,
         y_chroma_offset: ChromaLocation,
         chroma_filter: Filter,
-        force_explicit_reconsturction: Bool32,
+        force_explicit_reconstruction: Bool32,
         external_format: u64,
         external_format_features: FomatFeatureFlags,
     ) -> YcbcrConversionInfo {
@@ -132,7 +132,7 @@ impl YcbcrConversionInfo {
                 x_chroma_offset,
                 y_chroma_offset,
                 chroma_filter,
-                force_explicit_reconsturction,
+                force_explicit_reconstruction,
                 external_format,
                 external_format_features,
             )

--- a/skia-safe/src/interop/stream.rs
+++ b/skia-safe/src/interop/stream.rs
@@ -99,7 +99,7 @@ impl NativeDrop for SkDynamicMemoryWStream {
 
 impl Handle<SkDynamicMemoryWStream> {
     pub fn new() -> Self {
-        Self::construct_c(C_SkDynamicMemoryWStream_Construct)
+        Self::construct(|dmws| unsafe { C_SkDynamicMemoryWStream_Construct(dmws) })
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Self {

--- a/skia-safe/src/pathops.rs
+++ b/skia-safe/src/pathops.rs
@@ -62,7 +62,7 @@ impl NativeDrop for SkOpBuilder {
 
 impl Default for Handle<SkOpBuilder> {
     fn default() -> Self {
-        Self::construct_c(C_SkOpBuilder_Construct)
+        Self::construct(|opb| unsafe { C_SkOpBuilder_Construct(opb) })
     }
 }
 

--- a/skia-safe/src/prelude.rs
+++ b/skia-safe/src/prelude.rs
@@ -256,13 +256,9 @@ impl<N: NativeDrop> Handle<N> {
         unsafe { transmute_ref(n) }
     }
 
-    /// Constructs a C++ object in place by calling an
-    /// extern "C" function that expects a pointer that points to
-    /// zeroed memory of the native type.
-    pub fn construct_c(construct: unsafe extern "C" fn(*mut N) -> ()) -> Self {
-        Self::construct(|instance| unsafe { construct(instance) })
-    }
-
+    /// Constructs a C++ object in place by calling a
+    /// function that expects a pointer that points to
+    /// uninitialized memory of the native type.
     pub fn construct(construct: impl FnOnce(*mut N)) -> Self {
         Self::from_native(self::construct(construct))
     }


### PR DESCRIPTION
This PR replaces all uses of `mem::uninitialized` with `mem::MaybeUninit` and also removes most invocations of `mem::zeroed()` along the way.