### PR TITLE
Download dependencies from GitHub

### DIFF
--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -41,7 +41,8 @@ curl = "0.4.22"
 flate2 = "1.0.7"
 tar = "0.4.26"
 
-# for reading .cargo.vcs_info.json to get the repository sha1 in case we need the full build.
+# for reading .cargo.vcs_info.json to get the repository sha1 that is used to download
+# the matching prebuilt binaries.
 serde_json = "1.0.39"
 # for reading Cargo.toml from within a package.
 toml = "0.5.1"

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -20,7 +20,7 @@ include = [ "Cargo.toml", "build.rs", "build_support.rs", "build_support/**/*.rs
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
 skia = "75c3974"
-depot_tools = "2313020"
+depot_tools = "a110bf6"
 
 [features]
 default = []

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -16,6 +16,11 @@ build = "build.rs"
 links = "skia"
 include = [ "Cargo.toml", "build.rs", "build_support.rs", "build_support/**/*.rs", "src/**/*.cpp", "src/lib.rs", "src/icu.rs" ]
 
+# Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
+[package.metadata]
+skia = "75c3974d315f3accddb3583ff5f44f0d449cb424"
+depot_tools = "2313020206fce572179a52ac2cce0d342491e1ab"
+
 [features]
 default = []
 vulkan = []
@@ -30,13 +35,14 @@ cc = "1.0.35"
 # bindings are platform dependent and critical to this project.
 bindgen = "=0.51.0"
 
-# for downloading and extracting prebuilt binaries:
+# for downloading and extracting prebuilt binaries and skia / depot_tools archives:
 curl = "0.4.22"
 flate2 = "1.0.7"
 tar = "0.4.24"
 
 # for reading .cargo.vcs_info.json to get the repository sha1 in case we need the full build.
 serde_json = "1.0.39"
-
+# for reading Cargo.toml from within a package.
+toml = "0.5.1"
 # for finding python's executable and passing it to gn.
 which = "2.0.1"

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -1,14 +1,11 @@
 [package]
 
 name = "skia-bindings"
-
 description = "Skia Bindings for Rust"
 homepage = "https://github.com/rust-skia/rust-skia/skia-bindings"
 repository = "https://github.com/rust-skia/rust-skia"
 readme = "README.md"
-# 5 max
 keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
-# 6 max
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -17,9 +17,10 @@ links = "skia"
 include = [ "Cargo.toml", "build.rs", "build_support.rs", "build_support/**/*.rs", "src/**/*.cpp", "src/lib.rs", "src/icu.rs" ]
 
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
+# Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "75c3974d315f3accddb3583ff5f44f0d449cb424"
-depot_tools = "2313020206fce572179a52ac2cce0d342491e1ab"
+skia = "75c3974"
+depot_tools = "2313020"
 
 [features]
 default = []

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -38,7 +38,7 @@ bindgen = "=0.51.0"
 # for downloading and extracting prebuilt binaries and skia / depot_tools archives:
 curl = "0.4.22"
 flate2 = "1.0.7"
-tar = "0.4.24"
+tar = "0.4.26"
 
 # for reading .cargo.vcs_info.json to get the repository sha1 in case we need the full build.
 serde_json = "1.0.39"

--- a/skia-bindings/README.md
+++ b/skia-bindings/README.md
@@ -1,16 +1,14 @@
 # Skia Bindings
 
-**NOTE:** This is a supporting package for [skia-safe](https:://crates.io/crate/skia-safe), which provides safe Rust bindings to the [Skia Graphics Library](https://skia.org/).
-
-This package contains build support for Skia and number of additional C functions that support the package skia-safe.
+This is a supporting package for [skia-safe](https:://crates.io/crate/skia-safe), which provides safe Rust bindings to the [Skia Graphics Library](https://skia.org/).
 
 ## Organization
 
 This package contains three components. 
 
 - First, full configuration and build support for Skia in [`build.rs`](build.rs) and  [`build_support/`](build_support/).
-- Additional C binding sources to help out bindgen with stuff it has problems with or to work around linker errors. These are [`src/bindings.cpp`](src/bindings.cpp), and [`src/shaper.cpp`](src/shaper.cpp).
-- And a number of functions that are used to manage and download prebuilt binaries.
+- Additional C bindings to help out bindgen with stuff it has problems with or to work around linker errors. These are [`src/bindings.cpp`](src/bindings.cpp), and [`src/shaper.cpp`](src/shaper.cpp).
+- And a number of functions that are used to download prebuilt binaries.
 
 ### Skia Build Support
 

--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -1,7 +1,7 @@
 mod build_support;
 use crate::build_support::skia::FinalBuildConfiguration;
-use build_support::skia;
-use build_support::{azure, binaries, cargo, git};
+use build_support::{azure, binaries, cargo, git, skia, utils};
+use std::io::Cursor;
 use std::path::Path;
 use std::{fs, io};
 
@@ -106,12 +106,12 @@ fn should_try_download_binaries(config: &skia::BinariesConfiguration) -> Option<
 }
 
 fn download_and_install(url: impl AsRef<str>, output_directory: &Path) -> io::Result<()> {
-    let archive = binaries::download(url)?;
+    let archive = utils::download(url)?;
     println!(
         "UNPACKING ARCHIVE INTO: {}",
         output_directory.to_str().unwrap()
     );
-    binaries::unpack(archive, output_directory)?;
+    binaries::unpack(Cursor::new(archive), output_directory)?;
     // TODO: verify key?
     println!("INSTALLING BINDINGS");
     fs::copy(output_directory.join("bindings.rs"), SRC_BINDINGS_RS)?;

--- a/skia-bindings/build_support.rs
+++ b/skia-bindings/build_support.rs
@@ -8,4 +8,5 @@ pub mod clang;
 pub mod git;
 pub mod ios;
 pub mod skia;
+pub mod utils;
 pub mod vs;

--- a/skia-bindings/build_support/cargo.rs
+++ b/skia-bindings/build_support/cargo.rs
@@ -127,8 +127,8 @@ pub fn get_metadata() -> Vec<(String, String)> {
     )
     .join("Cargo.toml");
     let str = fs::read_to_string(cargo_toml).expect("Failed to read Cargo.toml");
-    let root: value::Table =
-        de::from_str::<value::Table>(&str).expect("Failed to parse Cargo.toml");
+    let root: value::Value =
+        de::from_str::<value::Value>(&str).expect("Failed to parse Cargo.toml");
     let manifest_table: &value::Table = root
         .get("package.metadata")
         .expect("[package.metadata] missing")

--- a/skia-bindings/build_support/cargo.rs
+++ b/skia-bindings/build_support/cargo.rs
@@ -139,6 +139,6 @@ pub fn get_metadata() -> Vec<(String, String)> {
 
     manifest_table
         .iter()
-        .map(|(a, b)| (a.clone(), b.to_string()))
+        .map(|(a, b)| (a.clone(), b.as_str().unwrap().to_owned()))
         .collect()
 }

--- a/skia-bindings/build_support/cargo.rs
+++ b/skia-bindings/build_support/cargo.rs
@@ -127,11 +127,13 @@ pub fn get_metadata() -> Vec<(String, String)> {
     )
     .join("Cargo.toml");
     let str = fs::read_to_string(cargo_toml).expect("Failed to read Cargo.toml");
-    let root: value::Value =
-        de::from_str::<value::Value>(&str).expect("Failed to parse Cargo.toml");
+    let root: value::Table =
+        de::from_str::<value::Table>(&str).expect("Failed to parse Cargo.toml");
     let manifest_table: &value::Table = root
-        .get("package.metadata")
-        .expect("[package.metadata] missing")
+        .get("package")
+        .expect("section [package] missing")
+        .get("metadata")
+        .expect("section [package.metadata] missing")
         .as_table()
         .unwrap();
 

--- a/skia-bindings/build_support/git.rs
+++ b/skia-bindings/build_support/git.rs
@@ -25,9 +25,9 @@ pub fn trim_hash(hash: &str) -> String {
 /// Run git with the given args in the given directory, print stderr to the current
 /// process's terminal, and capture its stdout output.
 /// Panics if the git command fails.
-pub fn run<'a>(args: &[impl AsRef<str>], dir: impl Into<Option<&'a Path>>) -> Vec<u8> {
+pub fn _run<'a>(args: &[impl AsRef<str>], dir: impl Into<Option<&'a Path>>) -> Vec<u8> {
     let args: Vec<&str> = args.iter().map(|s| s.as_ref()).collect();
-    let (status, output) = run2(&args, dir);
+    let (status, output) = _run2(&args, dir);
     if status == 0 {
         return output;
     }
@@ -37,7 +37,7 @@ pub fn run<'a>(args: &[impl AsRef<str>], dir: impl Into<Option<&'a Path>>) -> Ve
 /// Like run, but returns the status code _and_ the output or None if
 /// there is no status code (for example the command was interrupted).
 /// Panics if the git command could not be run at all.
-pub fn run2<'a>(args: &[impl AsRef<str>], dir: impl Into<Option<&'a Path>>) -> (i32, Vec<u8>) {
+pub fn _run2<'a>(args: &[impl AsRef<str>], dir: impl Into<Option<&'a Path>>) -> (i32, Vec<u8>) {
     let args: Vec<&str> = args.iter().map(|s| s.as_ref()).collect();
 
     let mut cmd = Command::new("git");

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -645,16 +645,15 @@ mod prerequisites {
             .ok()
     }
 
-    /// Get the skia and depot_tools, either by checking out the submodules, or
-    /// when the build.rs was called outside of the git repository,
-    /// by checking out the original repository in a temporary directory and
-    /// moving it over.
+    /// Resolve the skia and depot_tools subdirectory contents, either by checking out the
+    /// submodules, or when the build.rs was called outside of the git repository,
+    /// by downloading and unpacking them from GitHub.
     pub fn resolve_dependencies() {
         if cargo::is_crate() {
-            // we are in a package.
+            // we are in a crate.
             download_dependencies();
         } else {
-            // we are not in a package, assuming we are in our git repo.
+            // we are not in a crate, assuming we are in our git repo.
             // so just update all submodules.
             assert!(
                 Command::new("git")
@@ -669,9 +668,11 @@ mod prerequisites {
         }
     }
 
-    // We use codeload.github.com, otherwise the short hash will be expanded as the root
+    // Specifies where to download Skia and Depot Tools archives from.
+    //
+    // We use codeload.github.com, otherwise the short hash will be expanded to a full hash as the root
     // directory inside the tar.gz, and we run into filesystem path length restrictions
-    // with skia.
+    // with Skia.
     const DEPENDENCIES: &[(&str, &str); 2] = &[
         ("https://codeload.github.com/google/skia/tar.gz", "skia"),
         (
@@ -680,8 +681,9 @@ mod prerequisites {
         ),
     ];
 
-    /// Downloads the submodules skia and depot_tools from the origin
-    /// repository under rust skia.
+    /// Downloads the skia and depot_tools from their repositories.
+    ///
+    /// The hashes are taken from the Cargo.toml section [package.metadata].
     fn download_dependencies() {
         let metadata = cargo::get_metadata();
 
@@ -718,7 +720,6 @@ mod prerequisites {
                 .expect("Failed to extract archive");
 
             // move unpack directory to the target repository directory
-
             fs::rename(unpack_dir, repo_name).expect("failed to move directory");
         }
     }

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -669,9 +669,15 @@ mod prerequisites {
         }
     }
 
+    // We use codeload.github.com, otherwise the short hash will be expanded as the root
+    // directory inside the tar.gz, and we run into filesystem path length restrictions
+    // with skia.
     const DEPENDENCIES: &[(&str, &str); 2] = &[
-        ("https://github.com/google/skia", "skia"),
-        ("https://github.com/rust-skia/depot_tools", "depot_tools"),
+        ("https://codeload.github.com/google/skia/tar.gz", "skia"),
+        (
+            "https://codeload.github.com/rust-skia/depot_tools/tar.gz",
+            "depot_tools",
+        ),
     ];
 
     /// Downloads the submodules skia and depot_tools from the origin
@@ -688,19 +694,19 @@ mod prerequisites {
             }
 
             // hash available?
-            let (_, hash) = metadata
+            let (_, short_hash) = metadata
                 .iter()
                 .find(|(n, _)| n == repo_name)
                 .expect("metadata entry not found");
 
             // remove unpacking directory, github will format it to repo_name-hash
-            let unpack_dir = &PathBuf::from(format!("{}-{}", repo_name, hash));
+            let unpack_dir = &PathBuf::from(format!("{}-{}", repo_name, short_hash));
             if unpack_dir.is_dir() {
                 fs::remove_dir_all(unpack_dir).unwrap();
             }
 
             // download
-            let archive_url = &format!("{}/archive/{}.tar.gz", repo_url, hash);
+            let archive_url = &format!("{}/{}", repo_url, short_hash);
             println!("DOWNLOADING: {}", archive_url);
             let archive =
                 utils::download(archive_url).expect(&format!("Failed to download {}", archive_url));

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -695,7 +695,7 @@ mod prerequisites {
             // prepare unpacking directory
             let unpack_dir = &PathBuf::from(format!("{}.tmp", repo_name));
             if unpack_dir.is_dir() {
-                fs::remove_dir_all(unpack_dir);
+                fs::remove_dir_all(unpack_dir).unwrap();
             }
 
             // download

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -708,7 +708,7 @@ mod prerequisites {
             // unpack
             let tar = GzDecoder::new(Cursor::new(archive));
             tar::Archive::new(tar)
-                .unpack(".")
+                .unpack(std::env::current_dir().unwrap())
                 .expect("Failed to extract archive");
 
             // move unpack directory to the target repository directory

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -604,6 +604,7 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
 
 mod prerequisites {
     use crate::build_support::{cargo, utils};
+    use flate2::read::GzDecoder;
     use std::fs;
     use std::io::Cursor;
     use std::path::PathBuf;
@@ -705,7 +706,8 @@ mod prerequisites {
                 utils::download(archive_url).expect(&format!("Failed to download {}", archive_url));
 
             // unpack
-            tar::Archive::new(Cursor::new(archive))
+            let tar = GzDecoder::new(Cursor::new(archive));
+            tar::Archive::new(tar)
                 .unpack(unpack_dir)
                 .expect("Failed to extract archive");
 

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -693,8 +693,8 @@ mod prerequisites {
                 .find(|(n, _)| n == repo_name)
                 .expect("metadata entry not found");
 
-            // prepare unpacking directory
-            let unpack_dir = &PathBuf::from(format!("{}.tmp", repo_name));
+            // remove unpacking directory, github will format it to repo_name-hash
+            let unpack_dir = &PathBuf::from(format!("{}-{}", repo_name, hash));
             if unpack_dir.is_dir() {
                 fs::remove_dir_all(unpack_dir).unwrap();
             }
@@ -708,7 +708,7 @@ mod prerequisites {
             // unpack
             let tar = GzDecoder::new(Cursor::new(archive));
             tar::Archive::new(tar)
-                .unpack(unpack_dir)
+                .unpack(".")
                 .expect("Failed to extract archive");
 
             // move unpack directory to the target repository directory

--- a/skia-bindings/build_support/utils.rs
+++ b/skia-bindings/build_support/utils.rs
@@ -1,0 +1,25 @@
+use curl::easy::Easy;
+use std::io;
+
+/// Download a file from the given URL and return the data.
+pub fn download(url: impl AsRef<str>) -> io::Result<Vec<u8>> {
+    let mut data = Vec::new();
+    let mut handle = Easy::new();
+    handle.url(url.as_ref())?;
+    handle.fail_on_error(true)?;
+    handle.follow_location(true)?;
+    let curl_result = {
+        let mut transfer = handle.transfer();
+        transfer
+            .write_function(|new_data| {
+                data.extend_from_slice(new_data);
+                Ok(new_data.len())
+            })
+            .unwrap();
+        transfer.perform()
+    };
+    match curl_result {
+        Err(e) => Err(io::Error::new(io::ErrorKind::Other, e)),
+        Ok(()) => Ok(data),
+    }
+}


### PR DESCRIPTION
If a full build was needed in a downloaded crate, we cloned the repositories rust-skia, skia, and depot_tools. rust-skia was cloned only to find out what refs we used for the skia and depot_tools submodules. 

This PR resolves the hashes directly from the Cargo.toml and downloads and unpacks the archives directly from github without going through the git command line tool anymore.
