### PR TITLE
Replace more &str with AsRef<str> in public facing API functions

### DIFF
--- a/skia-safe/src/core/data.rs
+++ b/skia-safe/src/core/data.rs
@@ -87,8 +87,8 @@ impl RCHandle<SkData> {
     /// Functions that use Data as a string container usually expect it to contain
     /// a c-string including the terminating 0 byte, so this function converts
     /// the string to a CString and forwards it to new_cstr().
-    pub fn new_str(str: &str) -> Data {
-        Self::new_cstr(&CString::new(str).unwrap())
+    pub fn new_str(str: impl AsRef<str>) -> Data {
+        Self::new_cstr(&CString::new(str.as_ref()).unwrap())
     }
 
     /// Constructs Data from a &CStr by copying its contents.

--- a/skia-safe/src/docs/pdf_document.rs
+++ b/skia-safe/src/docs/pdf_document.rs
@@ -82,12 +82,12 @@ pub mod pdf {
     }
 
     trait Set {
-        fn set_s(&mut self, str: &str);
+        fn set_s(&mut self, str: impl AsRef<str>);
     }
 
     impl Set for SkString {
-        fn set_s(&mut self, str: &str) {
-            let bytes = str.as_bytes();
+        fn set_s(&mut self, str: impl AsRef<str>) {
+            let bytes = str.as_ref().as_bytes();
             unsafe { self.set2(bytes.as_ptr() as _, bytes.len()) }
         }
     }

--- a/skia-safe/src/interop/string.rs
+++ b/skia-safe/src/interop/string.rs
@@ -25,8 +25,8 @@ impl Default for Handle<SkString> {
 }
 
 impl Handle<SkString> {
-    pub fn from_str(str: &str) -> String {
-        let bytes = str.as_bytes();
+    pub fn from_str(str: impl AsRef<str>) -> String {
+        let bytes = str.as_ref().as_bytes();
         Handle::from_native(unsafe { SkString::new3(bytes.as_ptr() as _, bytes.len()) })
     }
 

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -183,8 +183,8 @@ impl BiDiRunIterator {
 }
 
 impl Shaper {
-    pub fn new_icu_bidi_run_iterator(utf8: &str, level: u8) -> Option<BiDiRunIterator> {
-        let bytes = utf8.as_bytes();
+    pub fn new_icu_bidi_run_iterator(utf8: impl AsRef<str>, level: u8) -> Option<BiDiRunIterator> {
+        let bytes = utf8.as_ref().as_bytes();
         unsafe { C_SkShaper_MakeIcuBidiRunIterator(bytes.as_ptr() as _, bytes.len(), level) }
             .to_option()
             .map(BiDiRunIterator)
@@ -226,8 +226,8 @@ impl ScriptRunIterator {
 }
 
 impl Shaper {
-    pub fn new_hb_icu_script_run_iterator(utf8: &str) -> ScriptRunIterator {
-        let bytes = utf8.as_bytes();
+    pub fn new_hb_icu_script_run_iterator(utf8: impl AsRef<str>) -> ScriptRunIterator {
+        let bytes = utf8.as_ref().as_bytes();
         unsafe { C_SkShaper_MakeHbIcuScriptRunIterator(bytes.as_ptr() as _, bytes.len()) }
             .to_option()
             .map(ScriptRunIterator)
@@ -272,8 +272,8 @@ impl LanguageRunIterator {
 }
 
 impl Shaper {
-    pub fn new_std_language_run_iterator(utf8: &str) -> Option<LanguageRunIterator> {
-        let bytes = utf8.as_bytes();
+    pub fn new_std_language_run_iterator(utf8: impl AsRef<str>) -> Option<LanguageRunIterator> {
+        let bytes = utf8.as_ref().as_bytes();
         unsafe { C_SkShaper_MakeStdLanguageRunIterator(bytes.as_ptr() as _, bytes.len()) }
             .to_option()
             .map(LanguageRunIterator)


### PR DESCRIPTION
Found some locations where replacing a `&str` parameter with a `AsRef<str>` seems appropriate.