### PR TITLE
Don't pass the full path of python's executable to gn

### DIFF
--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -46,5 +46,3 @@ tar = "0.4.26"
 serde_json = "1.0.39"
 # for reading Cargo.toml from within a package.
 toml = "0.5.1"
-# for finding python's executable and passing it to gn.
-which = "2.0.1"

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -372,8 +372,8 @@ impl BinariesConfiguration {
 pub fn build(build: &FinalBuildConfiguration, config: &BinariesConfiguration) {
     prerequisites::resolve_dependencies();
 
-    let python2 = &prerequisites::locate_python2_path();
-    println!("Python 2 found at: {:?}", python2);
+    let python2 = &prerequisites::locate_python2_cmd();
+    println!("Python 2 found: {:?}", python2);
 
     assert!(
         Command::new(python2)
@@ -403,8 +403,8 @@ pub fn build(build: &FinalBuildConfiguration, config: &BinariesConfiguration) {
         .args(&[
             "gen",
             output_directory_str,
-            &("--script-executable=".to_owned() + python2.to_str().unwrap()),
-            &("--args=".to_owned() + &gn_args),
+            &format!("--script-executable={}", python2),
+            &format!("--args={}", gn_args),
         ])
         .envs(env::vars())
         .current_dir(PathBuf::from("./skia"))
@@ -627,10 +627,6 @@ mod prerequisites {
     use std::path::Component;
     use std::path::{Path, PathBuf};
     use std::process::{Command, Stdio};
-
-    pub fn locate_python2_path() -> PathBuf {
-        which::which(locate_python2_cmd()).unwrap()
-    }
 
     pub fn locate_python2_cmd() -> &'static str {
         const PYTHON_CMDS: [&str; 2] = ["python", "python2"];


### PR DESCRIPTION
Not sure why, but the passing the python's executable full path to `gn --script-executable=[path]` just ceased to work on my machine, and thinking about that, passing just the name is probably the more sensible solution because the executable has been located through the PATH env variable anyway.