### PR TITLE
Add some canonical new functions to some of the core/ types

### DIFF
--- a/skia-safe/src/core/color.rs
+++ b/skia-safe/src/core/color.rs
@@ -22,8 +22,8 @@ fn test_color_layout() {
 }
 
 impl From<u32> for Color {
-    fn from(c: u32) -> Self {
-        Color(c)
+    fn from(argb: u32) -> Self {
+        Color::new(argb)
     }
 }
 
@@ -70,6 +70,11 @@ impl BitAnd<u32> for Color {
 }
 
 impl Color {
+    // This is the canonical Rust idiomatic new implementation:
+    pub const fn new(argb: u32) -> Self {
+        Self(argb)
+    }
+
     // note: we don't use the u8cpu type here, because we trust the Rust
     // compiler to optimize the storage type.
     pub fn from_argb(a: u8, r: u8, g: u8, b: u8) -> Color {

--- a/skia-safe/src/core/color_filter.rs
+++ b/skia-safe/src/core/color_filter.rs
@@ -130,7 +130,6 @@ pub mod color_filters {
             C_SkColorFilters_Lerp(t, dst.shared_native(), src.shared_native())
         })
     }
-
 }
 
 #[test]

--- a/skia-safe/src/core/contour_measure.rs
+++ b/skia-safe/src/core/contour_measure.rs
@@ -109,7 +109,13 @@ impl Iterator for Handle<SkContourMeasureIter> {
 }
 
 impl Handle<SkContourMeasureIter> {
+    // Canonical new:
+    pub fn new(path: &Path, force_closed: bool, res_scale: impl Into<Option<scalar>>) -> Self {
+        Self::from_path(path, force_closed, res_scale)
+    }
+
     // TODO: rename to of_path? for_path?
+    // TODO: may deprecate in favor of Self::new().
     pub fn from_path(
         path: &Path,
         force_closed: bool,

--- a/skia-safe/src/core/font.rs
+++ b/skia-safe/src/core/font.rs
@@ -45,6 +45,11 @@ impl Default for Font {
 }
 
 impl Handle<SkFont> {
+    // Canonical new.
+    pub fn new(typeface: &Typeface, size: impl Into<Option<scalar>>) -> Self {
+        Self::from_typeface(typeface, size)
+    }
+
     pub fn from_typeface(typeface: &Typeface, size: impl Into<Option<scalar>>) -> Self {
         match size.into() {
             None => Self::construct(|font| unsafe {
@@ -56,7 +61,7 @@ impl Handle<SkFont> {
         }
     }
 
-    #[deprecated(since = "0.12.0", note = "use from_typeface()")]
+    #[deprecated(since = "0.12.0", note = "use from_typeface() or new()")]
     pub fn from_typeface_with_size(typeface: &Typeface, size: scalar) -> Self {
         Self::construct(|font| unsafe {
             C_SkFont_ConstructFromTypefaceWithSize(font, typeface.shared_native(), size)

--- a/skia-safe/src/core/font_mgr.rs
+++ b/skia-safe/src/core/font_mgr.rs
@@ -96,6 +96,11 @@ impl Default for RCHandle<SkFontMgr> {
 }
 
 impl RCHandle<SkFontMgr> {
+    // Canonical new:
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     pub fn count_families(&self) -> usize {
         unsafe { self.native().countFamilies().try_into().unwrap() }
     }

--- a/skia-safe/src/core/path_measure.rs
+++ b/skia-safe/src/core/path_measure.rs
@@ -33,7 +33,13 @@ impl Default for Handle<SkPathMeasure> {
 }
 
 impl Handle<SkPathMeasure> {
+    // Canonical new:
+    pub fn new(path: &Path, force_closed: bool, res_scale: impl Into<Option<scalar>>) -> Self {
+        Self::from_path(path, force_closed, res_scale)
+    }
+
     // TODO: rename for_path / of_path?
+    // TODO: deprecate in favor of new()?
     pub fn from_path(
         path: &Path,
         force_closed: bool,

--- a/skia-safe/src/core/text_blob.rs
+++ b/skia-safe/src/core/text_blob.rs
@@ -25,6 +25,10 @@ impl NativeRefCounted for SkTextBlob {
 }
 
 impl RCHandle<SkTextBlob> {
+    pub fn new(str: impl AsRef<str>, font: &Font) -> Option<Self> {
+        Self::from_str(str, font)
+    }
+
     pub fn bounds(&self) -> &Rect {
         unsafe { Rect::from_native_ref(&*self.native().bounds()) }
     }

--- a/skia-safe/src/core/typeface.rs
+++ b/skia-safe/src/core/typeface.rs
@@ -51,6 +51,11 @@ impl Default for RCHandle<SkTypeface> {
 }
 
 impl RCHandle<SkTypeface> {
+    // Canonical new:
+    pub fn new(family_name: impl AsRef<str>, font_style: FontStyle) -> Option<Self> {
+        Self::from_name(family_name, font_style)
+    }
+
     pub fn font_style(&self) -> FontStyle {
         unsafe { FontStyle::from_native(self.native().fontStyle()) }
     }
@@ -119,8 +124,8 @@ impl RCHandle<SkTypeface> {
         unsafe { SkTypeface::Equal(face_a.native(), face_b.native()) }
     }
 
-    pub fn from_name(familiy_name: &str, font_style: FontStyle) -> Option<Typeface> {
-        let familiy_name = ffi::CString::new(familiy_name).ok()?;
+    pub fn from_name(family_name: impl AsRef<str>, font_style: FontStyle) -> Option<Typeface> {
+        let familiy_name = ffi::CString::new(family_name.as_ref()).ok()?;
         Typeface::from_ptr(unsafe {
             C_SkTypeface_MakeFromName(familiy_name.as_ptr(), *font_style.native())
         })

--- a/skia-safe/src/core/types.rs
+++ b/skia-safe/src/core/types.rs
@@ -31,11 +31,16 @@ impl Deref for FourByteTag {
 
 impl From<u32> for FourByteTag {
     fn from(v: u32) -> Self {
-        FourByteTag(v)
+        Self::new(v)
     }
 }
 
 impl FourByteTag {
+    // Canonical new.
+    pub fn new(v: u32) -> Self {
+        Self(v)
+    }
+
     pub fn a(self) -> u8 {
         (self.into_native() >> 24) as u8
     }


### PR DESCRIPTION
I'm quite lost when I don't find a `new*` function on a type, so I went through all the `core/` types of Skia and added some that I thought are good "canonical" ones.