### PR TITLE
Support HTTP redirection when downloading binaries

### DIFF
--- a/skia-bindings/build_support/binaries.rs
+++ b/skia-bindings/build_support/binaries.rs
@@ -62,8 +62,9 @@ pub fn download_url(tag: impl AsRef<str>, key: impl AsRef<str>) -> String {
 pub fn download(url: impl AsRef<str>) -> io::Result<impl Read> {
     let mut data = Vec::new();
     let mut handle = Easy::new();
-    handle.url(url.as_ref()).unwrap();
-    handle.fail_on_error(true).unwrap();
+    handle.url(url.as_ref())?;
+    handle.fail_on_error(true)?;
+    handle.follow_location(true)?;
     let curl_result = {
         let mut transfer = handle.transfer();
         transfer


### PR DESCRIPTION
The download of the binaries did not work from within the crates because the curl downloader was not following 302 redirections. This PR fixes that.