### PR TITLE
Filter archives in crate builds.

### DIFF
--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -735,21 +735,21 @@ mod prerequisites {
     // directory inside the tar.gz, and we run into filesystem path length restrictions
     // with Skia.
     struct Dependency {
-        pub url: &'static str,
         pub repo: &'static str,
+        pub url: &'static str,
         pub path_filter: fn(&Path) -> bool,
     }
 
-    fn dependencies() -> Vec<Dependency> {
-        return vec![
+    fn dependencies() -> &'static [Dependency] {
+        return &[
             Dependency {
-                url: "https://codeload.github.com/google/skia/tar.gz",
                 repo: "skia",
+                url: "https://codeload.github.com/google/skia/tar.gz",
                 path_filter: filter_skia,
             },
             Dependency {
-                url: "https://codeload.github.com/rust-skia/depot_tools/tar.gz",
                 repo: "depot_tools",
+                url: "https://codeload.github.com/rust-skia/depot_tools/tar.gz",
                 path_filter: filter_depot_tools,
             },
         ];

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -766,7 +766,7 @@ mod prerequisites {
         // we need only ninja from depot_tools.
         // https://github.com/rust-skia/rust-skia/pull/165
         fn filter_depot_tools(p: &Path) -> bool {
-            p.starts_with("ninja")
+            p.to_str().unwrap().starts_with("ninja")
         }
     }
 }

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -715,14 +715,10 @@ mod prerequisites {
                     let path = entry.path().unwrap();
                     let mut components = path.components();
                     let root = components.next().unwrap();
-                    if root.as_os_str() != unpack_dir.as_os_str() {
-                        panic!(
-                            "unexpected archive root directory: {:?}, expected: {:?}",
-                            root.as_os_str(),
-                            unpack_dir.as_os_str()
-                        )
-                    }
-                    if (dep.path_filter)(components.as_path()) {
+                    // skip pax headers.
+                    if root.as_os_str() == unpack_dir.as_os_str()
+                        && (dep.path_filter)(components.as_path())
+                    {
                         entry.unpack_in(&dir).unwrap();
                     }
                 }


### PR DESCRIPTION
This PRs filters the downloaded archives in a crate build:

- Containing files with very long pathnames, the `infra/` subdirectory is skipped when the Skia archive is downloaded.
- Only files starting with `ninja/` are extracted from the depot_tools archive because the build does not need anything else (#165).

Closes #169
