### PR TITLE
Probe for Python 2 executables and use the full path for the Skia build.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To see which version of LLVM/Clang is available, use `clang --version`.
 
 We recommend version 8, but also had successes to build Skia with 6.0.1 and 7.0.1, and - on macOS - Apple LLVM version 10. So it's probably best to use the preinstalled version or install version 8 if LLVM is not available on your platform by default.
 
-For Python, at least version 2.7 _should_ be available! Use `python --version` to see what's there.
+Python version 2.7 _should_ be available. The build script probes for `python --version` and `python2 --version` and uses the first one that looks like a version 2 executable.
 
 ### macOS
 

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -36,12 +36,6 @@ jobs:
     vmImage: $(image)
 
   steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '2.x'
-      addToPath: true
-      architecture: 'x64'
-
   - ${{ if eq(parameters.platform, 'macOS') }}:
     # macOS
     - script: |
@@ -59,6 +53,11 @@ jobs:
 
   - ${{ if eq(parameters.platform, 'Windows') }}:
     # Windows.
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '2.x'
+        addToPath: true
+        architecture: 'x64'
     - script: |
         curl -sSf -o rustup-init.exe https://win.rustup.rs
         rustup-init.exe -y --default-toolchain %TOOLCHAIN%

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,12 +32,6 @@ stages:
       rust_backtrace: 1
 
     steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '2.x'
-        addToPath: true
-        architecture: 'x64'
-
     - script: |
         curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
         echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -35,3 +35,6 @@ tar = "0.4.24"
 
 # for reading .cargo.vcs_info.json to get the repository sha1 in case we need the full build.
 serde_json = "1.0.39"
+
+# for finding python's executable and passing it to gn.
+which = "2.0.1"

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -575,7 +575,7 @@ mod prerequisites {
     }
 
     pub fn locate_python2_cmd() -> &'static str {
-        const PYTHON_CMDS: [&str; 3] = ["python2.7", "python2", "python"];
+        const PYTHON_CMDS: [&str; 2] = ["python", "python2"];
         for python in PYTHON_CMDS.as_ref() {
             println!("Probing '{}'", python);
             if let Some(true) = is_python_version_2(python) {

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -318,7 +318,7 @@ pub fn build(build: &FinalBuildConfiguration, config: &BinariesConfiguration) {
     prerequisites::get_skia();
 
     let python2 = &prerequisites::locate_python2_path();
-    println!("Python2 found at: {:?}", python2);
+    println!("Python 2 found at: {:?}", python2);
 
     assert!(
         Command::new(python2)
@@ -575,18 +575,15 @@ mod prerequisites {
     }
 
     pub fn locate_python2_cmd() -> &'static str {
-        println!("Probing 'python'");
-
-        if let Some(true) = is_python_version_2("python") {
-            return "python";
+        const PYTHON_CMDS: [&str; 3] = ["python2.7", "python2", "python"];
+        for python in PYTHON_CMDS.as_ref() {
+            println!("Probing '{}'", python);
+            if let Some(true) = is_python_version_2(python) {
+                return python;
+            }
         }
 
-        println!("Probing 'python2'");
-        if let Some(true) = is_python_version_2("python2") {
-            return "python2";
-        }
-
-        panic!(">>>>> Probing for python version 2 failed, please make sure that python2 or python is available in PATH <<<<<");
+        panic!(">>>>> Probing for Python 2 failed, please make sure that it's available in PATH, probed executables are: {:?} <<<<<", PYTHON_CMDS);
     }
 
     /// Returns true if the given python executable is python version 2.
@@ -603,7 +600,7 @@ mod prerequisites {
                 }
                 // Don't parse version output, for example output
                 // might be "Python 2.7.15+"
-                str.starts_with("Python 2")
+                str.starts_with("Python 2.")
             })
             .ok()
     }


### PR DESCRIPTION
This PR tries to resolve the full path of Python 2 by probing for `python --version` and `python2 --version`, and if found, configures the Skia build to use the full path of Python.

This makes it possible to build skia-bindings on systems where Python 3 is the default and Python2 is available as the `python2` executable.
