### PR TITLE
Use curl instead of reqwest to reduce the number of packages to build from 229 to 108.

### DIFF
--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -29,7 +29,7 @@ cc = "1.0.35"
 bindgen = "=0.51.0"
 
 # for downloading and extracting prebuilt binaries:
-reqwest = "0.9.16"
+curl = "0.4.22"
 flate2 = "1.0.7"
 tar = "0.4.24"
 

--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -106,7 +106,7 @@ fn should_try_download_binaries(config: &skia::BinariesConfiguration) -> Option<
 }
 
 fn download_and_install(url: impl AsRef<str>, output_directory: &Path) -> io::Result<()> {
-    let archive = binaries::begin_download(url)?;
+    let archive = binaries::download(url)?;
     println!(
         "UNPACKING ARCHIVE INTO: {}",
         output_directory.to_str().unwrap()

--- a/skia-bindings/build_support/binaries.rs
+++ b/skia-bindings/build_support/binaries.rs
@@ -63,6 +63,7 @@ pub fn download(url: impl AsRef<str>) -> io::Result<impl Read> {
     let mut data = Vec::new();
     let mut handle = Easy::new();
     handle.url(url.as_ref()).unwrap();
+    handle.fail_on_error(true).unwrap();
     let curl_result = {
         let mut transfer = handle.transfer();
         transfer


### PR DESCRIPTION
Just noticed that the reqwest crate pulls in _a lot_ of stuff for the HTTPs download function that is used for downloading prebuilt binaries in skia-bindings.

This PR uses the curl crate instead of the reqwest crate reducing the packages to build from 229 to 108. This also reduces full build times by about 5% compared to the current master.
