### PR TITLE
Add some more [repr(transparent)] for consistency

### DIFF
--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -165,6 +165,7 @@ impl NativeAccess<SkCanvas> for Canvas {
 /// This is the type representing a canvas that is owned and dropped
 /// when it goes out of scope _and_ is bound to a the lifetime of another
 /// instance. Function resolvement is done via the Deref trait.
+#[repr(transparent)]
 pub struct OwnedCanvas<'lt>(*mut Canvas, PhantomData<&'lt ()>);
 
 impl<'lt> Deref for OwnedCanvas<'lt> {

--- a/skia-safe/src/core/deferred_display_list_recorder.rs
+++ b/skia-safe/src/core/deferred_display_list_recorder.rs
@@ -42,6 +42,7 @@ pub(crate) mod private {
     use crate::prelude::*;
     use skia_bindings::{C_SkDeferredDisplayList_delete, SkDeferredDisplayList};
 
+    #[repr(transparent)]
     pub struct DeferredDisplayList(pub(crate) *mut SkDeferredDisplayList);
 
     impl NativeAccess<SkDeferredDisplayList> for DeferredDisplayList {

--- a/skia-safe/src/core/drawable.rs
+++ b/skia-safe/src/core/drawable.rs
@@ -82,6 +82,7 @@ impl RCHandle<SkDrawable> {
     }
 }
 
+#[repr(transparent)]
 pub struct GPUDrawHandler(*mut SkDrawable_GpuDrawHandler);
 
 impl NativeAccess<SkDrawable_GpuDrawHandler> for GPUDrawHandler {

--- a/skia-safe/src/core/image_generator.rs
+++ b/skia-safe/src/core/image_generator.rs
@@ -9,6 +9,7 @@ use skia_bindings::{
 };
 use std::ffi::c_void;
 
+#[repr(transparent)]
 pub struct ImageGenerator(*mut SkImageGenerator);
 
 impl NativeAccess<SkImageGenerator> for ImageGenerator {

--- a/skia-safe/src/interop/stream.rs
+++ b/skia-safe/src/interop/stream.rs
@@ -15,6 +15,7 @@ use std::marker::PhantomData;
 use std::ptr;
 
 /// Trait representing an Skia allocated Stream type with a base class of SkStream.
+#[repr(transparent)]
 pub struct Stream<N: NativeStreamBase>(*mut N);
 
 pub trait NativeStreamBase {

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -21,6 +21,7 @@ use std::marker::PhantomData;
 use std::mem;
 use std::os::raw;
 
+#[repr(transparent)]
 pub struct Shaper(*mut SkShaper);
 
 impl NativeAccess<SkShaper> for Shaper {
@@ -101,6 +102,7 @@ where
     }
 }
 
+#[repr(transparent)]
 pub struct FontRunIterator(*mut SkShaper_FontRunIterator);
 
 impl Drop for FontRunIterator {
@@ -151,6 +153,7 @@ impl Shaper {
     }
 }
 
+#[repr(transparent)]
 pub struct BiDiRunIterator(*mut SkShaper_BiDiRunIterator);
 
 impl Drop for BiDiRunIterator {
@@ -192,6 +195,7 @@ impl Shaper {
     }
 }
 
+#[repr(transparent)]
 pub struct ScriptRunIterator(*mut SkShaper_ScriptRunIterator);
 
 impl Drop for ScriptRunIterator {
@@ -236,6 +240,7 @@ impl Shaper {
     }
 }
 
+#[repr(transparent)]
 pub struct LanguageRunIterator(*mut SkShaper_LanguageRunIterator);
 
 impl Drop for LanguageRunIterator {

--- a/skia-safe/src/utils/camera.rs
+++ b/skia-safe/src/utils/camera.rs
@@ -265,6 +265,7 @@ impl Camera3D {
 // Also note that the implementation uses interior pointers,
 // so we let Skia do the allocation.
 
+#[repr(transparent)]
 pub struct View3D(*mut Sk3DView);
 
 impl NativeAccess<Sk3DView> for View3D {


### PR DESCRIPTION
... they are not used because the wrapper types in skia-safe are not used for interfacing with the C++ code, but it won't hurt to keep them consistent.