### PR TITLE
Add some unsafe Send impls to custom pointer type wrappers

### DIFF
--- a/skia-safe/src/interop/stream.rs
+++ b/skia-safe/src/interop/stream.rs
@@ -16,6 +16,7 @@ use std::ptr;
 
 /// Trait representing an Skia allocated Stream type with a base class of SkStream.
 pub struct Stream<N: NativeStreamBase>(*mut N);
+unsafe impl<N: NativeStreamBase> Send for Stream<N> {}
 
 pub trait NativeStreamBase {
     fn as_stream_mut(&mut self) -> &mut SkStream;
@@ -58,6 +59,7 @@ pub struct MemoryStream<'a> {
     native: *mut SkMemoryStream,
     pd: PhantomData<&'a ()>,
 }
+unsafe impl Send for MemoryStream<'_> {}
 
 impl NativeStreamBase for SkMemoryStream {
     fn as_stream_mut(&mut self) -> &mut SkStream {

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -22,6 +22,7 @@ use std::mem;
 use std::os::raw;
 
 pub struct Shaper(*mut SkShaper);
+unsafe impl Send for Shaper {}
 
 impl NativeAccess<SkShaper> for Shaper {
     fn native(&self) -> &SkShaper {

--- a/skia-safe/src/utils/camera.rs
+++ b/skia-safe/src/utils/camera.rs
@@ -266,6 +266,7 @@ impl Camera3D {
 // so we let Skia do the allocation.
 
 pub struct View3D(*mut Sk3DView);
+unsafe impl Send for View3D {}
 
 impl NativeAccess<Sk3DView> for View3D {
     fn native(&self) -> &Sk3DView {


### PR DESCRIPTION
I've marked some pointer wrapper types with `Send` of which I am sure that they can be sent safely to other threads.
