### PR TITLE
Wrappers for the skparagraph module.

### DIFF
--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -27,15 +27,19 @@ jobs:
           toolchain: stable
           features: 'shaper'
           exampleArgs: ''
+        stable-textlayout:
+          toolchain: stable
+          features: 'textlayout'
+          exampleArgs: ''
 
       ${{ if eq(parameters.deployRelease, 'False') }}:
         stable-all-features:
           toolchain: stable
-          features: 'vulkan,svg,shaper'
+          features: 'vulkan,svg,shaper,textlayout'
           exampleArgs: '--driver cpu --driver pdf --driver svg'
         beta-all-features:
           toolchain: beta
-          features: 'vulkan,svg,shaper'
+          features: 'vulkan,svg,shaper,textlayout'
           exampleArgs: ''
 
   variables:

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org
 edition = "2018"
 build = "build.rs"
 links = "skia"
-include = [ "Cargo.toml", "build.rs", "build_support.rs", "build_support/**/*.rs", "src/**/*.cpp", "src/lib.rs", "src/icu.rs" ]
+include = [ "Cargo.toml", "build.rs", "build_support.rs", "build_support/**/*.rs", "src/**/*.h", "src/**/*.cpp", "src/lib.rs", "src/icu.rs" ]
 
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org
 edition = "2018"
 build = "build.rs"
 links = "skia"
-include = [ "Cargo.toml", "build.rs", "build_support.rs", "build_support/**/*.rs", "src/**/*.h", "src/**/*.cpp", "src/lib.rs", "src/icu.rs" ]
+include = [ "Cargo.toml", "build.rs", "build_support.rs", "build_support/**/*.rs", "src/**/*.h", "src/**/*.cpp", "src/defaults.rs", "src/icu.rs", "src/lib.rs" ]
 
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -817,7 +817,7 @@ const OPAQUE_TYPES: &[&str] = &[
     "SkShaper_TrivialScriptRunIterator",
     // skparagraph
     "std::vector",
-    "std::basic_string",
+    "std::u16string",
     // Vulkan reexports with the wrong field naming conventions.
     "VkPhysicalDeviceFeatures",
     "VkPhysicalDeviceFeatures2",

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -595,6 +595,7 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
         // GrVkBackendContext contains u128 fields on macOS
         .raw_line("#![allow(improper_ctypes)]")
         .parse_callbacks(Box::new(ParseCallbacks))
+        .raw_line("#![allow(clippy::all)]")
         .constified_enum(".*Mask")
         .constified_enum(".*Flags")
         .constified_enum(".*Bits")

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -596,6 +596,8 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
         .raw_line("#![allow(improper_ctypes)]")
         .parse_callbacks(Box::new(ParseCallbacks))
         .raw_line("#![allow(clippy::all)]")
+        // GrVkBackendContext contains u128 fields on macOS
+        .raw_line("#![allow(improper_ctypes)]")
         .constified_enum(".*Mask")
         .constified_enum(".*Flags")
         .constified_enum(".*Bits")

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -838,6 +838,11 @@ impl bindgen::callbacks::ParseCallbacks for ParseCallbacks {
                 .map(|(_, replacer)| replacer(enum_name, original_variant_name))
         })
     }
+
+    fn item_name(&self, _original_item_name: &str) -> Option<String> {
+        println!("item: {}", _original_item_name);
+        None
+    }
 }
 
 type EnumEntry = (&'static str, fn(&str, &str) -> String);

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -594,10 +594,6 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
         .raw_line("#![allow(clippy::all)]")
         // GrVkBackendContext contains u128 fields on macOS
         .raw_line("#![allow(improper_ctypes)]")
-        .parse_callbacks(Box::new(ParseCallbacks))
-        .raw_line("#![allow(clippy::all)]")
-        // GrVkBackendContext contains u128 fields on macOS
-        .raw_line("#![allow(improper_ctypes)]")
         .constified_enum(".*Mask")
         .constified_enum(".*Flags")
         .constified_enum(".*Bits")

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -839,11 +839,6 @@ impl bindgen::callbacks::ParseCallbacks for ParseCallbacks {
                 .map(|(_, replacer)| replacer(enum_name, original_variant_name))
         })
     }
-
-    fn item_name(&self, _original_item_name: &str) -> Option<String> {
-        println!("item: {}", _original_item_name);
-        None
-    }
 }
 
 type EnumEntry = (&'static str, fn(&str, &str) -> String);

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -594,6 +594,7 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
         .raw_line("#![allow(clippy::all)]")
         // GrVkBackendContext contains u128 fields on macOS
         .raw_line("#![allow(improper_ctypes)]")
+        .parse_callbacks(Box::new(ParseCallbacks))
         .constified_enum(".*Mask")
         .constified_enum(".*Flags")
         .constified_enum(".*Bits")
@@ -1064,6 +1065,7 @@ mod prerequisites {
 
 use bindgen::EnumVariation;
 pub use definitions::{Definition, Definitions};
+use regex::Regex;
 
 pub(crate) mod definitions {
     use std::collections::HashSet;

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -1065,7 +1065,6 @@ mod prerequisites {
 
 use bindgen::EnumVariation;
 pub use definitions::{Definition, Definitions};
-use regex::Regex;
 
 pub(crate) mod definitions {
     use std::collections::HashSet;

--- a/skia-bindings/skparagraph.patch
+++ b/skia-bindings/skparagraph.patch
@@ -1,8 +1,8 @@
 diff --git a/BUILD.gn b/BUILD.gn
-index 07bdbc2370..90c346acc9 100644
+index 6a85dd96b..809d4724d 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -1179,6 +1179,9 @@ group("modules") {
+@@ -1076,6 +1076,9 @@ group("modules") {
      "modules/particles",
      "modules/skottie",
      "modules/skshaper",
@@ -12,3 +12,15 @@ index 07bdbc2370..90c346acc9 100644
    ]
  }
  
+diff --git a/modules/skparagraph/BUILD.gn b/modules/skparagraph/BUILD.gn
+index 5a85d37c4..a3ab9b884 100644
+--- a/modules/skparagraph/BUILD.gn
++++ b/modules/skparagraph/BUILD.gn
+@@ -18,6 +18,7 @@ if (skia_enable_skparagraph) {
+ 
+   component("skparagraph") {
+     import("skparagraph.gni")
++    complete_static_lib = false
+     public_configs = [ ":public_config" ]
+     public = skparagraph_public
+     if (skia_use_icu && skia_use_harfbuzz) {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1,3 +1,4 @@
+#include "bindings.h"
 // codec/
 #include "include/codec/SkEncodedOrigin.h"
 // core/
@@ -112,7 +113,6 @@ template<typename T>
 inline sk_sp<T> sp(T* pt) {
     return sk_sp<T>(pt);
 }
-
 
 //
 // codec/SkEncodedOrigin.h

--- a/skia-bindings/src/bindings.h
+++ b/skia-bindings/src/bindings.h
@@ -1,0 +1,11 @@
+#ifndef SKIA_BINDINGS_BINDINGS_H
+#define SKIA_BINDINGS_BINDINGS_H
+
+#include "include/core/SkRefCnt.h"
+
+template<typename T>
+inline sk_sp<T> spFromConst(const T* pt) {
+    return sk_sp<T>(const_cast<T*>(pt));
+}
+
+#endif //SKIA_BINDINGS_BINDINGS_H

--- a/skia-bindings/src/defaults.rs
+++ b/skia-bindings/src/defaults.rs
@@ -1,53 +1,56 @@
 //! This file contains Default trait implementations for types that are
 //! used without a handle in skia-safe and get reexported from there.
 
-impl Default for crate::skia_textlayout_Affinity {
-    fn default() -> Self {
-        Self::Upstream
-    }
-}
-
-impl Default for crate::skia_textlayout_RectHeightStyle {
-    fn default() -> Self {
-        Self::Tight
-    }
-}
-
-impl Default for crate::skia_textlayout_RectWidthStyle {
-    fn default() -> Self {
-        Self::Tight
-    }
-}
-
-impl Default for crate::skia_textlayout_TextAlign {
-    fn default() -> Self {
-        Self::Left
-    }
-}
-
-impl Default for crate::skia_textlayout_PositionWithAffinity {
-    fn default() -> Self {
-        Self {
-            position: 0,
-            affinity: Default::default(),
+#[cfg(feature = "textlayout")]
+pub mod textlayout {
+    impl Default for crate::skia_textlayout_Affinity {
+        fn default() -> Self {
+            Self::Upstream
         }
     }
-}
 
-impl Default for crate::skia_textlayout_TextBaseline {
-    fn default() -> Self {
-        Self::Alphabetic
+    impl Default for crate::skia_textlayout_RectHeightStyle {
+        fn default() -> Self {
+            Self::Tight
+        }
     }
-}
 
-impl Default for crate::skia_textlayout_TextDecorationStyle {
-    fn default() -> Self {
-        Self::Solid
+    impl Default for crate::skia_textlayout_RectWidthStyle {
+        fn default() -> Self {
+            Self::Tight
+        }
     }
-}
 
-impl Default for crate::skia_textlayout_StyleType {
-    fn default() -> Self {
-        Self::AllAttributes
+    impl Default for crate::skia_textlayout_TextAlign {
+        fn default() -> Self {
+            Self::Left
+        }
+    }
+
+    impl Default for crate::skia_textlayout_PositionWithAffinity {
+        fn default() -> Self {
+            Self {
+                position: 0,
+                affinity: Default::default(),
+            }
+        }
+    }
+
+    impl Default for crate::skia_textlayout_TextBaseline {
+        fn default() -> Self {
+            Self::Alphabetic
+        }
+    }
+
+    impl Default for crate::skia_textlayout_TextDecorationStyle {
+        fn default() -> Self {
+            Self::Solid
+        }
+    }
+
+    impl Default for crate::skia_textlayout_StyleType {
+        fn default() -> Self {
+            Self::AllAttributes
+        }
     }
 }

--- a/skia-bindings/src/defaults.rs
+++ b/skia-bindings/src/defaults.rs
@@ -1,0 +1,1 @@
+//! Default implementation for enums that are used in skia-safe and exported from there.

--- a/skia-bindings/src/defaults.rs
+++ b/skia-bindings/src/defaults.rs
@@ -1,1 +1,53 @@
-//! Default implementation for enums that are used in skia-safe and exported from there.
+//! This file contains Default trait implementations for types that are
+//! used without a handle in skia-safe and get reexported from there.
+
+impl Default for crate::skia_textlayout_Affinity {
+    fn default() -> Self {
+        Self::Upstream
+    }
+}
+
+impl Default for crate::skia_textlayout_RectHeightStyle {
+    fn default() -> Self {
+        Self::Tight
+    }
+}
+
+impl Default for crate::skia_textlayout_RectWidthStyle {
+    fn default() -> Self {
+        Self::Tight
+    }
+}
+
+impl Default for crate::skia_textlayout_TextAlign {
+    fn default() -> Self {
+        Self::Left
+    }
+}
+
+impl Default for crate::skia_textlayout_PositionWithAffinity {
+    fn default() -> Self {
+        Self {
+            position: 0,
+            affinity: Default::default(),
+        }
+    }
+}
+
+impl Default for crate::skia_textlayout_TextBaseline {
+    fn default() -> Self {
+        Self::Alphabetic
+    }
+}
+
+impl Default for crate::skia_textlayout_TextDecorationStyle {
+    fn default() -> Self {
+        Self::Solid
+    }
+}
+
+impl Default for crate::skia_textlayout_StyleType {
+    fn default() -> Self {
+        Self::AllAttributes
+    }
+}

--- a/skia-bindings/src/lib.rs
+++ b/skia-bindings/src/lib.rs
@@ -5,5 +5,8 @@
 mod bindings;
 pub use bindings::*;
 
+mod defaults;
+pub use defaults::*;
+
 #[cfg(feature = "shaper")]
 pub mod icu;

--- a/skia-bindings/src/paragraph.cpp
+++ b/skia-bindings/src/paragraph.cpp
@@ -1,1 +1,259 @@
 /// Skia skparagraph Module C Wrapper Functions
+
+#include "bindings.h"
+
+#include "modules/skparagraph/include/DartTypes.h"
+#include "modules/skparagraph/include/FontCollection.h"
+#include "modules/skparagraph/include/Paragraph.h"
+#include "modules/skparagraph/include/ParagraphBuilder.h"
+#include "modules/skparagraph/include/ParagraphStyle.h"
+#include "modules/skparagraph/include/TextShadow.h"
+#include "modules/skparagraph/include/TextStyle.h"
+#include "modules/skparagraph/include/TypefaceFontProvider.h"
+
+using namespace skia::textlayout;
+
+//
+// FontCollection.h
+//
+
+extern "C" {
+
+    void C_FontCollection_setAssetFontManager(FontCollection* self, const SkFontMgr* fontManager) {
+        self->setAssetFontManager(spFromConst(fontManager));
+    }
+
+    void C_FontCollection_setDynamicFontManager(FontCollection* self, const SkFontMgr* fontManager) {
+        self->setDynamicFontManager(spFromConst(fontManager));
+    }
+
+    void C_FontCollection_setTestFontManager(FontCollection* self, const SkFontMgr* fontManager) {
+        self->setTestFontManager(spFromConst(fontManager));
+    }
+
+    void C_FontCollection_setDefaultFontManager(FontCollection* self, const SkFontMgr* fontManager) {
+        self->setDefaultFontManager(spFromConst(fontManager));
+    }
+
+    void C_FontCollection_setDefaultFontManager2(FontCollection* self, const SkFontMgr* fontManager, const char* defaultFamilyName) {
+        self->setDefaultFontManager(spFromConst(fontManager), defaultFamilyName);
+    }
+
+    SkFontMgr* C_FontCollection_getFallbackManager(const FontCollection* self) {
+        return self->geFallbackManager().release();
+    }
+
+    SkTypeface* C_FontCollection_matchTypeface(FontCollection* self, const char* familyName, SkFontStyle fontStyle) {
+        return self->matchTypeface(familyName, fontStyle).release();
+    }
+
+    SkTypeface* C_FontCollection_matchDefaultTypeface(FontCollection* self, SkFontStyle fontStyle) {
+        return self->matchDefaultTypeface(fontStyle).release();
+    }
+
+    SkTypeface* C_FontCollection_defaultFallback(FontCollection* self, SkUnichar unicode, SkFontStyle fontStyle, const SkString* locale) {
+        return self->defaultFallback(unicode, fontStyle, *locale).release();
+    }
+}
+
+//
+// ParagraphStyle.h
+//
+
+extern "C" {
+    void C_StrutStyle_assign(StrutStyle* self, const StrutStyle* other) {
+        *self = *other;
+    }
+
+    void C_StrutStyle_destruct(StrutStyle* self) {
+        self->~StrutStyle();
+    }
+
+    const SkString* C_StrutStyle_getFontFamilies(const StrutStyle* self, size_t* count) {
+        auto& v = self->getFontFamilies();
+        *count = v.size();
+        return v.data();
+    }
+
+    void C_StrutStyle_setFontFamilies(StrutStyle* self, const SkString* data, size_t count) {
+        self->setFontFamilies(std::vector<SkString>(data, data + count));
+    }
+}
+
+extern "C" {
+    bool C_ParagraphStyle_Equals(const ParagraphStyle* left, const ParagraphStyle* right) {
+        return *left == *right;
+    }
+
+    void C_ParagraphStyle_setStrutStyle(ParagraphStyle* self, const StrutStyle* strutStyle) {
+        self->setStrutStyle(*strutStyle);
+    }
+
+    void C_ParagraphStyle_setEllipsis(ParagraphStyle* self, const StrutStyle* strutStyle) {
+        self->setStrutStyle(*strutStyle);
+    }
+}
+
+//
+// TextShadow.h
+//
+
+extern "C" {
+    void C_TextShadow_destruct(TextShadow* self) {
+        self->~TextShadow();
+    }
+}
+
+//
+// Paragraph.h
+//
+
+struct TextBoxes {
+    std::vector<TextBox> textBoxes;
+};
+
+extern "C" {
+    void C_TextBoxes_destruct(TextBoxes* self) {
+        self->~TextBoxes();
+    }
+
+    const TextBox* C_TextBoxes_ptr(TextBoxes* boxes) {
+        return &boxes->textBoxes.front();
+    }
+
+    size_t C_TextBoxes_count(const TextBoxes* boxes) {
+        return boxes->textBoxes.size();
+    }
+}
+
+extern "C" {
+    void C_Paragraph_delete(Paragraph* self) {
+        delete self;
+    }
+
+    bool C_Paragraph_didExceedMaxLines(Paragraph* self) {
+        return self->didExceedMaxLines();
+    }
+
+    void C_Paragraph_layout(Paragraph* self, SkScalar width) {
+        self->layout(width);
+    }
+
+    void C_Paragraph_paint(Paragraph* self, SkCanvas* canvas, SkScalar x, SkScalar y) {
+        self->paint(canvas, x, y);
+    }
+
+    void C_Paragraph_getRectsForRange(Paragraph *self, unsigned start, unsigned end, RectHeightStyle rectHeightStyle,
+                                            RectWidthStyle rectWidthStyle, TextBoxes* uninitialized) {
+        auto v = self->getRectsForRange(start, end, rectHeightStyle, rectWidthStyle);
+        new(uninitialized) TextBoxes{std::move(v)};
+    }
+
+    void C_Paragraph_getGlyphPositionAtCoordinate(Paragraph* self, SkScalar x, SkScalar y, PositionWithAffinity* position) {
+        *position = self->getGlyphPositionAtCoordinate(x, y);
+    }
+
+    void C_Paragraph_getWordBoundary(Paragraph* self, unsigned offset, size_t range[2]) {
+        auto sk_range = self->getWordBoundary(offset);
+        range[0] = sk_range.start;
+        range[1] = sk_range.end;
+    }
+
+    size_t C_Paragraph_lineNumber(Paragraph* self) {
+        return self->lineNumber();
+    }
+
+    void C_Paragraph_markDirty(Paragraph* self) {
+        self->markDirty();
+    }
+}
+
+//
+// ParagraphBuilder.h
+//
+
+extern "C" {
+    void C_ParagraphBuilder_delete(ParagraphBuilder* self) {
+        delete self;
+    }
+
+    void C_ParagraphBuilder_pushStyle(ParagraphBuilder* self, const TextStyle* style) {
+        self->pushStyle(*style);
+    }
+
+    void C_ParagraphBuilder_pop(ParagraphBuilder* self) {
+        self->pop();
+    }
+
+    void C_ParagraphBuilder_peekStyle(ParagraphBuilder* self, TextStyle* style) {
+        *style = self->peekStyle();
+    }
+
+    void C_ParagraphBuilder_addText(ParagraphBuilder* self, const char* text) {
+        self->addText(text);
+    }
+
+    void C_ParagraphBuilder_setParagraphStyle(ParagraphBuilder* self, const ParagraphStyle* style) {
+        self->setParagraphStyle(*style);
+    }
+
+    Paragraph* C_ParagraphBuilder_Build(ParagraphBuilder* self) {
+        return self->Build().release();
+    }
+
+    ParagraphBuilder* C_ParagraphBuilder_make(const ParagraphStyle* style, const FontCollection* fontCollection) {
+        return ParagraphBuilder::make(*style, spFromConst(fontCollection)).release();
+    }
+}
+
+//
+// TextStyle.h
+//
+
+extern "C" {
+    void C_TextStyle_assign(TextStyle* self, const TextStyle* other) {
+        *self = *other;
+    }
+
+    void C_TextStyle_destruct(TextStyle* self) {
+        self->~TextStyle();
+    }
+
+    size_t C_TextStyle_getShadowNumber(const TextStyle* self) {
+        return self->getShadowNumber();
+    }
+
+    void C_TextStyle_getShadows(const TextStyle* self, TextShadow shadowsOut[]) {
+        auto shadows = self->getShadows();
+        for(std::vector<TextShadow>::size_type i = 0; i != shadows.size(); ++i) {
+            shadowsOut[i] = shadows[i];
+        }
+    }
+
+    void C_TextStyle_addShadow(TextStyle* self, const TextShadow* shadow) {
+        self->addShadow(*shadow);
+    }
+
+    void C_TextStyle_resetShadows(TextStyle* self) {
+        self->resetShadows();
+    }
+
+    const SkString* C_TextStyle_getFontFamilies(const TextStyle* self, size_t* count) {
+        auto& v = self->getFontFamilies();
+        *count = v.size();
+        return v.data();
+    }
+
+    void C_TextStyle_setFontFamilies(TextStyle* self, const SkString* data, size_t count) {
+        self->setFontFamilies(std::vector<SkString>(data, data + count));
+    }
+
+    void C_TextStyle_setTypeface(TextStyle* self, const SkTypeface* typeface) {
+        self->setTypeface(spFromConst(typeface));
+    }
+
+    void C_TextStyle_getFontMetrics(const TextStyle* self, SkFontMetrics* metrics) {
+        self->getFontMetrics(metrics);
+    }
+}
+

--- a/skia-bindings/src/paragraph.cpp
+++ b/skia-bindings/src/paragraph.cpp
@@ -281,6 +281,6 @@ extern "C" {
         if (alias) {
             return self->registerTypeface(sk_sp<SkTypeface>(typeface), *alias);
         }
-        self->registerTypeface(sk_sp<SkTypeface>(typeface));
+        return self->registerTypeface(sk_sp<SkTypeface>(typeface));
     }
 }

--- a/skia-bindings/src/paragraph.cpp
+++ b/skia-bindings/src/paragraph.cpp
@@ -18,6 +18,9 @@ using namespace skia::textlayout;
 //
 
 extern "C" {
+    FontCollection* C_FontCollection_new() {
+        return new FontCollection();
+    }
 
     void C_FontCollection_setAssetFontManager(FontCollection* self, const SkFontMgr* fontManager) {
         self->setAssetFontManager(spFromConst(fontManager));

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -18,7 +18,6 @@ edition = "2018"
 [lib]
 doctest = false
 
-
 [features]
 default = []
 vulkan = ["skia-bindings/vulkan"]

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -15,6 +15,10 @@ version = "0.18.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
+[lib]
+doctest = false
+
+
 [features]
 default = []
 vulkan = ["skia-bindings/vulkan"]
@@ -33,3 +37,5 @@ offscreen_gl_context = "0.24.0"
 gleam = "0.7.0"
 clap = "2.33.0"
 ash = "0.29"
+serial_test = "0.2"
+serial_test_derive = "0.2"

--- a/skia-safe/examples/skia-org/main.rs
+++ b/skia-safe/examples/skia-org/main.rs
@@ -2,7 +2,7 @@ use crate::artifact::DrawingDriver;
 use clap::{App, Arg};
 use gleam;
 use offscreen_gl_context::{GLContext, GLVersion, NativeGLContext};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 extern crate skia_safe;
 
@@ -20,6 +20,8 @@ extern crate ash;
 mod drivers;
 mod skcanvas_overview;
 mod skpaint_overview;
+#[cfg(feature = "textlayout")]
+mod skparagraph_example;
 mod skpath_overview;
 #[cfg(feature = "shaper")]
 mod skshaper_example;
@@ -300,7 +302,7 @@ fn main() {
         }
     }
 
-    fn draw_all<Driver: DrawingDriver>(out_path: &PathBuf) {
+    fn draw_all<Driver: DrawingDriver>(out_path: &Path) {
         let out_path = out_path.join(Driver::NAME);
 
         skcanvas_overview::draw::<Driver>(&out_path);
@@ -309,6 +311,9 @@ fn main() {
 
         #[cfg(feature = "shaper")]
         skshaper_example::draw::<Driver>(&out_path);
+
+        #[cfg(feature = "textlayout")]
+        skparagraph_example::draw::<Driver>(&out_path);
     }
 }
 

--- a/skia-safe/examples/skia-org/skparagraph_example.rs
+++ b/skia-safe/examples/skia-org/skparagraph_example.rs
@@ -1,0 +1,28 @@
+use crate::artifact::DrawingDriver;
+use skia_safe::textlayout::{FontCollection, ParagraphBuilder, ParagraphStyle, TextStyle};
+use skia_safe::{icu, Canvas, FontMgr, Paint, Point};
+use std::path;
+
+pub fn draw<Driver: DrawingDriver>(path: &path::Path) {
+    let path = path.join("SkParagraph-Example");
+
+    icu::init();
+
+    Driver::draw_image_256(&path, "lorem-ipsum", draw_lorem_ipsum);
+}
+
+fn draw_lorem_ipsum(canvas: &mut Canvas) {
+    let mut font_collection = FontCollection::new();
+    font_collection.set_default_font_manager(FontMgr::new(), None);
+    let paragraph_style = ParagraphStyle::new();
+    let mut paragraph_builder = ParagraphBuilder::new(&paragraph_style, font_collection);
+    let mut ts = TextStyle::new();
+    ts.set_foreground_color(Paint::default());
+    paragraph_builder.push_style(&ts);
+    paragraph_builder.add_text(LOREM_IPSUM);
+    let mut paragraph = paragraph_builder.build();
+    paragraph.layout(256.0);
+    paragraph.paint(canvas, Point::default());
+}
+
+static LOREM_IPSUM: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur at leo at nulla tincidunt placerat. Proin eget purus augue. Quisque et est ullamcorper, pellentesque felis nec, pulvinar massa. Aliquam imperdiet, nulla ut dictum euismod, purus dui pulvinar risus, eu suscipit elit neque ac est. Nullam eleifend justo quis placerat ultricies. Vestibulum ut elementum velit. Praesent et dolor sit amet purus bibendum mattis. Aliquam erat volutpat.";

--- a/skia-safe/src/core/font_mgr.rs
+++ b/skia-safe/src/core/font_mgr.rs
@@ -197,25 +197,31 @@ impl RCHandle<SkFontMgr> {
     // TODO: makeFromStream(.., ttcIndex).
 }
 
-#[test]
-fn create_all_typefaces() {
-    let font_mgr = FontMgr::default();
-    let families = font_mgr.count_families();
-    println!("FontMgr families: {}", families);
-    // test requires that the font manager returns at least one family for now.
-    assert!(families > 0);
-    // print all family names and styles
-    for i in 0..families {
-        let name = font_mgr.family_name(i);
-        println!("font_family: {}", name);
-        let mut style_set = font_mgr.new_styleset(i);
-        for style_index in 0..style_set.count() {
-            let (_, style_name) = style_set.style(style_index);
-            if let Some(style_name) = style_name {
-                println!("  style: {}", style_name);
+#[cfg(test)]
+mod tests {
+    use crate::FontMgr;
+
+    #[test]
+    #[serial_test_derive::serial]
+    fn create_all_typefaces() {
+        let font_mgr = FontMgr::default();
+        let families = font_mgr.count_families();
+        println!("FontMgr families: {}", families);
+        // test requires that the font manager returns at least one family for now.
+        assert!(families > 0);
+        // print all family names and styles
+        for i in 0..families {
+            let name = font_mgr.family_name(i);
+            println!("font_family: {}", name);
+            let mut style_set = font_mgr.new_styleset(i);
+            for style_index in 0..style_set.count() {
+                let (_, style_name) = style_set.style(style_index);
+                if let Some(style_name) = style_name {
+                    println!("  style: {}", style_name);
+                }
+                let face = style_set.new_typeface(style_index);
+                drop(face);
             }
-            let face = style_set.new_typeface(style_index);
-            drop(face);
         }
     }
 }

--- a/skia-safe/src/gpu/vk.rs
+++ b/skia-safe/src/gpu/vk.rs
@@ -36,7 +36,6 @@ pub use sb::VkRect2D as Rect2D;
 pub use sb::VkRenderPass as RenderPass;
 pub use sb::VkSamplerYcbcrModelConversion as SamplerYcbcrModelConversion;
 pub use sb::VkSamplerYcbcrRange as SamplerYcbcrRange;
-pub use sb::VkStructureType as StructureType;
 
 pub const QUEUE_FAMILY_IGNORED: u32 = !0;
 

--- a/skia-safe/src/gpu/vk.rs
+++ b/skia-safe/src/gpu/vk.rs
@@ -36,6 +36,7 @@ pub use sb::VkRect2D as Rect2D;
 pub use sb::VkRenderPass as RenderPass;
 pub use sb::VkSamplerYcbcrModelConversion as SamplerYcbcrModelConversion;
 pub use sb::VkSamplerYcbcrRange as SamplerYcbcrRange;
+pub use sb::VkStructureType as StructureType;
 
 pub const QUEUE_FAMILY_IGNORED: u32 = !0;
 

--- a/skia-safe/src/modules.rs
+++ b/skia-safe/src/modules.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "paragraph")]
+#[cfg(feature = "textlayout")]
 pub(crate) mod paragraph;
 #[cfg(feature = "shaper")]
 pub mod shaper;
@@ -6,7 +6,7 @@ pub mod shaper;
 pub use shaper::{icu, Shaper};
 
 // Export everything below paragraph under textlayout
-#[cfg(feature = "paragraph")]
+#[cfg(feature = "textlayout")]
 pub mod textlayout {
     use crate::paragraph;
     pub use paragraph::*;

--- a/skia-safe/src/modules.rs
+++ b/skia-safe/src/modules.rs
@@ -1,4 +1,13 @@
+#[cfg(feature = "paragraph")]
+pub(crate) mod paragraph;
 #[cfg(feature = "shaper")]
 pub mod shaper;
 #[cfg(feature = "shaper")]
 pub use shaper::{icu, Shaper};
+
+// Export everything below paragraph under textlayout
+#[cfg(feature = "paragraph")]
+pub mod textlayout {
+    use crate::paragraph;
+    pub use paragraph::*;
+}

--- a/skia-safe/src/modules/paragraph.rs
+++ b/skia-safe/src/modules/paragraph.rs
@@ -7,6 +7,7 @@ pub use dart_types::*;
 mod font_collection;
 pub use font_collection::*;
 
+#[allow(clippy::module_inception)]
 mod paragraph;
 pub use paragraph::*;
 

--- a/skia-safe/src/modules/paragraph.rs
+++ b/skia-safe/src/modules/paragraph.rs
@@ -1,4 +1,5 @@
 use crate::interop;
+use crate::interop::AsStr;
 use std::ops::Index;
 
 mod dart_types;
@@ -33,14 +34,12 @@ pub struct FontFamilies<'a>(&'a [skia_bindings::SkString]);
 impl Index<usize> for FontFamilies<'_> {
     type Output = str;
     fn index(&self, index: usize) -> &Self::Output {
-        interop::String::from_native_ref(&self.0[index]).as_str()
+        self.0[index].as_str()
     }
 }
 
 impl FontFamilies<'_> {
     pub fn iter(&self) -> impl Iterator<Item = &str> {
-        self.0
-            .iter()
-            .map(|str| interop::String::from_native_ref(str).as_str())
+        self.0.iter().map(|str| str.as_str())
     }
 }

--- a/skia-safe/src/modules/paragraph.rs
+++ b/skia-safe/src/modules/paragraph.rs
@@ -1,0 +1,20 @@
+mod dart_types;
+pub use dart_types::*;
+
+mod font_collection;
+pub use font_collection::*;
+
+mod paragraph;
+pub use paragraph::*;
+
+mod paragraph_builder;
+pub use paragraph_builder::*;
+
+mod text_shadow;
+pub use text_shadow::*;
+
+mod text_style;
+pub use text_style::*;
+
+mod typeface_font_provider;
+pub use typeface_font_provider::*;

--- a/skia-safe/src/modules/paragraph.rs
+++ b/skia-safe/src/modules/paragraph.rs
@@ -1,3 +1,6 @@
+use crate::interop;
+use std::ops::Index;
+
 mod dart_types;
 pub use dart_types::*;
 
@@ -10,6 +13,9 @@ pub use paragraph::*;
 mod paragraph_builder;
 pub use paragraph_builder::*;
 
+mod paragraph_style;
+pub use paragraph_style::*;
+
 mod text_shadow;
 pub use text_shadow::*;
 
@@ -18,3 +24,23 @@ pub use text_style::*;
 
 mod typeface_font_provider;
 pub use typeface_font_provider::*;
+
+/// Efficient reference type to a C++ vector of font family SkStrings.
+///
+/// Use indexer or .iter() to access the Rust str references.
+pub struct FontFamilies<'a>(&'a [skia_bindings::SkString]);
+
+impl Index<usize> for FontFamilies<'_> {
+    type Output = str;
+    fn index(&self, index: usize) -> &Self::Output {
+        interop::String::from_native_ref(&self.0[index]).as_str()
+    }
+}
+
+impl FontFamilies<'_> {
+    pub fn iter(&self) -> impl Iterator<Item = &str> {
+        self.0
+            .iter()
+            .map(|str| interop::String::from_native_ref(str).as_str())
+    }
+}

--- a/skia-safe/src/modules/paragraph.rs
+++ b/skia-safe/src/modules/paragraph.rs
@@ -1,4 +1,3 @@
-use crate::interop;
 use crate::interop::AsStr;
 use std::ops::Index;
 

--- a/skia-safe/src/modules/paragraph/dart_types.rs
+++ b/skia-safe/src/modules/paragraph/dart_types.rs
@@ -1,0 +1,27 @@
+use crate::prelude::*;
+use crate::Rect;
+use skia_bindings as sb;
+
+pub type Affinity = sb::skia_textlayout_Affinity;
+pub type RectHeightStyle = sb::skia_textlayout_RectHeightStyle;
+pub type RectWidthStyle = sb::skia_textlayout_RectWidthStyle;
+pub type TextAlign = sb::skia_textlayout_TextAlign;
+pub type TextDirection = sb::skia_textlayout_TextDirection;
+
+pub type PositionWithAffinity = sb::skia_textlayout_PositionWithAffinity;
+
+#[derive(Copy, Clone, PartialEq, Debug)]
+#[repr(C)]
+pub struct TextBox {
+    pub rect: Rect,
+    pub direct: TextDirection,
+}
+
+impl NativeTransmutable<sb::skia_textlayout_TextBox> for TextBox {}
+
+#[test]
+fn text_box_layout() {
+    TextBox::test_layout()
+}
+
+pub type TextBaseline = sb::skia_textlayout_TextBaseline;

--- a/skia-safe/src/modules/paragraph/dart_types.rs
+++ b/skia-safe/src/modules/paragraph/dart_types.rs
@@ -2,13 +2,13 @@ use crate::prelude::*;
 use crate::Rect;
 use skia_bindings as sb;
 
-pub type Affinity = sb::skia_textlayout_Affinity;
-pub type RectHeightStyle = sb::skia_textlayout_RectHeightStyle;
-pub type RectWidthStyle = sb::skia_textlayout_RectWidthStyle;
-pub type TextAlign = sb::skia_textlayout_TextAlign;
-pub type TextDirection = sb::skia_textlayout_TextDirection;
+pub use sb::skia_textlayout_Affinity as Affinity;
+pub use sb::skia_textlayout_RectHeightStyle as RectHeightStyle;
+pub use sb::skia_textlayout_RectWidthStyle as RectWidthStyle;
+pub use sb::skia_textlayout_TextAlign as TextAlign;
+pub use sb::skia_textlayout_TextDirection as TextDirection;
 
-pub type PositionWithAffinity = sb::skia_textlayout_PositionWithAffinity;
+pub use sb::skia_textlayout_PositionWithAffinity as PositionWithAffinity;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[repr(C)]
@@ -24,4 +24,4 @@ fn text_box_layout() {
     TextBox::test_layout()
 }
 
-pub type TextBaseline = sb::skia_textlayout_TextBaseline;
+pub use sb::skia_textlayout_TextBaseline as TextBaseline;

--- a/skia-safe/src/modules/paragraph/font_collection.rs
+++ b/skia-safe/src/modules/paragraph/font_collection.rs
@@ -1,7 +1,6 @@
 use crate::prelude::*;
 use crate::{interop, FontMgr, FontStyle, Typeface, Unichar};
 use skia_bindings as sb;
-use skia_bindings::C_FontCollection_matchTypeface;
 use std::ffi;
 
 pub type FontCollection = RCHandle<sb::skia_textlayout_FontCollection>;
@@ -81,7 +80,7 @@ impl RCHandle<sb::skia_textlayout_FontCollection> {
     ) -> Option<Typeface> {
         let family_name = ffi::CString::new(family_name.as_ref()).unwrap();
         Typeface::from_ptr(unsafe {
-            C_FontCollection_matchTypeface(
+            sb::C_FontCollection_matchTypeface(
                 self.native_mut(),
                 family_name.as_ptr(),
                 font_style.into_native(),

--- a/skia-safe/src/modules/paragraph/font_collection.rs
+++ b/skia-safe/src/modules/paragraph/font_collection.rs
@@ -1,0 +1,160 @@
+use crate::prelude::*;
+use crate::{interop, FontMgr, FontStyle, Typeface, Unichar};
+use skia_bindings as sb;
+use skia_bindings::C_FontCollection_matchTypeface;
+use std::ffi;
+
+pub type FontCollection = RCHandle<sb::skia_textlayout_FontCollection>;
+
+impl NativeRefCountedBase for sb::skia_textlayout_FontCollection {
+    type Base = sb::SkRefCntBase;
+}
+
+impl RCHandle<sb::skia_textlayout_FontCollection> {
+    pub fn new() -> Self {
+        Self::from_ptr(unsafe { sb::C_FontCollection_new() }).unwrap()
+    }
+
+    pub fn font_managers_count(&self) -> usize {
+        unsafe { self.native().getFontManagersCount() }
+    }
+
+    pub fn set_asset_font_manager(&mut self, font_manager: impl Into<Option<FontMgr>>) {
+        unsafe {
+            sb::C_FontCollection_setAssetFontManager(
+                self.native_mut(),
+                font_manager.into().into_ptr_or_null(),
+            )
+        }
+    }
+
+    pub fn set_dynamic_font_manager(&mut self, font_manager: impl Into<Option<FontMgr>>) {
+        unsafe {
+            sb::C_FontCollection_setDynamicFontManager(
+                self.native_mut(),
+                font_manager.into().into_ptr_or_null(),
+            )
+        }
+    }
+
+    pub fn set_test_font_manager(&mut self, font_manager: impl Into<Option<FontMgr>>) {
+        unsafe {
+            sb::C_FontCollection_setTestFontManager(
+                self.native_mut(),
+                font_manager.into().into_ptr_or_null(),
+            )
+        }
+    }
+
+    pub fn set_default_font_manager<'a>(
+        &mut self,
+        font_manager: impl Into<Option<FontMgr>>,
+        default_family_name: impl Into<Option<&'a str>>,
+    ) {
+        let font_manager = font_manager.into();
+        unsafe {
+            match default_family_name.into() {
+                Some(fname) => {
+                    let fname = ffi::CString::new(fname).unwrap();
+                    sb::C_FontCollection_setDefaultFontManager2(
+                        self.native_mut(),
+                        font_manager.into_ptr_or_null(),
+                        fname.as_ptr(),
+                    )
+                }
+                None => sb::C_FontCollection_setDefaultFontManager(
+                    self.native_mut(),
+                    font_manager.into_ptr_or_null(),
+                ),
+            }
+        }
+    }
+
+    pub fn fallback_manager(&self) -> Option<FontMgr> {
+        FontMgr::from_unshared_ptr(self.native().fDefaultFontManager.fPtr)
+    }
+
+    pub fn match_typeface(
+        &mut self,
+        family_name: impl AsRef<str>,
+        font_style: FontStyle,
+    ) -> Option<Typeface> {
+        let family_name = ffi::CString::new(family_name.as_ref()).unwrap();
+        Typeface::from_ptr(unsafe {
+            C_FontCollection_matchTypeface(
+                self.native_mut(),
+                family_name.as_ptr(),
+                font_style.into_native(),
+            )
+        })
+    }
+
+    pub fn match_default_typeface(&mut self, font_style: FontStyle) -> Option<Typeface> {
+        Typeface::from_ptr(unsafe {
+            sb::C_FontCollection_matchDefaultTypeface(self.native_mut(), font_style.into_native())
+        })
+    }
+
+    pub fn default_fallback(
+        &mut self,
+        unicode: Unichar,
+        font_style: FontStyle,
+        locale: impl AsRef<str>,
+    ) -> Option<Typeface> {
+        let locale = interop::String::from_str(locale.as_ref());
+        Typeface::from_ptr(unsafe {
+            sb::C_FontCollection_defaultFallback(
+                self.native_mut(),
+                unicode,
+                font_style.into_native(),
+                locale.native(),
+            )
+        })
+    }
+
+    pub fn disable_font_fallback(&mut self) {
+        unsafe { self.native_mut().disableFontFallback() }
+    }
+
+    pub fn font_fallback_enabled(&self) -> bool {
+        self.native().fEnableFontFallback
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::prelude::*;
+    use crate::textlayout::FontCollection;
+    use crate::FontMgr;
+
+    #[test]
+    #[serial_test_derive::serial]
+    fn ref_counts() {
+        let mut fc = FontCollection::new();
+        assert_eq!(fc.native().ref_counted_base()._ref_cnt(), 1);
+
+        let fm = FontMgr::new();
+        let fm_base = fm.native().ref_counted_base()._ref_cnt();
+
+        fc.set_default_font_manager(fm.clone(), None);
+        assert_eq!(fm.native().ref_counted_base()._ref_cnt(), fm_base + 1);
+
+        let cloned_fc = fc.clone();
+        assert_eq!(fm.native().ref_counted_base()._ref_cnt(), fm_base + 1);
+        assert_eq!(fc.native().ref_counted_base()._ref_cnt(), 2);
+        drop(cloned_fc);
+        assert_eq!(fc.native().ref_counted_base()._ref_cnt(), 1);
+        assert_eq!(fm.native().ref_counted_base()._ref_cnt(), fm_base + 1);
+
+        {
+            let fmc = fc.fallback_manager().unwrap();
+            assert_eq!(fmc.native().ref_counted_base()._ref_cnt(), fm_base + 2);
+            drop(fmc);
+        }
+
+        fc.set_default_font_manager(None, None);
+        assert_eq!(fm.native().ref_counted_base()._ref_cnt(), fm_base);
+        drop(fm);
+        drop(fc);
+    }
+}

--- a/skia-safe/src/modules/paragraph/paragraph.rs
+++ b/skia-safe/src/modules/paragraph/paragraph.rs
@@ -1,0 +1,129 @@
+use super::{PositionWithAffinity, RectHeightStyle, RectWidthStyle, TextBox};
+use crate::prelude::*;
+use crate::{scalar, Canvas, Point};
+use skia_bindings as sb;
+use std::ops::{Index, Range};
+
+pub type Paragraph = RefHandle<sb::skia_textlayout_Paragraph>;
+
+impl NativeDrop for sb::skia_textlayout_Paragraph {
+    fn drop(&mut self) {
+        unsafe { sb::C_Paragraph_delete(self) }
+    }
+}
+
+impl RefHandle<sb::skia_textlayout_Paragraph> {
+    pub fn max_width(&self) -> scalar {
+        self.native().fWidth
+    }
+
+    pub fn height(&self) -> scalar {
+        self.native().fHeight
+    }
+
+    pub fn min_intrinsic_width(&self) -> scalar {
+        self.native().fMinIntrinsicWidth
+    }
+
+    pub fn max_intrinsic_width(&self) -> scalar {
+        self.native().fMaxIntrinsicWidth
+    }
+
+    pub fn alphabetic_baseline(&self) -> scalar {
+        self.native().fAlphabeticBaseline
+    }
+
+    pub fn ideographic_baseline(&self) -> scalar {
+        self.native().fIdeographicBaseline
+    }
+
+    pub fn did_exceed_max_lines(&mut self) -> bool {
+        unsafe { sb::C_Paragraph_didExceedMaxLines(self.native_mut()) }
+    }
+
+    pub fn layout(&mut self, width: scalar) {
+        unsafe { sb::C_Paragraph_layout(self.native_mut(), width) }
+    }
+
+    pub fn paint(&mut self, canvas: &mut Canvas, p: impl Into<Point>) {
+        let p = p.into();
+        unsafe { sb::C_Paragraph_paint(self.native_mut(), canvas.native_mut(), p.x, p.y) }
+    }
+
+    pub fn get_rects_for_range(
+        &mut self,
+        range: Range<usize>,
+        rect_height_style: RectHeightStyle,
+        rect_width_style: RectWidthStyle,
+    ) -> TextBoxes {
+        TextBoxes::construct(|tb| unsafe {
+            sb::C_Paragraph_getRectsForRange(
+                self.native_mut(),
+                range.start.try_into().unwrap(),
+                range.end.try_into().unwrap(),
+                rect_height_style,
+                rect_width_style,
+                tb,
+            )
+        })
+    }
+
+    pub fn get_glyph_position_at_coordinate(
+        &mut self,
+        p: impl Into<Point>,
+    ) -> PositionWithAffinity {
+        let p = p.into();
+        let mut r = Default::default();
+        unsafe { sb::C_Paragraph_getGlyphPositionAtCoordinate(self.native_mut(), p.x, p.y, &mut r) }
+        r
+    }
+
+    pub fn get_word_boundary(&mut self, offset: u32) -> Range<usize> {
+        let mut range: [usize; 2] = Default::default();
+        unsafe { sb::C_Paragraph_getWordBoundary(self.native_mut(), offset, range.as_mut_ptr()) }
+        range[0]..range[1]
+    }
+
+    pub fn line_number(&mut self) -> usize {
+        unsafe { sb::C_Paragraph_lineNumber(self.native_mut()) }
+    }
+
+    pub fn mark_dirty(&mut self) {
+        unsafe { sb::C_Paragraph_markDirty(self.native_mut()) }
+    }
+}
+
+pub type TextBoxes = Handle<sb::TextBoxes>;
+
+impl NativeDrop for sb::TextBoxes {
+    fn drop(&mut self) {
+        unsafe { sb::C_TextBoxes_destruct(self) }
+    }
+}
+
+impl Index<usize> for Handle<sb::TextBoxes> {
+    type Output = TextBox;
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.as_slice()[index]
+    }
+}
+
+impl AsRef<[TextBox]> for TextBoxes {
+    fn as_ref(&self) -> &[TextBox] {
+        self.as_slice()
+    }
+}
+
+impl Handle<sb::TextBoxes> {
+    pub fn iter(&self) -> impl Iterator<Item = &TextBox> {
+        self.as_slice().iter()
+    }
+
+    pub fn as_slice(&self) -> &[TextBox] {
+        unsafe {
+            let mut count = 0;
+            let ptr = sb::C_TextBoxes_ptr_count(self.native(), &mut count);
+            std::slice::from_raw_parts(ptr as *const TextBox, count)
+        }
+    }
+}

--- a/skia-safe/src/modules/paragraph/paragraph_builder.rs
+++ b/skia-safe/src/modules/paragraph/paragraph_builder.rs
@@ -1,0 +1,48 @@
+use super::{FontCollection, Paragraph, ParagraphStyle, TextStyle};
+use crate::prelude::*;
+use skia_bindings as sb;
+use std::ffi;
+
+pub type ParagraphBuilder = RefHandle<sb::skia_textlayout_ParagraphBuilder>;
+
+impl NativeDrop for sb::skia_textlayout_ParagraphBuilder {
+    fn drop(&mut self) {
+        unsafe { sb::C_ParagraphBuilder_delete(self) }
+    }
+}
+
+impl RefHandle<sb::skia_textlayout_ParagraphBuilder> {
+    pub fn push_style(&mut self, style: &TextStyle) {
+        unsafe { sb::C_ParagraphBuilder_pushStyle(self.native_mut(), style.native()) }
+    }
+
+    pub fn pop(&mut self) {
+        unsafe { sb::C_ParagraphBuilder_pop(self.native_mut()) }
+    }
+
+    pub fn peek_style(&mut self) -> TextStyle {
+        let mut ts = TextStyle::default();
+        unsafe { sb::C_ParagraphBuilder_peekStyle(self.native_mut(), ts.native_mut()) }
+        ts
+    }
+
+    pub fn add_text(&mut self, str: impl AsRef<str>) {
+        let cstr = ffi::CString::new(str.as_ref()).unwrap();
+        unsafe { sb::C_ParagraphBuilder_addText(self.native_mut(), cstr.as_ptr()) }
+    }
+
+    pub fn set_paragraph_style(&mut self, style: &ParagraphStyle) {
+        unsafe { sb::C_ParagraphBuilder_setParagraphStyle(self.native_mut(), style.native()) }
+    }
+
+    pub fn build(&mut self) -> Paragraph {
+        Paragraph::from_ptr(unsafe { sb::C_ParagraphBuilder_Build(self.native_mut()) }).unwrap()
+    }
+
+    pub fn new(style: &ParagraphStyle, font_collection: FontCollection) -> Self {
+        Self::from_ptr(unsafe {
+            sb::C_ParagraphBuilder_make(style.native(), font_collection.into_ptr())
+        })
+        .unwrap()
+    }
+}

--- a/skia-safe/src/modules/paragraph/paragraph_builder.rs
+++ b/skia-safe/src/modules/paragraph/paragraph_builder.rs
@@ -12,12 +12,14 @@ impl NativeDrop for sb::skia_textlayout_ParagraphBuilder {
 }
 
 impl RefHandle<sb::skia_textlayout_ParagraphBuilder> {
-    pub fn push_style(&mut self, style: &TextStyle) {
+    pub fn push_style(&mut self, style: &TextStyle) -> &mut Self {
         unsafe { sb::C_ParagraphBuilder_pushStyle(self.native_mut(), style.native()) }
+        self
     }
 
-    pub fn pop(&mut self) {
+    pub fn pop(&mut self) -> &mut Self {
         unsafe { sb::C_ParagraphBuilder_pop(self.native_mut()) }
+        self
     }
 
     pub fn peek_style(&mut self) -> TextStyle {
@@ -26,13 +28,15 @@ impl RefHandle<sb::skia_textlayout_ParagraphBuilder> {
         ts
     }
 
-    pub fn add_text(&mut self, str: impl AsRef<str>) {
+    pub fn add_text(&mut self, str: impl AsRef<str>) -> &mut Self {
         let cstr = ffi::CString::new(str.as_ref()).unwrap();
         unsafe { sb::C_ParagraphBuilder_addText(self.native_mut(), cstr.as_ptr()) }
+        self
     }
 
-    pub fn set_paragraph_style(&mut self, style: &ParagraphStyle) {
+    pub fn set_paragraph_style(&mut self, style: &ParagraphStyle) -> &mut Self {
         unsafe { sb::C_ParagraphBuilder_setParagraphStyle(self.native_mut(), style.native()) }
+        self
     }
 
     pub fn build(&mut self) -> Paragraph {

--- a/skia-safe/src/modules/paragraph/paragraph_style.rs
+++ b/skia-safe/src/modules/paragraph/paragraph_style.rs
@@ -38,40 +38,45 @@ impl Handle<sb::skia_textlayout_StrutStyle> {
         }
     }
 
-    pub fn set_font_families(&mut self, families: &[impl AsRef<str>]) {
-        let families = interop::Strings::from_strs(families);
+    pub fn set_font_families(&mut self, families: &[impl AsRef<str>]) -> &mut Self {
+        let families: Vec<interop::String> = FromStrs::from_strs(families);
         let families = families.native();
         unsafe {
             sb::C_StrutStyle_setFontFamilies(self.native_mut(), families.as_ptr(), families.len());
         }
+        self
     }
 
     pub fn font_style(&self) -> FontStyle {
         FontStyle::from_native(self.native().fFontStyle)
     }
 
-    pub fn set_font_style(&mut self, font_style: FontStyle) {
-        self.native_mut().fFontStyle = font_style.into_native()
+    pub fn set_font_style(&mut self, font_style: FontStyle) -> &mut Self {
+        self.native_mut().fFontStyle = font_style.into_native();
+        self
     }
 
     pub fn font_size(&self) -> scalar {
         self.native().fFontSize
     }
 
-    pub fn set_font_size(&mut self, font_size: scalar) {
+    pub fn set_font_size(&mut self, font_size: scalar) -> &mut Self {
         self.native_mut().fFontSize = font_size;
+        self
     }
 
-    pub fn set_height(&mut self, height: scalar) {
+    pub fn set_height(&mut self, height: scalar) -> &mut Self {
         self.native_mut().fHeight = height;
+        self
     }
 
     pub fn height(&self) -> scalar {
         self.native().fHeight
     }
 
-    pub fn set_leading(&mut self, leading: scalar) {
+    pub fn set_leading(&mut self, leading: scalar) -> &mut Self {
         self.native_mut().fLeading = leading;
+        self
     }
 
     pub fn leading(&self) -> scalar {
@@ -82,16 +87,18 @@ impl Handle<sb::skia_textlayout_StrutStyle> {
         self.native().fStrutEnabled
     }
 
-    pub fn set_strut_enabled(&mut self, strut_enabled: bool) {
+    pub fn set_strut_enabled(&mut self, strut_enabled: bool) -> &mut Self {
         self.native_mut().fStrutEnabled = strut_enabled;
+        self
     }
 
     pub fn force_strut_height(&self) -> bool {
         self.native().fForceStrutHeight
     }
 
-    pub fn set_force_strut_height(&mut self, force_strut_height: bool) {
+    pub fn set_force_strut_height(&mut self, force_strut_height: bool) -> &mut Self {
         self.native_mut().fForceStrutHeight = force_strut_height;
+        self
     }
 }
 
@@ -130,35 +137,39 @@ impl Handle<sb::skia_textlayout_ParagraphStyle> {
         StrutStyle::from_native_ref(&self.native().fStrutStyle)
     }
 
-    pub fn set_strut_style(&mut self, strut_style: StrutStyle) {
+    pub fn set_strut_style(&mut self, strut_style: StrutStyle) -> &mut Self {
         self.native_mut().fStrutStyle.replace_with(strut_style);
+        self
     }
 
     pub fn text_style(&self) -> &TextStyle {
         TextStyle::from_native_ref(&self.native().fDefaultTextStyle)
     }
 
-    pub fn set_text_style(&mut self, text_style: &TextStyle) {
+    pub fn set_text_style(&mut self, text_style: &TextStyle) -> &mut Self {
         // TODO: implement the assignment operator in C.
         self.native_mut()
             .fDefaultTextStyle
             .replace_with(text_style.clone());
+        self
     }
 
     pub fn text_direction(&self) -> TextDirection {
         self.native().fTextDirection
     }
 
-    pub fn set_text_direction(&mut self, direction: TextDirection) {
+    pub fn set_text_direction(&mut self, direction: TextDirection) -> &mut Self {
         self.native_mut().fTextDirection = direction;
+        self
     }
 
     pub fn text_align(&self) -> TextAlign {
         self.native().fTextAlign
     }
 
-    pub fn set_text_align(&mut self, align: TextAlign) {
-        self.native_mut().fTextAlign = align
+    pub fn set_text_align(&mut self, align: TextAlign) -> &mut Self {
+        self.native_mut().fTextAlign = align;
+        self
     }
 
     pub fn max_lines(&self) -> Option<usize> {
@@ -168,24 +179,27 @@ impl Handle<sb::skia_textlayout_ParagraphStyle> {
         }
     }
 
-    pub fn set_max_lines(&mut self, lines: impl Into<Option<usize>>) {
-        self.native_mut().fLinesLimit = lines.into().unwrap_or(usize::max_value())
+    pub fn set_max_lines(&mut self, lines: impl Into<Option<usize>>) -> &mut Self {
+        self.native_mut().fLinesLimit = lines.into().unwrap_or(usize::max_value());
+        self
     }
 
     pub fn ellipsis(&self) -> &str {
         self.native().fEllipsis.as_str()
     }
 
-    pub fn set_ellipsis(&mut self, ellipsis: impl AsRef<str>) {
-        self.native_mut().fEllipsis.set_str(ellipsis)
+    pub fn set_ellipsis(&mut self, ellipsis: impl AsRef<str>) -> &mut Self {
+        self.native_mut().fEllipsis.set_str(ellipsis);
+        self
     }
 
     pub fn height(&self) -> scalar {
         self.native().fHeight
     }
 
-    pub fn set_height(&mut self, height: scalar) {
+    pub fn set_height(&mut self, height: scalar) -> &mut Self {
         self.native_mut().fHeight = height;
+        self
     }
 
     pub fn unlimited_lines(&self) -> bool {
@@ -204,7 +218,8 @@ impl Handle<sb::skia_textlayout_ParagraphStyle> {
         self.native().fHintingIsOn
     }
 
-    pub fn turn_hinting_off(&mut self) {
-        self.native_mut().fHintingIsOn = false
+    pub fn turn_hinting_off(&mut self) -> &mut Self {
+        self.native_mut().fHintingIsOn = false;
+        self
     }
 }

--- a/skia-safe/src/modules/paragraph/paragraph_style.rs
+++ b/skia-safe/src/modules/paragraph/paragraph_style.rs
@@ -1,0 +1,210 @@
+use super::{FontFamilies, TextAlign, TextDirection, TextStyle};
+use crate::interop::{AsStr, FromStrs, SetStr};
+use crate::prelude::*;
+use crate::{interop, scalar, FontStyle};
+use skia_bindings as sb;
+use std::slice;
+
+pub type StrutStyle = Handle<sb::skia_textlayout_StrutStyle>;
+
+impl NativeDrop for sb::skia_textlayout_StrutStyle {
+    fn drop(&mut self) {
+        unsafe { sb::C_StrutStyle_destruct(self) }
+    }
+}
+
+impl NativeClone for sb::skia_textlayout_StrutStyle {
+    fn clone(&self) -> Self {
+        construct(|ss| unsafe { sb::C_StrutStyle_CopyConstruct(ss, self) })
+    }
+}
+
+impl Default for Handle<sb::skia_textlayout_StrutStyle> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Handle<sb::skia_textlayout_StrutStyle> {
+    pub fn new() -> Self {
+        StrutStyle::from_native(unsafe { sb::skia_textlayout_StrutStyle::new() })
+    }
+
+    pub fn font_families(&self) -> FontFamilies {
+        unsafe {
+            let mut count = 0;
+            let ptr = sb::C_StrutStyle_getFontFamilies(self.native(), &mut count);
+            FontFamilies(slice::from_raw_parts(ptr, count))
+        }
+    }
+
+    pub fn set_font_families(&mut self, families: &[impl AsRef<str>]) {
+        let families = interop::Strings::from_strs(families);
+        let families = families.native();
+        unsafe {
+            sb::C_StrutStyle_setFontFamilies(self.native_mut(), families.as_ptr(), families.len());
+        }
+    }
+
+    pub fn font_style(&self) -> FontStyle {
+        FontStyle::from_native(self.native().fFontStyle)
+    }
+
+    pub fn set_font_style(&mut self, font_style: FontStyle) {
+        self.native_mut().fFontStyle = font_style.into_native()
+    }
+
+    pub fn font_size(&self) -> scalar {
+        self.native().fFontSize
+    }
+
+    pub fn set_font_size(&mut self, font_size: scalar) {
+        self.native_mut().fFontSize = font_size;
+    }
+
+    pub fn set_height(&mut self, height: scalar) {
+        self.native_mut().fHeight = height;
+    }
+
+    pub fn height(&self) -> scalar {
+        self.native().fHeight
+    }
+
+    pub fn set_leading(&mut self, leading: scalar) {
+        self.native_mut().fLeading = leading;
+    }
+
+    pub fn leading(&self) -> scalar {
+        self.native().fLeading
+    }
+
+    pub fn strut_enabled(&self) -> bool {
+        self.native().fStrutEnabled
+    }
+
+    pub fn set_strut_enabled(&mut self, strut_enabled: bool) {
+        self.native_mut().fStrutEnabled = strut_enabled;
+    }
+
+    pub fn force_strut_height(&self) -> bool {
+        self.native().fForceStrutHeight
+    }
+
+    pub fn set_force_strut_height(&mut self, force_strut_height: bool) {
+        self.native_mut().fForceStrutHeight = force_strut_height;
+    }
+}
+
+pub type ParagraphStyle = Handle<sb::skia_textlayout_ParagraphStyle>;
+
+impl NativeDrop for sb::skia_textlayout_ParagraphStyle {
+    fn drop(&mut self) {
+        unsafe { sb::C_ParagraphStyle_destruct(self) }
+    }
+}
+
+impl NativeClone for sb::skia_textlayout_ParagraphStyle {
+    fn clone(&self) -> Self {
+        construct(|ps| unsafe { sb::C_ParagraphStyle_CopyConstruct(ps, self) })
+    }
+}
+
+impl NativePartialEq for sb::skia_textlayout_ParagraphStyle {
+    fn eq(&self, rhs: &Self) -> bool {
+        unsafe { sb::C_ParagraphStyle_Equals(self, rhs) }
+    }
+}
+
+impl Default for Handle<sb::skia_textlayout_ParagraphStyle> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Handle<sb::skia_textlayout_ParagraphStyle> {
+    pub fn new() -> Self {
+        Self::from_native(unsafe { sb::skia_textlayout_ParagraphStyle::new() })
+    }
+
+    pub fn strut_style(&self) -> &StrutStyle {
+        StrutStyle::from_native_ref(&self.native().fStrutStyle)
+    }
+
+    pub fn set_strut_style(&mut self, strut_style: StrutStyle) {
+        self.native_mut().fStrutStyle.replace_with(strut_style);
+    }
+
+    pub fn text_style(&self) -> &TextStyle {
+        TextStyle::from_native_ref(&self.native().fDefaultTextStyle)
+    }
+
+    pub fn set_text_style(&mut self, text_style: &TextStyle) {
+        // TODO: implement the assignment operator in C.
+        self.native_mut()
+            .fDefaultTextStyle
+            .replace_with(text_style.clone());
+    }
+
+    pub fn text_direction(&self) -> TextDirection {
+        self.native().fTextDirection
+    }
+
+    pub fn set_text_direction(&mut self, direction: TextDirection) {
+        self.native_mut().fTextDirection = direction;
+    }
+
+    pub fn text_align(&self) -> TextAlign {
+        self.native().fTextAlign
+    }
+
+    pub fn set_text_align(&mut self, align: TextAlign) {
+        self.native_mut().fTextAlign = align
+    }
+
+    pub fn max_lines(&self) -> Option<usize> {
+        match self.native().fLinesLimit {
+            std::usize::MAX => None,
+            lines => Some(lines),
+        }
+    }
+
+    pub fn set_max_lines(&mut self, lines: impl Into<Option<usize>>) {
+        self.native_mut().fLinesLimit = lines.into().unwrap_or(usize::max_value())
+    }
+
+    pub fn ellipsis(&self) -> &str {
+        self.native().fEllipsis.as_str()
+    }
+
+    pub fn set_ellipsis(&mut self, ellipsis: impl AsRef<str>) {
+        self.native_mut().fEllipsis.set_str(ellipsis)
+    }
+
+    pub fn height(&self) -> scalar {
+        self.native().fHeight
+    }
+
+    pub fn set_height(&mut self, height: scalar) {
+        self.native_mut().fHeight = height;
+    }
+
+    pub fn unlimited_lines(&self) -> bool {
+        self.max_lines().is_none()
+    }
+
+    pub fn ellipsized(&self) -> bool {
+        !self.native().fEllipsis.as_str().is_empty()
+    }
+
+    pub fn effective_align(&self) -> TextAlign {
+        unsafe { self.native().effective_align() }
+    }
+
+    pub fn hinting_is_on(&self) -> bool {
+        self.native().fHintingIsOn
+    }
+
+    pub fn turn_hinting_off(&mut self) {
+        self.native_mut().fHintingIsOn = false
+    }
+}

--- a/skia-safe/src/modules/paragraph/text_shadow.rs
+++ b/skia-safe/src/modules/paragraph/text_shadow.rs
@@ -1,0 +1,45 @@
+use crate::prelude::*;
+use crate::{Color, Point};
+use skia_bindings as sb;
+
+#[derive(Copy, Clone, Debug)]
+pub struct TextShadow {
+    pub color: Color,
+    pub offset: Point,
+    pub blur_radius: f64,
+}
+
+impl NativeTransmutable<sb::skia_textlayout_TextShadow> for TextShadow {}
+
+#[test]
+fn text_shadow_layout() {
+    TextShadow::test_layout()
+}
+
+impl Default for TextShadow {
+    fn default() -> Self {
+        TextShadow::from_native(unsafe { sb::skia_textlayout_TextShadow::new() })
+    }
+}
+
+impl PartialEq for TextShadow {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { sb::C_TextShadow_Equals(self.native(), other.native()) }
+    }
+}
+
+impl TextShadow {
+    pub fn new(color: impl Into<Color>, offset: impl Into<Point>, blur_radius: f64) -> Self {
+        TextShadow::from_native(unsafe {
+            sb::skia_textlayout_TextShadow::new1(
+                color.into().into_native(),
+                offset.into().into_native(),
+                blur_radius,
+            )
+        })
+    }
+
+    pub fn has_shadow(&self) -> bool {
+        unsafe { self.native().hasShadow() }
+    }
+}

--- a/skia-safe/src/modules/paragraph/text_style.rs
+++ b/skia-safe/src/modules/paragraph/text_style.rs
@@ -88,8 +88,9 @@ impl Handle<sb::skia_textlayout_TextStyle> {
         Color::from_native(self.native().fColor)
     }
 
-    pub fn set_color(&mut self, color: impl Into<Color>) {
-        self.native_mut().fColor = color.into().into_native()
+    pub fn set_color(&mut self, color: impl Into<Color>) -> &mut Self {
+        self.native_mut().fColor = color.into().into_native();
+        self
     }
 
     pub fn foreground(&self) -> Option<&Paint> {
@@ -98,12 +99,13 @@ impl Handle<sb::skia_textlayout_TextStyle> {
             .if_true_some(Paint::from_native_ref(&self.native().fForeground))
     }
 
-    pub fn set_foreground_color(&mut self, paint: impl Into<Option<Paint>>) {
+    pub fn set_foreground_color(&mut self, paint: impl Into<Option<Paint>>) -> &mut Self {
         let n = self.native_mut();
         n.fHasForeground = paint
             .into()
             .map(|paint| n.fForeground.replace_with(paint))
             .is_some();
+        self
     }
 
     pub fn background(&self) -> Option<&Paint> {
@@ -112,12 +114,13 @@ impl Handle<sb::skia_textlayout_TextStyle> {
             .if_true_some(Paint::from_native_ref(&self.native().fBackground))
     }
 
-    pub fn set_background_color(&mut self, paint: impl Into<Option<Paint>>) {
+    pub fn set_background_color(&mut self, paint: impl Into<Option<Paint>>) -> &mut Self {
         let n = self.native_mut();
         n.fHasBackground = paint
             .into()
             .map(|paint| n.fBackground.replace_with(paint))
             .is_some();
+        self
     }
 
     pub fn decoration(&self) -> &Decoration {
@@ -132,8 +135,9 @@ impl Handle<sb::skia_textlayout_TextStyle> {
         FontStyle::from_native(self.native().fFontStyle)
     }
 
-    pub fn set_font_style(&mut self, font_style: FontStyle) {
-        self.native_mut().fFontStyle = font_style.into_native()
+    pub fn set_font_style(&mut self, font_style: FontStyle) -> &mut Self {
+        self.native_mut().fFontStyle = font_style.into_native();
+        self
     }
 
     pub fn shadows(&self) -> &[TextShadow] {
@@ -145,12 +149,14 @@ impl Handle<sb::skia_textlayout_TextStyle> {
         }
     }
 
-    pub fn add_shadow(&mut self, shadow: TextShadow) {
+    pub fn add_shadow(&mut self, shadow: TextShadow) -> &mut Self {
         unsafe { sb::C_TextStyle_addShadow(self.native_mut(), shadow.native()) }
+        self
     }
 
-    pub fn reset_shadows(&mut self) {
+    pub fn reset_shadows(&mut self) -> &mut Self {
         unsafe { sb::C_TextStyle_resetShadows(self.native_mut()) }
+        self
     }
 
     pub fn font_families(&self) -> FontFamilies {
@@ -161,32 +167,36 @@ impl Handle<sb::skia_textlayout_TextStyle> {
         }
     }
 
-    pub fn set_font_families(&mut self, families: &[impl AsRef<str>]) {
-        let families = interop::Strings::from_strs(families);
+    pub fn set_font_families(&mut self, families: &[impl AsRef<str>]) -> &mut Self {
+        let families: Vec<interop::String> = FromStrs::from_strs(families);
         let families = families.native();
         unsafe {
             sb::C_TextStyle_setFontFamilies(self.native_mut(), families.as_ptr(), families.len())
         }
+        self
     }
 
-    pub fn set_height(&mut self, height: scalar) {
+    pub fn set_height(&mut self, height: scalar) -> &mut Self {
         self.native_mut().fHeight = height;
+        self
     }
 
     pub fn height(&self) -> scalar {
         self.native().fHeight
     }
 
-    pub fn set_letter_spacing(&mut self, letter_spacing: scalar) {
+    pub fn set_letter_spacing(&mut self, letter_spacing: scalar) -> &mut Self {
         self.native_mut().fLetterSpacing = letter_spacing;
+        self
     }
 
     pub fn letter_spacing(&self) -> scalar {
         self.native().fLetterSpacing
     }
 
-    pub fn set_word_spacing(&mut self, word_spacing: scalar) {
+    pub fn set_word_spacing(&mut self, word_spacing: scalar) -> &mut Self {
         self.native_mut().fWordSpacing = word_spacing;
+        self
     }
 
     pub fn word_spacing(&self) -> scalar {
@@ -197,26 +207,29 @@ impl Handle<sb::skia_textlayout_TextStyle> {
         Typeface::from_unshared_ptr(self.native().fTypeface.fPtr)
     }
 
-    pub fn set_typeface(&mut self, typeface: impl Into<Option<Typeface>>) {
+    pub fn set_typeface(&mut self, typeface: impl Into<Option<Typeface>>) -> &mut Self {
         unsafe {
             sb::C_TextStyle_setTypeface(self.native_mut(), typeface.into().into_ptr_or_null())
         }
+        self
     }
 
     pub fn locale(&self) -> &str {
         self.native().fLocale.as_str()
     }
 
-    pub fn set_locale(&mut self, locale: impl AsRef<str>) {
-        self.native_mut().fLocale.set_str(locale)
+    pub fn set_locale(&mut self, locale: impl AsRef<str>) -> &mut Self {
+        self.native_mut().fLocale.set_str(locale);
+        self
     }
 
     pub fn text_baseline(&self) -> TextBaseline {
         self.native().fTextBaseline
     }
 
-    pub fn set_text_baseline(&mut self, baseline: TextBaseline) {
-        self.native_mut().fTextBaseline = baseline
+    pub fn set_text_baseline(&mut self, baseline: TextBaseline) -> &mut Self {
+        self.native_mut().fTextBaseline = baseline;
+        self
     }
 
     pub fn font_metrics(&self) -> FontMetrics {

--- a/skia-safe/src/modules/paragraph/text_style.rs
+++ b/skia-safe/src/modules/paragraph/text_style.rs
@@ -30,7 +30,7 @@ pub use sb::skia_textlayout_TextDecorationStyle as TextDecorationStyle;
 
 pub use sb::skia_textlayout_StyleType as StyleType;
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Default, Debug)]
 pub struct Decoration {
     pub ty: TextDecoration,
     pub color: Color,

--- a/skia-safe/src/modules/paragraph/text_style.rs
+++ b/skia-safe/src/modules/paragraph/text_style.rs
@@ -1,0 +1,227 @@
+use super::{FontFamilies, TextBaseline, TextShadow};
+use crate::interop::{AsStr, FromStrs, SetStr};
+use crate::prelude::*;
+use crate::{interop, scalar, Color, FontMetrics, FontStyle, Paint, Typeface};
+use skia_bindings as sb;
+use std::slice;
+
+bitflags! {
+    pub struct TextDecoration: u32 {
+        const NO_DECORATION = sb::skia_textlayout_TextDecoration::kNoDecoration as _;
+        const UNDERLINE = sb::skia_textlayout_TextDecoration::kUnderline as _;
+        const OVERLINE = sb::skia_textlayout_TextDecoration::kOverline as _;
+        const LINE_THROUGH = sb::skia_textlayout_TextDecoration::kOverline as _;
+    }
+}
+
+pub const ALL_TEXT_DECORATIONS: TextDecoration = TextDecoration::ALL;
+
+impl Default for TextDecoration {
+    fn default() -> Self {
+        TextDecoration::NO_DECORATION
+    }
+}
+
+impl TextDecoration {
+    pub const ALL: TextDecoration = TextDecoration::all();
+}
+
+pub use sb::skia_textlayout_TextDecorationStyle as TextDecorationStyle;
+
+pub use sb::skia_textlayout_StyleType as StyleType;
+
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct Decoration {
+    pub ty: TextDecoration,
+    pub color: Color,
+    pub style: TextDecorationStyle,
+    pub thickness_multiplier: scalar,
+}
+
+impl NativeTransmutable<sb::skia_textlayout_Decoration> for Decoration {}
+
+#[test]
+fn decoration_layout() {
+    Decoration::test_layout();
+}
+
+pub type TextStyle = Handle<sb::skia_textlayout_TextStyle>;
+
+impl NativeDrop for sb::skia_textlayout_TextStyle {
+    fn drop(&mut self) {
+        unsafe { sb::C_TextStyle_destruct(self) }
+    }
+}
+
+impl NativeClone for sb::skia_textlayout_TextStyle {
+    fn clone(&self) -> Self {
+        construct(|ts| unsafe { sb::C_TextStyle_CopyConstruct(ts, self) })
+    }
+}
+
+impl NativePartialEq for sb::skia_textlayout_TextStyle {
+    fn eq(&self, rhs: &Self) -> bool {
+        unsafe { self.equals(rhs) }
+    }
+}
+
+impl Default for Handle<sb::skia_textlayout_TextStyle> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Handle<sb::skia_textlayout_TextStyle> {
+    pub fn new() -> Self {
+        TextStyle::from_native(unsafe { sb::skia_textlayout_TextStyle::new() })
+    }
+
+    pub fn equals(&self, other: &TextStyle) -> bool {
+        *self == *other
+    }
+
+    pub fn match_one_attribute(&self, style_type: StyleType, other: &TextStyle) -> bool {
+        unsafe { self.native().matchOneAttribute(style_type, other.native()) }
+    }
+
+    pub fn color(&self) -> Color {
+        Color::from_native(self.native().fColor)
+    }
+
+    pub fn set_color(&mut self, color: impl Into<Color>) {
+        self.native_mut().fColor = color.into().into_native()
+    }
+
+    pub fn foreground(&self) -> Option<&Paint> {
+        self.native()
+            .fHasForeground
+            .if_true_some(Paint::from_native_ref(&self.native().fForeground))
+    }
+
+    pub fn set_foreground_color(&mut self, paint: impl Into<Option<Paint>>) {
+        let n = self.native_mut();
+        n.fHasForeground = paint
+            .into()
+            .map(|paint| n.fForeground.replace_with(paint))
+            .is_some();
+    }
+
+    pub fn background(&self) -> Option<&Paint> {
+        self.native()
+            .fHasBackground
+            .if_true_some(Paint::from_native_ref(&self.native().fBackground))
+    }
+
+    pub fn set_background_color(&mut self, paint: impl Into<Option<Paint>>) {
+        let n = self.native_mut();
+        n.fHasBackground = paint
+            .into()
+            .map(|paint| n.fBackground.replace_with(paint))
+            .is_some();
+    }
+
+    pub fn decoration(&self) -> &Decoration {
+        Decoration::from_native_ref(&self.native().fDecoration)
+    }
+
+    pub fn decoration_mut(&mut self) -> &mut Decoration {
+        Decoration::from_native_ref_mut(&mut self.native_mut().fDecoration)
+    }
+
+    pub fn font_style(&self) -> FontStyle {
+        FontStyle::from_native(self.native().fFontStyle)
+    }
+
+    pub fn set_font_style(&mut self, font_style: FontStyle) {
+        self.native_mut().fFontStyle = font_style.into_native()
+    }
+
+    pub fn shadows(&self) -> &[TextShadow] {
+        unsafe {
+            let ts: &sb::TextShadows = transmute_ref(&self.native().fTextShadows);
+            let mut cnt = 0;
+            let ptr = TextShadow::from_native_ref(&*sb::C_TextShadows_ptr_count(ts, &mut cnt));
+            slice::from_raw_parts(ptr, cnt)
+        }
+    }
+
+    pub fn add_shadow(&mut self, shadow: TextShadow) {
+        unsafe { sb::C_TextStyle_addShadow(self.native_mut(), shadow.native()) }
+    }
+
+    pub fn reset_shadows(&mut self) {
+        unsafe { sb::C_TextStyle_resetShadows(self.native_mut()) }
+    }
+
+    pub fn font_families(&self) -> FontFamilies {
+        unsafe {
+            let mut count = 0;
+            let ptr = sb::C_TextStyle_getFontFamilies(self.native(), &mut count);
+            FontFamilies(slice::from_raw_parts(ptr, count))
+        }
+    }
+
+    pub fn set_font_families(&mut self, families: &[impl AsRef<str>]) {
+        let families = interop::Strings::from_strs(families);
+        let families = families.native();
+        unsafe {
+            sb::C_TextStyle_setFontFamilies(self.native_mut(), families.as_ptr(), families.len())
+        }
+    }
+
+    pub fn set_height(&mut self, height: scalar) {
+        self.native_mut().fHeight = height;
+    }
+
+    pub fn height(&self) -> scalar {
+        self.native().fHeight
+    }
+
+    pub fn set_letter_spacing(&mut self, letter_spacing: scalar) {
+        self.native_mut().fLetterSpacing = letter_spacing;
+    }
+
+    pub fn letter_spacing(&self) -> scalar {
+        self.native().fLetterSpacing
+    }
+
+    pub fn set_word_spacing(&mut self, word_spacing: scalar) {
+        self.native_mut().fWordSpacing = word_spacing;
+    }
+
+    pub fn word_spacing(&self) -> scalar {
+        self.native().fWordSpacing
+    }
+
+    pub fn typeface(&self) -> Option<Typeface> {
+        Typeface::from_unshared_ptr(self.native().fTypeface.fPtr)
+    }
+
+    pub fn set_typeface(&mut self, typeface: impl Into<Option<Typeface>>) {
+        unsafe {
+            sb::C_TextStyle_setTypeface(self.native_mut(), typeface.into().into_ptr_or_null())
+        }
+    }
+
+    pub fn locale(&self) -> &str {
+        self.native().fLocale.as_str()
+    }
+
+    pub fn set_locale(&mut self, locale: impl AsRef<str>) {
+        self.native_mut().fLocale.set_str(locale)
+    }
+
+    pub fn text_baseline(&self) -> TextBaseline {
+        self.native().fTextBaseline
+    }
+
+    pub fn set_text_baseline(&mut self, baseline: TextBaseline) {
+        self.native_mut().fTextBaseline = baseline
+    }
+
+    pub fn font_metrics(&self) -> FontMetrics {
+        let mut m = FontMetrics::default();
+        unsafe { sb::C_TextStyle_getFontMetrics(self.native(), m.native_mut()) }
+        m
+    }
+}

--- a/skia-safe/src/modules/paragraph/typeface_font_provider.rs
+++ b/skia-safe/src/modules/paragraph/typeface_font_provider.rs
@@ -38,8 +38,9 @@ impl RCHandle<sb::skia_textlayout_TypefaceFontStyleSet> {
         self.native().fAlias.as_str()
     }
 
-    pub fn append_typeface(&mut self, typeface: Typeface) {
+    pub fn append_typeface(&mut self, typeface: Typeface) -> &mut Self {
         unsafe { sb::C_TypefaceFontStyleSet_appendTypeface(self.native_mut(), typeface.into_ptr()) }
+        self
     }
 }
 

--- a/skia-safe/src/modules/paragraph/typeface_font_provider.rs
+++ b/skia-safe/src/modules/paragraph/typeface_font_provider.rs
@@ -1,0 +1,126 @@
+use crate::interop::AsStr;
+use crate::prelude::*;
+use crate::{interop, FontMgr, FontStyleSet, Typeface};
+use skia_bindings as sb;
+use std::ops::{Deref, DerefMut};
+use std::ptr;
+
+pub type TypefaceFontStyleSet = RCHandle<sb::skia_textlayout_TypefaceFontStyleSet>;
+
+impl NativeRefCountedBase for sb::skia_textlayout_TypefaceFontStyleSet {
+    type Base = sb::SkRefCntBase;
+}
+
+impl Deref for RCHandle<sb::skia_textlayout_TypefaceFontStyleSet> {
+    type Target = FontStyleSet;
+    fn deref(&self) -> &Self::Target {
+        unsafe { transmute_ref(self) }
+    }
+}
+
+impl DerefMut for RCHandle<sb::skia_textlayout_TypefaceFontStyleSet> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { transmute_ref_mut(self) }
+    }
+}
+
+impl RCHandle<sb::skia_textlayout_TypefaceFontStyleSet> {
+    pub fn new(family_name: impl AsRef<str>) -> Self {
+        let family = interop::String::from_str(family_name.as_ref());
+        Self::from_ptr(unsafe { sb::C_TypefaceFontStyleSet_new(family.native()) }).unwrap()
+    }
+
+    pub fn family_name(&self) -> &str {
+        self.native().fFamilyName.as_str()
+    }
+
+    pub fn alias(&self) -> &str {
+        self.native().fAlias.as_str()
+    }
+
+    pub fn append_typeface(&mut self, typeface: Typeface) {
+        unsafe { sb::C_TypefaceFontStyleSet_appendTypeface(self.native_mut(), typeface.into_ptr()) }
+    }
+}
+
+pub type TypefaceFontProvider = RCHandle<sb::skia_textlayout_TypefaceFontProvider>;
+
+impl NativeRefCountedBase for sb::skia_textlayout_TypefaceFontProvider {
+    type Base = sb::SkRefCntBase;
+}
+
+impl Deref for RCHandle<sb::skia_textlayout_TypefaceFontProvider> {
+    type Target = FontMgr;
+    fn deref(&self) -> &Self::Target {
+        unsafe { transmute_ref(self) }
+    }
+}
+
+impl DerefMut for RCHandle<sb::skia_textlayout_TypefaceFontProvider> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { transmute_ref_mut(self) }
+    }
+}
+
+impl Default for RCHandle<sb::skia_textlayout_TypefaceFontProvider> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RCHandle<sb::skia_textlayout_TypefaceFontProvider> {
+    pub fn new() -> Self {
+        Self::from_ptr(unsafe { sb::C_TypefaceFontProvider_new() }).unwrap()
+    }
+
+    pub fn register_typeface(
+        &mut self,
+        typeface: Typeface,
+        alias: Option<impl AsRef<str>>,
+    ) -> usize {
+        unsafe {
+            match alias {
+                Some(alias) => {
+                    let alias = interop::String::from_str(alias.as_ref());
+                    sb::C_TypefaceFontProvider_registerTypeface(
+                        self.native_mut(),
+                        typeface.into_ptr(),
+                        alias.native(),
+                    )
+                }
+                None => sb::C_TypefaceFontProvider_registerTypeface(
+                    self.native_mut(),
+                    typeface.into_ptr(),
+                    ptr::null(),
+                ),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TypefaceFontStyleSet;
+    use crate::prelude::{NativeAccess, NativeRefCounted, NativeRefCountedBase};
+    use crate::Typeface;
+
+    #[test]
+    #[serial_test_derive::serial]
+    fn font_style_set_typeface_ref_counts() {
+        let mut style_set = TypefaceFontStyleSet::new("");
+        assert_eq!(style_set.native().ref_counted_base()._ref_cnt(), 1);
+
+        let tf = Typeface::default();
+        let base_cnt = tf.native().ref_counted_base()._ref_cnt();
+
+        let tfclone = tf.clone();
+        assert_eq!(tf.native().ref_counted_base()._ref_cnt(), base_cnt + 1);
+
+        style_set.append_typeface(tfclone);
+        assert_eq!(tf.native().ref_counted_base()._ref_cnt(), base_cnt + 1);
+
+        drop(style_set);
+        assert_eq!(tf.native().ref_counted_base()._ref_cnt(), base_cnt);
+        drop(tf);
+    }
+}

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -575,6 +575,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test_derive::serial]
     fn test_rtl_text_shaping() {
         skia_bindings::icu::init();
 

--- a/skia-safe/src/prelude.rs
+++ b/skia-safe/src/prelude.rs
@@ -494,9 +494,7 @@ impl<N: NativeRefCounted> NativeAccess<N> for RCHandle<N> {
 
 impl<N: NativeRefCounted> Clone for RCHandle<N> {
     fn clone(&self) -> Self {
-        // yes, we _do_ support shared mutability when
-        // a ref-counted handle is cloned, so beware of spooky action at
-        // a distance.
+        // Support shared mutability when a ref-counted handle is cloned.
         let ptr = self.0;
         unsafe { (&*ptr)._ref() };
         Self(ptr)


### PR DESCRIPTION
This PR adds the C bindings and Rust wrappers for the skparagraph module to the M77 branch.

- [x] C bindings
- [x] Rust wrapper
- [x] Rename feature `paragraph` to `textlayout`?
- [x] return `-> &mut Self` for setters of *Style types
- [ ] Support to build on all platforms
- [ ] Add example
- [ ] Update README
