### PR TITLE
Experiment: Support Skia debug builds

### DIFF
--- a/azure-pipelines-build-target.yml
+++ b/azure-pipelines-build-target.yml
@@ -9,8 +9,6 @@ parameters:
   exampleArgs: ''
   # Set up Android environment? Not compatible with runBinaries or runClippy!
   androidEnv: false
-  # Build Skia with Debugging enabled?
-  skiaDebug: '0'
 
 steps:
   - bash: |
@@ -30,9 +28,8 @@ steps:
         export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=${{ parameters.target }}$(androidAPILevel)-clang$(androidBinExt)
         echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
       fi
-      set
       touch skia-bindings/build.rs
-      export SKIA_DEBUG=${{ parameters.skiaDebug }}
+      set
       (cd skia-safe && cargo build --release --features "$(features)" --all-targets --target ${{ parameters.target }} -vv)
       export SKIA_BINARIES_TAG=$(cat "$(Build.ArtifactStagingDirectory)/skia-binaries/tag.txt")
       export SKIA_BINARIES_KEY=$(cat "$(Build.ArtifactStagingDirectory)/skia-binaries/key.txt")
@@ -43,6 +40,7 @@ steps:
   - ${{ if eq(parameters.runClippy, True) }}:
     - bash: |
         set -e
+        set
         (cd skia-bindings && cargo clippy --release --features "$(features)" --all-targets --target ${{ parameters.target }} -- -D warnings)
         (cd skia-safe && cargo clippy --release --features "$(features)" --all-targets --target ${{ parameters.target }} -- -D warnings)
       displayName: 'Clippy skia-bindings and skia-safe'

--- a/azure-pipelines-build-target.yml
+++ b/azure-pipelines-build-target.yml
@@ -9,6 +9,8 @@ parameters:
   exampleArgs: ''
   # Set up Android environment? Not compatible with runBinaries or runClippy!
   androidEnv: false
+  # Build Skia with Debugging enabled?
+  skiaDebug: '0'
 
 steps:
   - bash: |
@@ -30,6 +32,7 @@ steps:
       fi
       set
       touch skia-bindings/build.rs
+      export SKIA_DEBUG=${{ parameters.skiaDebug }}
       (cd skia-safe && cargo build --release --features "$(features)" --all-targets --target ${{ parameters.target }} -vv)
       export SKIA_BINARIES_TAG=$(cat "$(Build.ArtifactStagingDirectory)/skia-binaries/tag.txt")
       export SKIA_BINARIES_KEY=$(cat "$(Build.ArtifactStagingDirectory)/skia-binaries/key.txt")

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -44,7 +44,7 @@ jobs:
           toolchain: stable
           features: 'vulkan,svg,shaper,textlayout'
           exampleArgs: ''
-          skiaDebug: '1'
+          skia_debug: '1'
         beta-all-features:
           toolchain: beta
           features: 'vulkan,svg,shaper,textlayout'

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -9,12 +9,12 @@ jobs:
 
   strategy:
     matrix:
-      stable:
-        toolchain: stable
-        features: ''
-        exampleArgs: '--driver cpu --driver pdf'
 
       ${{ if eq(parameters.deployRelease, 'True') }}:
+        stable:
+          toolchain: stable
+          features: ''
+          exampleArgs: ''
         stable-vulkan:
           toolchain: stable
           features: 'vulkan'
@@ -40,6 +40,11 @@ jobs:
           toolchain: stable
           features: 'vulkan,svg,shaper,textlayout'
           exampleArgs: '--driver cpu --driver pdf --driver svg'
+        stable-all-features-debug:
+          toolchain: stable
+          features: 'vulkan,svg,shaper,textlayout'
+          exampleArgs: ''
+          skiaDebug: '1'
         beta-all-features:
           toolchain: beta
           features: 'vulkan,svg,shaper,textlayout'

--- a/skia-bindings/README.md
+++ b/skia-bindings/README.md
@@ -36,7 +36,7 @@ And whenever the build script detects that `skia-bindings` is built from inside 
 
 ## Build Customization
 
-Besides of the features `vulkan`, `svg`, and `shaper` that can be directly specified when the package is added as a cargo dependency, the Skia build can be customized further in `build.rs` by adjusting one of two structs that are defined in `build_support/skia.rs`:
+Besides of the features `vulkan`, `svg`, `shaper`, and `textlayout` that can be directly specified when the package is added as a cargo dependency, the Skia build can be customized further in `build.rs` by adjusting one of two structs that are defined in `build_support/skia.rs`:
 
 ### `BuildConfiguration`
 

--- a/skia-bindings/README.md
+++ b/skia-bindings/README.md
@@ -14,7 +14,7 @@ This package contains three components.
 
 Building Skia is quite exceptional, a number of prerequisites need to be available and configured properly for the target platform.
 
-To configure and build Skia, [`build_support/skia.rs`](build_support/skia.rs) does all the hard work: it pulls `depot_tools/` and `skia/` from Google's repositories and a number of additional dependencies with the help of Python. After that, it configures Skia with Google's [GN](https://gn.googlesource.com/gn/+/refs/heads/master/README.md) tool, and finally builds it by giving control to the `ninja` executable from the `depot_tools/` package.
+To configure and build Skia, [`build_support/skia.rs`](build_support/skia.rs) does all the hard work: it pulls `depot_tools/` and `skia/` from Google's repositories and a number of additional dependencies by executing `skia/tools/git-sync-deps` with Python. After that, it configures Skia with Google's [GN](https://gn.googlesource.com/gn/+/refs/heads/master/README.md) tool, and finally builds it by giving control to the `ninja` executable from the `depot_tools/` package.
 
 ### Binding Generation
 

--- a/skia-bindings/README.md
+++ b/skia-bindings/README.md
@@ -22,6 +22,10 @@ To configure and build Skia, [`build_support/skia.rs`](build_support/skia.rs) do
 
 If both steps went well, the resulting Rust binding code is written to `src/bindings.rs`, and the `skia-bindings` library is found in the output directory alongside where Skia was built previously.
 
+### Debug Builds
+
+By default, and for performance reasons, Skia is built in release mode even when cargo creates debug output. Skia debug builds can be enabled only by explicitly setting the environment variable `SKIA_DEBUG=1`.
+
 ### Prebuilt Binaries
 
 Because building Skia _and_ creating the bindings is slow and depend on a number of components that lie outside the Rust ecosystem, we decided to experiment with prebuilt binaries.

--- a/skia-bindings/build_support/cargo.rs
+++ b/skia-bindings/build_support/cargo.rs
@@ -1,5 +1,7 @@
 //! Support function for communicating with cargo's variables and outputs.
 
+#![allow(dead_code)]
+
 use std::fmt::{Display, Formatter};
 use std::path::{Path, PathBuf};
 use std::{env, fmt, fs, io};
@@ -8,8 +10,22 @@ pub fn output_directory() -> PathBuf {
     PathBuf::from(env::var("OUT_DIR").unwrap())
 }
 
-pub fn add_dependent_path(path: impl AsRef<Path>) {
+pub fn rerun_if_changed(path: impl AsRef<Path>) {
     println!("cargo:rerun-if-changed={}", path.as_ref().to_str().unwrap());
+}
+
+/// Returns the value of an environment variable and notify cargo that the build
+/// should rereun if it changes.
+pub fn env_var(name: impl AsRef<str>) -> Option<String> {
+    let name = name.as_ref();
+    rerun_if_env_changed(name);
+    env::var(name).ok()
+}
+
+/// Notify cargo that it should rerun the build if the environment
+/// variable changes.
+pub fn rerun_if_env_changed(name: impl AsRef<str>) {
+    println!("cargo:rerun-if-env-changed={}", name.as_ref())
 }
 
 pub fn add_link_libs(libs: &[impl AsRef<str>]) {

--- a/skia-bindings/build_support/cargo.rs
+++ b/skia-bindings/build_support/cargo.rs
@@ -105,9 +105,10 @@ fn parse_target(target_str: impl AsRef<str>) -> Target {
     }
 }
 
-// We can not assume that the build profile of the build.rs script reflects the build
-// profile that the target needs.
-#[allow(dead_code)]
+/// Returns `true` if the target should be built in release mode, `false`, if in debug mode.
+///
+/// We can not assume that the build profile of the build.rs script reflects the build
+/// profile that the target needs.
 pub fn build_release() -> bool {
     match env::var("PROFILE").unwrap().as_str() {
         "release" => true,

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -47,9 +47,8 @@ impl Default for BuildConfiguration {
         };
 
         let skia_debug = {
-            match env::var("SKIA_DEBUG") {
-                Ok(v) if v != "0" => true,
-                Err(_) => true,
+            match cargo::env_var("SKIA_DEBUG") {
+                Some(v) if v != "0" => true,
                 _ => false,
             }
         };
@@ -741,14 +740,14 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
     for source in &build.binding_sources {
         cc_build.file(source);
         let source = source.to_str().unwrap();
-        cargo::add_dependent_path(source);
+        cargo::rerun_if_changed(source);
         builder = builder.header(source);
     }
 
     // TODO: may put the include paths into the FinalBuildConfiguration?
 
     let include_path = current_dir.join("skia");
-    cargo::add_dependent_path(include_path.join("include"));
+    cargo::rerun_if_changed(include_path.join("include"));
 
     builder = builder.clang_arg(format!("-I{}", include_path.display()));
     cc_build.include(include_path);

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -706,6 +706,9 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
         //   std::_Tree* types
         .blacklist_type("std::_Tree.*")
         .blacklist_type("std::map.*")
+        //   debug builds:
+        .blacklist_type("SkLRUCache")
+        .blacklist_type("SkLRUCache_Entry")
         //   not used at all:
         .blacklist_type("std::vector.*")
         // Vulkan reexports that got swallowed by making them opaque.

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -48,9 +48,7 @@ impl Default for BuildConfiguration {
 
         BuildConfiguration {
             on_windows: cargo::host().is_windows(),
-            // Note that currently, we don't support debug Skia builds,
-            // because they are hard to configure and pull in a lot of testing related modules.
-            skia_release: true,
+            skia_release: cargo::build_release(),
             keep_inline_functions: true,
             features: Features {
                 vulkan: cfg!(feature = "vulkan"),
@@ -222,6 +220,7 @@ impl FinalBuildConfiguration {
                     "is_official_build",
                     if build.skia_release { yes() } else { no() },
                 ),
+                ("is_debug", if build.skia_release { no() } else { yes() }),
                 ("skia_use_system_libjpeg_turbo", no()),
                 ("skia_use_system_libpng", no()),
                 ("skia_use_libwebp", no()),


### PR DESCRIPTION
For Rust Debug builds, Skia was always built in Release mode before (`NDEBUG` defined) which removed all `SkAssert` invariant checks. 

This PR tries to build Skia in Debug mode when `skia-bindings` is built without the `--release` argument.

Even if this works, there will be no changes regarding the prebuilt binaries: when a downloaded cargo package `skia-bindings` is compiled in Debugging mode, the Release binaries will downloaded and linked to for now, so this change is only relevant for developers working with the repository.
