### PR TITLE
Remove a string copy in TextBlobBuilderRunHandler.

### DIFF
--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -19,6 +19,7 @@ use skia_bindings::{
 use std::ffi::CStr;
 use std::marker::PhantomData;
 use std::mem;
+use std::os::raw;
 
 pub struct Shaper(*mut SkShaper);
 
@@ -461,7 +462,11 @@ impl TextBlobBuilderRunHandler<'_> {
         // we can never be sure that the RunHandler callbacks refer to that range. For
         // now we ensure that by not exposing the RunHandler of a TextBlobBuilder.
         let run_handler = construct(|rh| unsafe {
-            C_SkTextBlobBuilderRunHandler_construct(rh, ptr as *const i8, offset.into().native())
+            C_SkTextBlobBuilderRunHandler_construct(
+                rh,
+                ptr as *const raw::c_char,
+                offset.into().native(),
+            )
         });
         TextBlobBuilderRunHandler(run_handler, PhantomData)
     }

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -16,10 +16,9 @@ use skia_bindings::{
     SkShaper_LanguageRunIterator, SkShaper_RunHandler_Buffer, SkShaper_RunHandler_RunInfo,
     SkShaper_RunIterator, SkShaper_ScriptRunIterator, SkTextBlobBuilderRunHandler, TraitObject,
 };
-use std::ffi::{CStr, CString};
+use std::ffi::CStr;
 use std::marker::PhantomData;
 use std::mem;
-use std::pin::Pin;
 
 pub struct Shaper(*mut SkShaper);
 


### PR DESCRIPTION
While reading the source of `SkShaper.cpp` I found that `SkTextBlobBuilderRunHandler` does not check for a final 0 in the utf8 string it uses and relies only on that the offsets provided through the `RunHandler` callbacks are in range. 

This PR removes the unneeded copy of the string.