### PR TITLE
Add skshaper library to the binaries.

### DIFF
--- a/skia-bindings/build_support/binaries.rs
+++ b/skia-bindings/build_support/binaries.rs
@@ -30,17 +30,12 @@ pub fn export(config: &skia::BinariesConfiguration, target_dir: &Path) -> io::Re
 
     let output_directory = &config.output_directory;
 
-    let (skia_lib, skia_bindings_lib) = if cargo::target().is_windows() {
-        ("skia.lib", "skia-bindings.lib")
-    } else {
-        ("libskia.a", "libskia-bindings.a")
-    };
+    let target = cargo::target();
 
-    fs::copy(output_directory.join(skia_lib), export_dir.join(skia_lib))?;
-    fs::copy(
-        output_directory.join(skia_bindings_lib),
-        export_dir.join(skia_bindings_lib),
-    )?;
+    for lib in &config.built_libraries {
+        let filename = &target.library_to_filename(lib);
+        fs::copy(output_directory.join(filename), export_dir.join(filename))?;
+    }
 
     for file in &config.additional_files {
         fs::copy(output_directory.join(file), export_dir.join(file))?;

--- a/skia-bindings/build_support/cargo.rs
+++ b/skia-bindings/build_support/cargo.rs
@@ -33,6 +33,16 @@ impl Target {
         self.system == "windows"
     }
 
+    /// Convert a library name to a filename.
+    pub fn library_to_filename(&self, name: impl AsRef<str>) -> PathBuf {
+        let name = name.as_ref();
+        if self.is_windows() {
+            format!("{}.lib", name).into()
+        } else {
+            format!("lib{}.a", name).into()
+        }
+    }
+
     pub fn as_strs(&self) -> (&str, &str, &str, Option<&str>) {
         (
             self.architecture.as_str(),


### PR DESCRIPTION
After #168 was fixed, another bug with the feature `shaper` came up: I forgot to copy `skshaper` library into the binaries. This PR fixes that.