### PR TITLE
Update Skia and bump version to 0.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Skia Submodule Status: chrome/m76 ([pending changes][skiapending]).
 
-[skiapending]: https://github.com/google/skia/compare/75c3974d315f3accddb3583ff5f44f0d449cb424...chrome/m76
+[skiapending]: https://github.com/google/skia/compare/f13f8690bede09ca97071e9786d68bc0758a24cc...chrome/m76
 
 ## Goals
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.14.4"
+version = "0.15.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"
@@ -19,7 +19,7 @@ include = [ "Cargo.toml", "build.rs", "build_support.rs", "build_support/**/*.rs
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "75c3974"
+skia = "f13f8690be"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.14.4"
+version = "0.15.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -23,7 +23,7 @@ shaper = ["skia-bindings/shaper"]
 
 [dependencies]
 bitflags = "1.0.4"
-skia-bindings = { version = "0.14.4", path = "../skia-bindings" }
+skia-bindings = { version = "0.15.0", path = "../skia-bindings" }
 # TODO: 1.3 breaks offscreen_gl_context
 lazy_static = "=1.2"
 


### PR DESCRIPTION
There were some minor updates to the Skia branch `chrome/m76` which should be integrated into the next release of rust-skia. 

And the next update of skia-safe will bring a small number changes that break backward compatibility, so the next version is going to be `0.15.0`.