### PR TITLE
Pass some reference counted types by value

### DIFF
--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1664,8 +1664,8 @@ extern "C" SkDrawable* C_SkDrawable_Deserialize(const void* data, size_t length)
     return SkDrawable::Deserialize(data, length).release();
 }
 
-extern "C" void C_SkDrawable_GpuDrawHandler_destruct(SkDrawable::GpuDrawHandler *self) {
-    self->~GpuDrawHandler();
+extern "C" void C_SkDrawable_GpuDrawHandler_delete(SkDrawable::GpuDrawHandler *self) {
+    delete self;
 }
 
 extern "C" void C_SkDrawable_GpuDrawHandler_draw(SkDrawable::GpuDrawHandler *self, const GrBackendDrawableInfo *info) {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1203,8 +1203,8 @@ extern "C" SkTypeface* C_SkTypeface_MakeFromFile(const char path[], int index) {
 }
 */
 
-extern "C" SkTypeface* C_SkTypeface_MakeFromData(const SkData* data, int index) {
-    return SkTypeface::MakeFromData(sk_sp<SkData>(const_cast<SkData*>(data)), index).release();
+extern "C" SkTypeface* C_SkTypeface_MakeFromData(SkData* data, int index) {
+    return SkTypeface::MakeFromData(sp(data), index).release();
 }
 
 extern "C" SkTypeface* C_SkTypeface_makeClone(const SkTypeface* self, const SkFontArguments* arguments) {
@@ -2438,9 +2438,9 @@ extern "C" const GrGLInterface* C_GrGLInterface_MakeNativeInterface() {
 // gpu/GrContext.h
 //
 
-extern "C" GrContext* C_GrContext_MakeGL(const GrGLInterface* interface) {
+extern "C" GrContext* C_GrContext_MakeGL(GrGLInterface* interface) {
     if (interface)
-        return GrContext::MakeGL(sk_sp<const GrGLInterface>(interface)).release();
+        return GrContext::MakeGL(sp(interface)).release();
     else
         return GrContext::MakeGL().release();
 }

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -108,9 +108,10 @@
 #endif
 
 template<typename T>
-inline sk_sp<T> spFromConst(const T* pt) {
-    return sk_sp<T>(const_cast<T*>(pt));
+inline sk_sp<T> sp(T* pt) {
+    return sk_sp<T>(pt);
 }
+
 
 //
 // codec/SkEncodedOrigin.h
@@ -142,7 +143,7 @@ extern "C" SkSurface* C_SkSurface_MakeFromBackendTexture(
         GrSurfaceOrigin origin,
         int sampleCnt,
         SkColorType colorType,
-        const SkColorSpace* colorSpace,
+        SkColorSpace* colorSpace,
         const SkSurfaceProps* surfaceProps) {
     return SkSurface::MakeFromBackendTexture(
             context,
@@ -150,7 +151,7 @@ extern "C" SkSurface* C_SkSurface_MakeFromBackendTexture(
             origin,
             sampleCnt,
             colorType,
-            spFromConst(colorSpace), surfaceProps).release();
+            sp(colorSpace), surfaceProps).release();
 }
 
 extern "C" SkSurface* C_SkSurface_MakeFromBackendRenderTarget(
@@ -158,7 +159,7 @@ extern "C" SkSurface* C_SkSurface_MakeFromBackendRenderTarget(
         const GrBackendRenderTarget* backendRenderTarget,
         GrSurfaceOrigin origin,
         SkColorType colorType,
-        const SkColorSpace* colorSpace,
+        SkColorSpace* colorSpace,
         const SkSurfaceProps* surfaceProps
         ) {
     return SkSurface::MakeFromBackendRenderTarget(
@@ -166,7 +167,7 @@ extern "C" SkSurface* C_SkSurface_MakeFromBackendRenderTarget(
             *backendRenderTarget,
             origin,
             colorType,
-            spFromConst(colorSpace),
+            sp(colorSpace),
             surfaceProps).release();
 }
 
@@ -176,7 +177,7 @@ extern "C" SkSurface* C_SkSurface_MakeFromBackendTextureAsRenderTarget(
         GrSurfaceOrigin origin,
         int sampleCnt,
         SkColorType colorType,
-        const SkColorSpace* colorSpace,
+        SkColorSpace* colorSpace,
         const SkSurfaceProps* surfaceProps) {
     return SkSurface::MakeFromBackendTextureAsRenderTarget(
             context,
@@ -184,7 +185,7 @@ extern "C" SkSurface* C_SkSurface_MakeFromBackendTextureAsRenderTarget(
             origin,
             sampleCnt,
             colorType,
-            spFromConst(colorSpace), surfaceProps).release();
+            sp(colorSpace), surfaceProps).release();
 }
 
 extern "C" SkSurface* C_SkSurface_MakeRenderTarget(
@@ -286,8 +287,8 @@ extern "C" const SkImageInfo* C_SkSurfaceCharacterization_imageInfo(const SkSurf
 // SkImage
 //
 
-extern "C" SkImage* C_SkImage_MakeRasterData(const SkImageInfo* info, const SkData* pixels, size_t rowBytes) {
-    return SkImage::MakeRasterData(*info, spFromConst(pixels), rowBytes).release();
+extern "C" SkImage* C_SkImage_MakeRasterData(const SkImageInfo* info, SkData* pixels, size_t rowBytes) {
+    return SkImage::MakeRasterData(*info, sp(pixels), rowBytes).release();
 }
 
 extern "C" SkImage* C_SkImage_MakeFromBitmap(const SkBitmap* bitmap) {
@@ -298,12 +299,12 @@ extern "C" SkImage* C_SkImage_MakeFromGenerator(SkImageGenerator* imageGenerator
     return SkImage::MakeFromGenerator(std::unique_ptr<SkImageGenerator>(imageGenerator), subset).release();
 }
 
-extern "C" SkImage* C_SkImage_MakeFromEncoded(const SkData* encoded, const SkIRect* subset) {
-    return SkImage::MakeFromEncoded(spFromConst(encoded), subset).release();
+extern "C" SkImage* C_SkImage_MakeFromEncoded(SkData* encoded, const SkIRect* subset) {
+    return SkImage::MakeFromEncoded(sp(encoded), subset).release();
 }
 
-extern "C" SkImage* C_SkImage_MakeFromCompressed(GrContext* context, const SkData* encoded, int width, int height, SkImage::CompressionType type) {
-    return SkImage::MakeFromCompressed(context, spFromConst(encoded), width, height, type).release();
+extern "C" SkImage* C_SkImage_MakeFromCompressed(GrContext* context, SkData* encoded, int width, int height, SkImage::CompressionType type) {
+    return SkImage::MakeFromCompressed(context, sp(encoded), width, height, type).release();
 }
 
 extern "C" SkImage* C_SkImage_MakeFromTexture(
@@ -312,18 +313,18 @@ extern "C" SkImage* C_SkImage_MakeFromTexture(
         GrSurfaceOrigin origin,
         SkColorType colorType,
         SkAlphaType alphaType,
-        const SkColorSpace* colorSpace) {
-    return SkImage::MakeFromTexture(context, *backendTexture, origin, colorType, alphaType, spFromConst(colorSpace)).release();
+        SkColorSpace* colorSpace) {
+    return SkImage::MakeFromTexture(context, *backendTexture, origin, colorType, alphaType, sp(colorSpace)).release();
 }
 
 extern "C" SkImage* C_SkImage_MakeCrossContextFromEncoded(
         GrContext* context,
-        const SkData* data,
+        SkData* data,
         bool buildMips,
         const SkColorSpace* dstColorSpace,
         bool limitToMaxTextureSize
         ) {
-    return SkImage::MakeCrossContextFromEncoded(context, spFromConst(data), buildMips, const_cast<SkColorSpace*>(dstColorSpace), limitToMaxTextureSize).release();
+    return SkImage::MakeCrossContextFromEncoded(context, sp(data), buildMips, const_cast<SkColorSpace*>(dstColorSpace), limitToMaxTextureSize).release();
 }
 
 extern "C" SkImage* C_SkImage_MakeFromAdoptedTexture(
@@ -332,8 +333,8 @@ extern "C" SkImage* C_SkImage_MakeFromAdoptedTexture(
         GrSurfaceOrigin origin,
         SkColorType colorType,
         SkAlphaType alphaType,
-        const SkColorSpace* colorSpace) {
-    return SkImage::MakeFromAdoptedTexture(context, *backendTexture, origin, colorType, alphaType, spFromConst(colorSpace)).release();
+        SkColorSpace* colorSpace) {
+    return SkImage::MakeFromAdoptedTexture(context, *backendTexture, origin, colorType, alphaType, sp(colorSpace)).release();
 }
 
 extern "C" SkImage* C_SkImage_MakeFromYUVATexturesCopy(
@@ -343,11 +344,11 @@ extern "C" SkImage* C_SkImage_MakeFromYUVATexturesCopy(
         const SkYUVAIndex yuvaIndices[4],
         SkISize imageSize,
         GrSurfaceOrigin imageOrigin,
-        const SkColorSpace* colorSpace) {
+        SkColorSpace* colorSpace) {
     return SkImage::MakeFromYUVATexturesCopy(
             context,
             yuvColorSpace, yuvaTextures, yuvaIndices,
-            imageSize, imageOrigin, spFromConst(colorSpace)).release();
+            imageSize, imageOrigin, sp(colorSpace)).release();
 }
 
 extern "C" SkImage* C_SkImage_MakeFromYUVATexturesCopyWithExternalBackend(
@@ -358,12 +359,12 @@ extern "C" SkImage* C_SkImage_MakeFromYUVATexturesCopyWithExternalBackend(
         SkISize imageSize,
         GrSurfaceOrigin imageOrigin,
         const GrBackendTexture& backendTexture,
-        const SkColorSpace* colorSpace) {
+        SkColorSpace* colorSpace) {
     return SkImage::MakeFromYUVATexturesCopyWithExternalBackend(
             context,
             yuvColorSpace, yuvaTextures, yuvaIndices,
             imageSize, imageOrigin, backendTexture,
-            spFromConst(colorSpace)).release();
+            sp(colorSpace)).release();
 }
 
 extern "C" SkImage* C_SkImage_MakeFromYUVATextures(
@@ -373,11 +374,11 @@ extern "C" SkImage* C_SkImage_MakeFromYUVATextures(
         const SkYUVAIndex yuvaIndices[4],
         SkISize imageSize,
         GrSurfaceOrigin imageOrigin,
-        const SkColorSpace* colorSpace) {
+        SkColorSpace* colorSpace) {
     return SkImage::MakeFromYUVATextures(
             context,
             yuvColorSpace, yuvaTextures, yuvaIndices,
-            imageSize, imageOrigin, spFromConst(colorSpace)).release();
+            imageSize, imageOrigin, sp(colorSpace)).release();
 }
 
 extern "C" SkImage* C_SkImage_MakeFromNV12TexturesCopy(
@@ -385,10 +386,10 @@ extern "C" SkImage* C_SkImage_MakeFromNV12TexturesCopy(
         SkYUVColorSpace yuvColorSpace,
         const GrBackendTexture nv12Textures[2],
         GrSurfaceOrigin imageOrigin,
-        const SkColorSpace* imageColorSpace) {
+        SkColorSpace* imageColorSpace) {
     return SkImage::MakeFromNV12TexturesCopy(
             context, yuvColorSpace, nv12Textures, imageOrigin,
-            spFromConst(imageColorSpace)).release();
+            sp(imageColorSpace)).release();
 }
 
 extern "C" SkImage* C_SkImage_MakeFromNV12TexturesCopyWithExternalBackend(
@@ -397,21 +398,21 @@ extern "C" SkImage* C_SkImage_MakeFromNV12TexturesCopyWithExternalBackend(
         const GrBackendTexture nv12Textures[2],
         GrSurfaceOrigin imageOrigin,
         const GrBackendTexture* backendTexture,
-        const SkColorSpace* imageColorSpace) {
+        SkColorSpace* imageColorSpace) {
     return SkImage::MakeFromNV12TexturesCopyWithExternalBackend(
             context,
             yuvColorSpace, nv12Textures, imageOrigin, *backendTexture,
-            spFromConst(imageColorSpace)).release();
+            sp(imageColorSpace)).release();
 }
 
 extern "C" SkImage* C_SkImage_MakeFromPicture(
-        const SkPicture* picture,
+        SkPicture* picture,
         const SkISize* dimensions,
         const SkMatrix* matrix,
         const SkPaint* paint,
         SkImage::BitDepth bitDepth,
-        const SkColorSpace* colorSpace) {
-    return SkImage::MakeFromPicture(spFromConst(picture), *dimensions, matrix, paint, bitDepth, spFromConst(colorSpace)).release();
+        SkColorSpace* colorSpace) {
+    return SkImage::MakeFromPicture(sp(picture), *dimensions, matrix, paint, bitDepth, sp(colorSpace)).release();
 }
 
 extern "C" SkShader* C_SkImage_makeShader(const SkImage* self, SkTileMode tileMode1, SkTileMode tileMode2, const SkMatrix* localMatrix) {
@@ -462,8 +463,8 @@ extern "C" SkImage *C_SkImage_makeWithFilter(const SkImage *self, GrContext *con
     return self->makeWithFilter(context, filter, *subset, *clipBounds, outSubset, offset).release();
 }
 
-extern "C" SkImage* C_SkImage_makeColorSpace(const SkImage* self, const SkColorSpace* target) {
-    return self->makeColorSpace(spFromConst(target)).release();
+extern "C" SkImage* C_SkImage_makeColorSpace(const SkImage* self, SkColorSpace* target) {
+    return self->makeColorSpace(sp(target)).release();
 }
 
 //
@@ -562,36 +563,36 @@ extern "C" SkPaint::Join C_SkPaint_getStrokeJoin(const SkPaint* self) {
     return self->getStrokeJoin();
 }
 
-extern "C" void C_SkPaint_setShader(SkPaint* self, const SkShader* shader) {
-    self->setShader(spFromConst(shader));
+extern "C" void C_SkPaint_setShader(SkPaint* self, SkShader* shader) {
+    self->setShader(sp(shader));
 }
 
-extern "C" void C_SkPaint_setColorFilter(SkPaint* self, const SkColorFilter* colorFilter) {
-    self->setColorFilter(spFromConst(colorFilter));
+extern "C" void C_SkPaint_setColorFilter(SkPaint* self, SkColorFilter* colorFilter) {
+    self->setColorFilter(sp(colorFilter));
 }
 
 extern "C" SkBlendMode C_SkPaint_getBlendMode(const SkPaint* self) {
     return self->getBlendMode();
 }
 
-extern "C" void C_SkPaint_setPathEffect(SkPaint* self, const SkPathEffect* pathEffect) {
-    self->setPathEffect(spFromConst(pathEffect));
+extern "C" void C_SkPaint_setPathEffect(SkPaint* self, SkPathEffect* pathEffect) {
+    self->setPathEffect(sp(pathEffect));
 }
 
-extern "C" void C_SkPaint_setMaskFilter(SkPaint* self, const SkMaskFilter* maskFilter) {
-    self->setMaskFilter(spFromConst(maskFilter));
+extern "C" void C_SkPaint_setMaskFilter(SkPaint* self, SkMaskFilter* maskFilter) {
+    self->setMaskFilter(sp(maskFilter));
 }
 
-extern "C" void C_SkPaint_setImageFilter(SkPaint* self, const SkImageFilter* imageFilter) {
-    self->setImageFilter(spFromConst(imageFilter));
+extern "C" void C_SkPaint_setImageFilter(SkPaint* self, SkImageFilter* imageFilter) {
+    self->setImageFilter(sp(imageFilter));
 }
 
 extern "C" SkDrawLooper* C_SkPaint_getDrawLooper(const SkPaint* self) {
     return self->getDrawLooper();
 }
 
-extern "C" void C_SkPaint_setDrawLooper(SkPaint* self, const SkDrawLooper* drawLooper) {
-    self->setDrawLooper(spFromConst(drawLooper));
+extern "C" void C_SkPaint_setDrawLooper(SkPaint* self, SkDrawLooper* drawLooper) {
+    self->setDrawLooper(sp(drawLooper));
 }
 
 //
@@ -777,8 +778,8 @@ extern "C" bool C_SkImageInfo_Equals(const SkImageInfo* lhs, const SkImageInfo* 
     return *lhs == *rhs;
 }
 
-extern "C" void C_SkImageInfo_Make(SkImageInfo* self, int width, int height, SkColorType ct, SkAlphaType at, const SkColorSpace* cs) {
-    *self = SkImageInfo::Make(width, height, ct, at, spFromConst(cs));
+extern "C" void C_SkImageInfo_Make(SkImageInfo* self, int width, int height, SkColorType ct, SkAlphaType at, SkColorSpace* cs) {
+    *self = SkImageInfo::Make(width, height, ct, at, sp(cs));
 }
 
 extern "C" void C_SkImageInfo_MakeS32(SkImageInfo* self, int width, int height, SkAlphaType at) {
@@ -946,8 +947,8 @@ extern "C" bool C_SkBitmap_tryAllocPixels(SkBitmap* self) {
     return self->tryAllocPixels();
 }
 
-extern "C" void C_SkBitmap_setPixelRef(SkBitmap* self, const SkPixelRef* pixelRef, int dx, int dy) {
-    self->setPixelRef(spFromConst(pixelRef), dx, dy);
+extern "C" void C_SkBitmap_setPixelRef(SkBitmap* self, SkPixelRef* pixelRef, int dx, int dy) {
+    self->setPixelRef(sp(pixelRef), dx, dy);
 }
 
 extern "C" bool C_SkBitmap_readyToDraw(const SkBitmap* self) {
@@ -1268,16 +1269,16 @@ extern "C" SkData* C_SkFlattenable_serialize(const SkFlattenable* self) {
 // core/SkFont.h
 //
 
-extern "C" void C_SkFont_ConstructFromTypeface(SkFont* uninitialized, const SkTypeface* typeface) {
-    new(uninitialized) SkFont(spFromConst(typeface));
+extern "C" void C_SkFont_ConstructFromTypeface(SkFont* uninitialized, SkTypeface* typeface) {
+    new(uninitialized) SkFont(sp(typeface));
 }
 
-extern "C" void C_SkFont_ConstructFromTypefaceWithSize(SkFont* uninitialized, const SkTypeface* typeface, SkScalar size) {
-    new(uninitialized) SkFont(spFromConst(typeface), size);
+extern "C" void C_SkFont_ConstructFromTypefaceWithSize(SkFont* uninitialized, SkTypeface* typeface, SkScalar size) {
+    new(uninitialized) SkFont(sp(typeface), size);
 }
 
-extern "C" void C_SkFont_ConstructFromTypefaceWithSizeScaleAndSkew(SkFont* uninitialized, const SkTypeface* typeface, SkScalar size, SkScalar scaleX, SkScalar skewX) {
-    new(uninitialized) SkFont(spFromConst(typeface), size, scaleX, skewX);
+extern "C" void C_SkFont_ConstructFromTypefaceWithSizeScaleAndSkew(SkFont* uninitialized, SkTypeface* typeface, SkScalar size, SkScalar scaleX, SkScalar skewX) {
+    new(uninitialized) SkFont(sp(typeface), size, scaleX, skewX);
 }
 
 extern "C" bool C_SkFont_Equals(const SkFont* self, const SkFont* other) {
@@ -1300,8 +1301,8 @@ extern "C" SkTypeface* C_SkFont_getTypeface(SkFont* self) {
     return self->getTypeface();
 }
 
-extern "C" void C_SkFont_setTypeface(SkFont* self, const SkTypeface* tf) {
-    self->setTypeface(spFromConst(tf));
+extern "C" void C_SkFont_setTypeface(SkFont* self, SkTypeface* tf) {
+    self->setTypeface(sp(tf));
 }
 
 extern "C" void C_SkFont_destruct(SkFont* self) {
@@ -1535,8 +1536,8 @@ extern "C" bool C_SkRefCntBase_unique(const SkRefCntBase* self) {
 // SkColorFilter
 //
 
-extern "C" SkColorFilter* C_SkColorFilter_makeComposed(const SkColorFilter* self, const SkColorFilter* inner) {
-    return self->makeComposed(spFromConst(inner)).release();
+extern "C" SkColorFilter* C_SkColorFilter_makeComposed(const SkColorFilter* self, SkColorFilter* inner) {
+    return self->makeComposed(sp(inner)).release();
 }
 
 extern "C" bool C_SkColorFilter_asAColorMode(const SkColorFilter* self, SkColor* color, SkBlendMode* mode) {
@@ -1559,8 +1560,8 @@ extern "C" SkColorFilter* C_SkColorFilter_Deserialize(const void* data, size_t s
 // SkColorFilters
 //
 
-extern "C" SkColorFilter* C_SkColorFilters_Compose(const SkColorFilter* outer, const SkColorFilter* inner) {
-    return SkColorFilters::Compose(spFromConst(outer), spFromConst(inner)).release();
+extern "C" SkColorFilter* C_SkColorFilters_Compose(SkColorFilter* outer, SkColorFilter* inner) {
+    return SkColorFilters::Compose(sp(outer), sp(inner)).release();
 }
 
 extern "C" SkColorFilter* C_SkColorFilters_Blend(const SkColor c, SkBlendMode blendMode) {
@@ -1584,8 +1585,8 @@ extern "C" SkColorFilter* C_SkColorFilters_SRGBToLinearGamma() {
     return SkColorFilters::SRGBToLinearGamma().release();
 }
 
-extern "C" SkColorFilter* C_SkColorFilters_Lerp(float t, const SkColorFilter* dst, const SkColorFilter* src) {
-    return SkColorFilters::Lerp(t, spFromConst(dst), spFromConst(src)).release();
+extern "C" SkColorFilter* C_SkColorFilters_Lerp(float t, SkColorFilter* dst, SkColorFilter* src) {
+    return SkColorFilters::Lerp(t, sp(dst), sp(src)).release();
 }
 
 //
@@ -1684,8 +1685,8 @@ extern "C" SkImageFilter* C_SkImageFilter_makeWithLocalMatrix(const SkImageFilte
     return self->makeWithLocalMatrix(*matrix).release();
 }
 
-extern "C" SkImageFilter* C_SkImageFilter_MakeMatrixFilter(const SkMatrix* matrix, SkFilterQuality quality, const SkImageFilter* input) {
-    return SkImageFilter::MakeMatrixFilter(*matrix, quality, spFromConst(input)).release();
+extern "C" SkImageFilter* C_SkImageFilter_MakeMatrixFilter(const SkMatrix* matrix, SkFilterQuality quality, SkImageFilter* input) {
+    return SkImageFilter::MakeMatrixFilter(*matrix, quality, sp(input)).release();
 }
 
 extern "C" SkImageFilter* C_SkImageFilter_Deserialize(const void* data, size_t length) {
@@ -1720,24 +1721,24 @@ extern "C" bool C_SkImageGenerator_isValid(const SkImageGenerator* self, GrConte
     return self->isValid(context);
 }
 
-extern "C" SkImageGenerator *C_SkImageGenerator_MakeFromEncoded(const SkData *data) {
-    return SkImageGenerator::MakeFromEncoded(spFromConst(data)).release();
+extern "C" SkImageGenerator *C_SkImageGenerator_MakeFromEncoded(SkData *data) {
+    return SkImageGenerator::MakeFromEncoded(sp(data)).release();
 }
 
 extern "C" SkImageGenerator *C_SkImageGenerator_MakeFromPicture(
         const SkISize *size,
-        const SkPicture *picture,
+        SkPicture *picture,
         const SkMatrix *matrix,
         const SkPaint *paint,
         SkImage::BitDepth bd,
-        const SkColorSpace *cs) {
+        SkColorSpace *cs) {
     return SkImageGenerator::MakeFromPicture(
             *size,
-            spFromConst(picture),
+            sp(picture),
             matrix,
             paint,
             bd,
-            spFromConst(cs)).release();
+            sp(cs)).release();
 }
 
 //
@@ -1784,12 +1785,12 @@ extern "C" bool C_SkStrokeRec_hasEqualEffect(const SkStrokeRec* self, const SkSt
 // SkPathEffect
 //
 
-extern "C" SkPathEffect* C_SkPathEffect_MakeSum(const SkPathEffect* first, const SkPathEffect* second) {
-    return SkPathEffect::MakeSum(spFromConst(first), spFromConst(second)).release();
+extern "C" SkPathEffect* C_SkPathEffect_MakeSum(SkPathEffect* first, SkPathEffect* second) {
+    return SkPathEffect::MakeSum(sp(first), sp(second)).release();
 }
 
-extern "C" SkPathEffect* C_SkPathEffect_MakeCompose(const SkPathEffect* outer, const SkPathEffect* inner) {
-    return SkPathEffect::MakeCompose(spFromConst(outer), spFromConst(inner)).release();
+extern "C" SkPathEffect* C_SkPathEffect_MakeCompose(SkPathEffect* outer, SkPathEffect* inner) {
+    return SkPathEffect::MakeCompose(sp(outer), sp(inner)).release();
 }
 
 extern "C" void C_SkPathEffect_PointData_Construct(SkPathEffect::PointData* unitialized) {
@@ -1817,8 +1818,8 @@ extern "C" void C_SkPixmap_destruct(SkPixmap* self) {
     self->~SkPixmap();
 }
 
-extern "C" void C_SkPixmap_setColorSpace(SkPixmap* self, const SkColorSpace* colorSpace) {
-    self->setColorSpace(spFromConst(colorSpace));
+extern "C" void C_SkPixmap_setColorSpace(SkPixmap* self, SkColorSpace* colorSpace) {
+    self->setColorSpace(sp(colorSpace));
 }
 
 //
@@ -1829,12 +1830,12 @@ extern "C" SkMaskFilter* C_SkMaskFilter_MakeBlur(SkBlurStyle style, SkScalar sig
     return SkMaskFilter::MakeBlur(style, sigma, respectCTM).release();
 }
 
-extern "C" SkMaskFilter* C_SkMaskFilter_Compose(const SkMaskFilter* outer, const SkMaskFilter* inner) {
-    return SkMaskFilter::MakeCompose(spFromConst(outer), spFromConst(inner)).release();
+extern "C" SkMaskFilter* C_SkMaskFilter_Compose(SkMaskFilter* outer, SkMaskFilter* inner) {
+    return SkMaskFilter::MakeCompose(sp(outer), sp(inner)).release();
 }
 
-extern "C" SkMaskFilter* C_SkMaskFilter_Combine(const SkMaskFilter* filterA, const SkMaskFilter* filterB, SkCoverageMode coverageMode) {
-    return SkMaskFilter::MakeCombine(spFromConst(filterA), spFromConst(filterB), coverageMode).release();
+extern "C" SkMaskFilter* C_SkMaskFilter_Combine(SkMaskFilter* filterA, SkMaskFilter* filterB, SkCoverageMode coverageMode) {
+    return SkMaskFilter::MakeCombine(sp(filterA), sp(filterB), coverageMode).release();
 }
 
 extern "C" SkMaskFilter* C_SkMaskFilter_makeWithMatrix(const SkMaskFilter* self, const SkMatrix* matrix) {
@@ -1881,8 +1882,8 @@ extern "C" SkShader* C_SkShader_makeWithLocalMatrix(const SkShader* self, const 
     return self->makeWithLocalMatrix(*matrix).release();
 }
 
-extern "C" SkShader* C_SkShader_makeWithColorFilter(const SkShader* self, const SkColorFilter* colorFilter) {
-    return self->makeWithColorFilter(spFromConst(colorFilter)).release();
+extern "C" SkShader* C_SkShader_makeWithColorFilter(const SkShader* self, SkColorFilter* colorFilter) {
+    return self->makeWithColorFilter(sp(colorFilter)).release();
 }
 
 extern "C" SkShader* C_SkShaders_Empty() {
@@ -1893,20 +1894,20 @@ extern "C" SkShader* C_SkShaders_Color(SkColor color) {
     return SkShaders::Color(color).release();
 }
 
-extern "C" SkShader* C_SkShaders_Color2(const SkColor4f* color, const SkColorSpace* colorSpace) {
-    return SkShaders::Color(*color, spFromConst(colorSpace)).release();
+extern "C" SkShader* C_SkShaders_Color2(const SkColor4f* color, SkColorSpace* colorSpace) {
+    return SkShaders::Color(*color, sp(colorSpace)).release();
 }
 
-extern "C" SkShader* C_SkShaders_Blend(SkBlendMode mode, const SkShader* dst, const SkShader* src) {
-    return SkShaders::Blend(mode, spFromConst(dst), spFromConst(src)).release();
+extern "C" SkShader* C_SkShaders_Blend(SkBlendMode mode, SkShader* dst, SkShader* src) {
+    return SkShaders::Blend(mode, sp(dst), sp(src)).release();
 }
 
-extern "C" SkShader* C_SkShaders_Lerp(float t, const SkShader* dst, const SkShader* src) {
-    return SkShaders::Lerp(t, spFromConst(dst), spFromConst(src)).release();
+extern "C" SkShader* C_SkShaders_Lerp(float t, SkShader* dst, SkShader* src) {
+    return SkShaders::Lerp(t, sp(dst), sp(src)).release();
 }
 
-extern "C" SkShader* C_SkShaders_Lerp2(const SkShader* red, const SkShader* dst, const SkShader* src) {
-    return SkShaders::Lerp(spFromConst(red), spFromConst(dst), spFromConst(src)).release();
+extern "C" SkShader* C_SkShaders_Lerp2(SkShader* red, SkShader* dst, SkShader* src) {
+    return SkShaders::Lerp(sp(red), sp(dst), sp(src)).release();
 }
 
 extern "C" SkShader* C_SkShader_Deserialize(const void* data, size_t length) {
@@ -1969,32 +1970,32 @@ extern "C" SkShader* C_SkGradientShader_MakeLinear(const SkPoint pts[2], const S
     return SkGradientShader::MakeLinear(pts, colors, pos, count, mode, flags, localMatrix).release();
 }
 
-extern "C" SkShader* C_SkGradientShader_MakeLinear2(const SkPoint pts[2], const SkColor4f colors[], const SkColorSpace* colorSpace, const SkScalar pos[], int count, SkTileMode mode, uint32_t flags, const SkMatrix* localMatrix) {
-    return SkGradientShader::MakeLinear(pts, colors, spFromConst(colorSpace), pos, count, mode, flags, localMatrix).release();
+extern "C" SkShader* C_SkGradientShader_MakeLinear2(const SkPoint pts[2], const SkColor4f colors[], SkColorSpace* colorSpace, const SkScalar pos[], int count, SkTileMode mode, uint32_t flags, const SkMatrix* localMatrix) {
+    return SkGradientShader::MakeLinear(pts, colors, sp(colorSpace), pos, count, mode, flags, localMatrix).release();
 }
 
 extern "C" SkShader* C_SkGradientShader_MakeRadial(const SkPoint* center, SkScalar radius, const SkColor colors[], const SkScalar pos[], int count, SkTileMode mode, uint32_t flags, const SkMatrix* localMatrix) {
     return SkGradientShader::MakeRadial(*center, radius, colors, pos, count, mode, flags, localMatrix).release();
 }
 
-extern "C" SkShader* C_SkGradientShader_MakeRadial2(const SkPoint* center, SkScalar radius, const SkColor4f colors[], const SkColorSpace* colorSpace, const SkScalar pos[], int count, SkTileMode mode, uint32_t flags, const SkMatrix* localMatrix) {
-    return SkGradientShader::MakeRadial(*center, radius, colors, spFromConst(colorSpace), pos, count, mode, flags, localMatrix).release();
+extern "C" SkShader* C_SkGradientShader_MakeRadial2(const SkPoint* center, SkScalar radius, const SkColor4f colors[], SkColorSpace* colorSpace, const SkScalar pos[], int count, SkTileMode mode, uint32_t flags, const SkMatrix* localMatrix) {
+    return SkGradientShader::MakeRadial(*center, radius, colors, sp(colorSpace), pos, count, mode, flags, localMatrix).release();
 }
 
 extern "C" SkShader* C_SkGradientShader_MakeTwoPointConical(const SkPoint* start, SkScalar startRadius, const SkPoint* end, SkScalar endRadius, const SkColor colors[], const SkScalar pos[], int count, SkTileMode mode, uint32_t flags, const SkMatrix* localMatrix) {
     return SkGradientShader::MakeTwoPointConical(*start, startRadius, *end, endRadius, colors, pos, count, mode, flags, localMatrix).release();
 }
 
-extern "C" SkShader* C_SkGradientShader_MakeTwoPointConical2(const SkPoint* start, SkScalar startRadius, const SkPoint* end, SkScalar endRadius, const SkColor4f colors[], const SkColorSpace* colorSpace, const SkScalar pos[], int count, SkTileMode mode, uint32_t flags, const SkMatrix* localMatrix) {
-    return SkGradientShader::MakeTwoPointConical(*start, startRadius, *end, endRadius, colors, spFromConst(colorSpace), pos, count, mode, flags, localMatrix).release();
+extern "C" SkShader* C_SkGradientShader_MakeTwoPointConical2(const SkPoint* start, SkScalar startRadius, const SkPoint* end, SkScalar endRadius, const SkColor4f colors[], SkColorSpace* colorSpace, const SkScalar pos[], int count, SkTileMode mode, uint32_t flags, const SkMatrix* localMatrix) {
+    return SkGradientShader::MakeTwoPointConical(*start, startRadius, *end, endRadius, colors, sp(colorSpace), pos, count, mode, flags, localMatrix).release();
 }
 
 extern "C" SkShader* C_SkGradientShader_MakeSweep(SkScalar cx, SkScalar cy, const SkColor colors[], const SkScalar pos[], int count, SkTileMode mode, SkScalar startAngle, SkScalar endAngle, uint32_t flags, const SkMatrix* localMatrix) {
     return SkGradientShader::MakeSweep(cx, cy, colors, pos, count, mode, startAngle, endAngle, flags, localMatrix).release();
 }
 
-extern "C" SkShader* C_SkGradientShader_MakeSweep2(SkScalar cx, SkScalar cy, const SkColor4f colors[], const SkColorSpace* colorSpace, const SkScalar pos[], int count, SkTileMode mode, SkScalar startAngle, SkScalar endAngle, uint32_t flags, const SkMatrix* localMatrix) {
-    return SkGradientShader::MakeSweep(cx, cy, colors, spFromConst(colorSpace), pos, count, mode, startAngle, endAngle, flags, localMatrix).release();
+extern "C" SkShader* C_SkGradientShader_MakeSweep2(SkScalar cx, SkScalar cy, const SkColor4f colors[], SkColorSpace* colorSpace, const SkScalar pos[], int count, SkTileMode mode, SkScalar startAngle, SkScalar endAngle, uint32_t flags, const SkMatrix* localMatrix) {
+    return SkGradientShader::MakeSweep(cx, cy, colors, sp(colorSpace), pos, count, mode, startAngle, endAngle, flags, localMatrix).release();
 }
 
 //
@@ -2042,9 +2043,9 @@ extern "C" SkPathEffect* C_SkPath2DPathEffect_Make(const SkMatrix* matrix, const
 //
 
 extern "C" SkImageFilter *
-C_SkAlphaThresholdFilter_Make(const SkRegion &region, SkScalar innerMin, SkScalar outerMax, const SkImageFilter &input,
+C_SkAlphaThresholdFilter_Make(const SkRegion &region, SkScalar innerMin, SkScalar outerMax, SkImageFilter *input,
                               const SkImageFilter::CropRect *cropRect) {
-    return SkAlphaThresholdFilter::Make(region, innerMin, outerMax, spFromConst(&input), cropRect).release();
+    return SkAlphaThresholdFilter::Make(region, innerMin, outerMax, sp(input), cropRect).release();
 }
 
 //
@@ -2052,11 +2053,11 @@ C_SkAlphaThresholdFilter_Make(const SkRegion &region, SkScalar innerMin, SkScala
 //
 
 extern "C" SkImageFilter *C_SkArithmeticImageFilter_Make(float k1, float k2, float k3, float k4, bool enforcePMColor,
-                                                         const SkImageFilter &background,
-                                                         const SkImageFilter &foreground,
+                                                         SkImageFilter *background,
+                                                         SkImageFilter *foreground,
                                                          const SkImageFilter::CropRect *cropRect) {
-    return SkArithmeticImageFilter::Make(k1, k2, k3, k4, enforcePMColor, spFromConst(&background),
-                                         spFromConst(&foreground), cropRect).release();
+    return SkArithmeticImageFilter::Make(k1, k2, k3, k4, enforcePMColor, sp(background),
+                                         sp(foreground), cropRect).release();
 }
 
 //
@@ -2076,19 +2077,19 @@ extern "C" SkDrawLooper* C_SkBlurDrawLooper_Make2(SkColor4f color, const SkColor
 // effects/SkBlurImageFilter
 //
 
-extern "C" SkImageFilter *C_SkBlurImageFilter_Make(SkScalar sigmaX, SkScalar sigmaY, const SkImageFilter &input,
+extern "C" SkImageFilter *C_SkBlurImageFilter_Make(SkScalar sigmaX, SkScalar sigmaY, SkImageFilter *input,
                                                    const SkImageFilter::CropRect *cropRect,
                                                    SkBlurImageFilter::TileMode tileMode) {
-    return SkBlurImageFilter::Make(sigmaX, sigmaY, spFromConst(&input), cropRect, tileMode).release();
+    return SkBlurImageFilter::Make(sigmaX, sigmaY, sp(input), cropRect, tileMode).release();
 }
 
 //
 // effects/SkColorFilterImageFilter
 //
 
-extern "C" SkImageFilter *C_SkColorFilterImageFilter_Make(const SkColorFilter &cf, const SkImageFilter &input,
+extern "C" SkImageFilter *C_SkColorFilterImageFilter_Make(SkColorFilter *cf, SkImageFilter *input,
                                                           const SkImageFilter::CropRect *cropRect) {
-    return SkColorFilterImageFilter::Make(spFromConst(&cf), spFromConst(&input), cropRect).release();
+    return SkColorFilterImageFilter::Make(sp(cf), sp(input), cropRect).release();
 }
 
 //
@@ -2111,8 +2112,8 @@ extern "C" void C_SkColorMatrix_set20(SkColorMatrix* self, const float m[20]) {
 // effects/SkComposeImageFilter
 //
 
-extern "C" SkImageFilter *C_SkComposeImageFilter_Make(const SkImageFilter &outer, const SkImageFilter &inner) {
-    return SkComposeImageFilter::Make(spFromConst(&outer), spFromConst(&inner)).release();
+extern "C" SkImageFilter *C_SkComposeImageFilter_Make(SkImageFilter *outer, SkImageFilter *inner) {
+    return SkComposeImageFilter::Make(sp(outer), sp(inner)).release();
 }
 
 //
@@ -2145,12 +2146,12 @@ extern "C" SkPathEffect* C_SkDiscretePathEffect_Make(SkScalar segLength, SkScala
 
 extern "C" SkImageFilter *C_SkDisplacementMapEffect_Make(SkDisplacementMapEffect::ChannelSelectorType xChannelSelector,
                                                          SkDisplacementMapEffect::ChannelSelectorType yChannelSelector,
-                                                         SkScalar scale, const SkImageFilter &displacement,
-                                                         const SkImageFilter &color,
+                                                         SkScalar scale, SkImageFilter *displacement,
+                                                         SkImageFilter *color,
                                                          const SkImageFilter::CropRect *cropRect) {
 
-    return SkDisplacementMapEffect::Make(xChannelSelector, yChannelSelector, scale, spFromConst(&displacement),
-                                         spFromConst(&color), cropRect).release();
+    return SkDisplacementMapEffect::Make(xChannelSelector, yChannelSelector, scale, sp(displacement),
+                                         sp(color), cropRect).release();
 }
 
 //
@@ -2159,9 +2160,9 @@ extern "C" SkImageFilter *C_SkDisplacementMapEffect_Make(SkDisplacementMapEffect
 
 extern "C" SkImageFilter *C_SkDropShadowImageFilter_Make(SkScalar dx, SkScalar dy, SkScalar sigmaX, SkScalar sigmaY,
                                                          SkColor color, SkDropShadowImageFilter::ShadowMode shadowMode,
-                                                         const SkImageFilter &input,
+                                                         SkImageFilter *input,
                                                          const SkImageFilter::CropRect *cropRect) {
-    return SkDropShadowImageFilter::Make(dx, dy, sigmaX, sigmaY, color, shadowMode, spFromConst(&input),
+    return SkDropShadowImageFilter::Make(dx, dy, sigmaX, sigmaY, color, shadowMode, sp(input),
                                          cropRect).release();
 }
 
@@ -2169,14 +2170,14 @@ extern "C" SkImageFilter *C_SkDropShadowImageFilter_Make(SkScalar dx, SkScalar d
 // effects/SkImageSource
 //
 
-extern "C" SkImageFilter *C_SkImageSource_Make(const SkImage &image) {
-    return SkImageSource::Make(spFromConst(&image)).release();
+extern "C" SkImageFilter *C_SkImageSource_Make(SkImage *image) {
+    return SkImageSource::Make(sp(image)).release();
 }
 
 extern "C" SkImageFilter *
-C_SkImageSource_Make2(const SkImage &image, const SkRect &srcRect, const SkRect &dstRect,
+C_SkImageSource_Make2(SkImage* image, const SkRect &srcRect, const SkRect &dstRect,
                       SkFilterQuality filterQuality) {
-    return SkImageSource::Make(spFromConst(&image), srcRect, dstRect, filterQuality).release();
+    return SkImageSource::Make(sp(image), srcRect, dstRect, filterQuality).release();
 }
 
 //
@@ -2197,17 +2198,17 @@ extern "C" SkDrawLooper* C_SkLayerDrawLooper_Builder_detach(SkLayerDrawLooper::B
 
 extern "C" SkImageFilter *
 C_SkLightingImageFilter_MakeDistantLitDiffuse(const SkPoint3 &direction, SkColor lightColor, SkScalar surfaceScale,
-                                              SkScalar kd, const SkImageFilter &input,
+                                              SkScalar kd, SkImageFilter *input,
                                               const SkImageFilter::CropRect *cropRect) {
-    return SkLightingImageFilter::MakeDistantLitDiffuse(direction, lightColor, surfaceScale, kd, spFromConst(&input),
+    return SkLightingImageFilter::MakeDistantLitDiffuse(direction, lightColor, surfaceScale, kd, sp(input),
                                                         cropRect).release();
 }
 
 extern "C" SkImageFilter *
 C_SkLightingImageFilter_MakePointLitDiffuse(const SkPoint3 &location, SkColor lightColor, SkScalar surfaceScale,
-                                            SkScalar kd, const SkImageFilter &input,
+                                            SkScalar kd, SkImageFilter *input,
                                             const SkImageFilter::CropRect *cropRect) {
-    return SkLightingImageFilter::MakePointLitDiffuse(location, lightColor, surfaceScale, kd, spFromConst(&input),
+    return SkLightingImageFilter::MakePointLitDiffuse(location, lightColor, surfaceScale, kd, sp(input),
                                                       cropRect).release();
 }
 
@@ -2215,37 +2216,37 @@ extern "C" SkImageFilter *
 C_SkLightingImageFilter_MakeSpotLitDiffuse(const SkPoint3 &location,
                                            const SkPoint3 &target, SkScalar specularExponent, SkScalar cutoffAngle,
                                            SkColor lightColor, SkScalar surfaceScale, SkScalar kd,
-                                           const SkImageFilter *input, const SkImageFilter::CropRect *cropRect) {
+                                           SkImageFilter *input, const SkImageFilter::CropRect *cropRect) {
     return SkLightingImageFilter::MakeSpotLitDiffuse(location, target, specularExponent, cutoffAngle, lightColor,
-                                                     surfaceScale, kd, spFromConst(input), cropRect).release();
+                                                     surfaceScale, kd, sp(input), cropRect).release();
 }
 
 extern "C" SkImageFilter *
 C_SkLightingImageFilter_MakeDistantLitSpecular(const SkPoint3 &direction,
                                                SkColor lightColor, SkScalar surfaceScale, SkScalar ks,
-                                               SkScalar shininess, const SkImageFilter &input,
+                                               SkScalar shininess, SkImageFilter *input,
                                                const SkImageFilter::CropRect *cropRect) {
     return SkLightingImageFilter::MakeDistantLitSpecular(direction, lightColor, surfaceScale, ks, shininess,
-                                                         spFromConst(&input), cropRect).release();
+                                                         sp(input), cropRect).release();
 }
 
 extern "C" SkImageFilter *
 C_SkLightingImageFilter_MakePointLitSpecular(const SkPoint3 &location,
                                              SkColor lightColor, SkScalar surfaceScale, SkScalar ks,
-                                             SkScalar shininess, const SkImageFilter &input,
+                                             SkScalar shininess, SkImageFilter *input,
                                              const SkImageFilter::CropRect *cropRect) {
     return SkLightingImageFilter::MakePointLitSpecular(location, lightColor, surfaceScale, ks, shininess,
-                                                       spFromConst(&input), cropRect).release();
+                                                       sp(input), cropRect).release();
 }
 
 extern "C" SkImageFilter *
 C_SkLightingImageFilter_MakeSpotLitSpecular(const SkPoint3 &location,
                                             const SkPoint3 &target, SkScalar specularExponent, SkScalar cutoffAngle,
                                             SkColor lightColor, SkScalar surfaceScale, SkScalar ks,
-                                            SkScalar shininess, const SkImageFilter &input,
+                                            SkScalar shininess, SkImageFilter *input,
                                             const SkImageFilter::CropRect *cropRect) {
     return SkLightingImageFilter::MakeSpotLitSpecular(location, target, specularExponent, cutoffAngle, lightColor,
-                                                      surfaceScale, ks, shininess, spFromConst(&input),
+                                                      surfaceScale, ks, shininess, sp(input),
                                                       cropRect).release();
 }
 
@@ -2254,9 +2255,9 @@ C_SkLightingImageFilter_MakeSpotLitSpecular(const SkPoint3 &location,
 //
 
 extern "C" SkImageFilter *
-C_SkMagnifierImageFilter_Make(const SkRect &srcRect, SkScalar inset, const SkImageFilter &input,
+C_SkMagnifierImageFilter_Make(const SkRect &srcRect, SkScalar inset, SkImageFilter *input,
                               const SkImageFilter::CropRect *cropRect) {
-    return SkMagnifierImageFilter::Make(srcRect, inset, spFromConst(&input), cropRect).release();
+    return SkMagnifierImageFilter::Make(srcRect, inset, sp(input), cropRect).release();
 }
 
 //
@@ -2271,10 +2272,10 @@ C_SkMatrixConvolutionImageFilter_Make(const SkISize &kernelSize,
                                       const SkIPoint &kernelOffset,
                                       SkMatrixConvolutionImageFilter::TileMode tileMode,
                                       bool convolveAlpha,
-                                      const SkImageFilter &input,
+                                      SkImageFilter *input,
                                       const SkImageFilter::CropRect *cropRect) {
     return SkMatrixConvolutionImageFilter::Make(kernelSize, kernel, gain, bias, kernelOffset, tileMode, convolveAlpha,
-                                                spFromConst(&input), cropRect).release();
+                                                sp(input), cropRect).release();
 }
 
 //
@@ -2282,10 +2283,10 @@ C_SkMatrixConvolutionImageFilter_Make(const SkISize &kernelSize,
 //
 
 extern "C" SkImageFilter *
-C_SkMergeImageFilter_Make(const SkImageFilter *const filters[], int count, const SkImageFilter::CropRect *cropRect) {
+C_SkMergeImageFilter_Make(SkImageFilter *const filters[], int count, const SkImageFilter::CropRect *cropRect) {
     auto array = new sk_sp<SkImageFilter>[count];
     for (int i = 0; i < count; ++i) {
-        array[i] = spFromConst(filters[i]);
+        array[i] = sp(filters[i]);
     }
     auto imageFilter = SkMergeImageFilter::Make(array, count, cropRect).release();
     delete[] array;
@@ -2296,23 +2297,23 @@ C_SkMergeImageFilter_Make(const SkImageFilter *const filters[], int count, const
 // effects/SkMorphologyImageFiter
 //
 
-extern "C" SkImageFilter *C_SkDilateImageFilter_Make(int radiusX, int radiusY, const SkImageFilter &input,
+extern "C" SkImageFilter *C_SkDilateImageFilter_Make(int radiusX, int radiusY, SkImageFilter *input,
                                                      const SkImageFilter::CropRect *cropRect) {
-    return SkDilateImageFilter::Make(radiusX, radiusY, spFromConst(&input), cropRect).release();
+    return SkDilateImageFilter::Make(radiusX, radiusY, sp(input), cropRect).release();
 }
 
-extern "C" SkImageFilter *C_SkErodeImageFilter_Make(int radiusX, int radiusY, const SkImageFilter &input,
+extern "C" SkImageFilter *C_SkErodeImageFilter_Make(int radiusX, int radiusY, SkImageFilter *input,
                                                     const SkImageFilter::CropRect *cropRect) {
-    return SkErodeImageFilter::Make(radiusX, radiusY, spFromConst(&input), cropRect).release();
+    return SkErodeImageFilter::Make(radiusX, radiusY, sp(input), cropRect).release();
 }
 
 //
 // effects/SkOffsetImageFilter
 //
 
-extern "C" SkImageFilter *C_SkOffsetImageFilter_Make(SkScalar dx, SkScalar dy, const SkImageFilter &input,
+extern "C" SkImageFilter *C_SkOffsetImageFilter_Make(SkScalar dx, SkScalar dy, SkImageFilter *input,
                                                      const SkImageFilter::CropRect *cropRect) {
-    return SkOffsetImageFilter::Make(dx, dy, spFromConst(&input), cropRect).release();
+    return SkOffsetImageFilter::Make(dx, dy, sp(input), cropRect).release();
 }
 
 //
@@ -2327,11 +2328,11 @@ extern "C" SkImageFilter *C_SkPaintImageFilter_Make(const SkPaint &paint, const 
 // effects/SkPictureImageFilter
 //
 
-extern "C" SkImageFilter *C_SkPictureImageFilter_Make(const SkPicture &picture, const SkRect *cropRect) {
+extern "C" SkImageFilter *C_SkPictureImageFilter_Make(SkPicture *picture, const SkRect *cropRect) {
     if (cropRect) {
-        return SkPictureImageFilter::Make(spFromConst(&picture), *cropRect).release();
+        return SkPictureImageFilter::Make(sp(picture), *cropRect).release();
     } else {
-        return SkPictureImageFilter::Make(spFromConst(&picture)).release();
+        return SkPictureImageFilter::Make(sp(picture)).release();
     }
 }
 
@@ -2351,8 +2352,8 @@ extern "C" SkColorFilter* C_SkTableColorFilter_MakeARGB(const uint8_t tableA[256
 // effects/SkTileImageFilter
 //
 
-extern "C" SkImageFilter *C_SkTileImageFilter_Make(const SkRect &src, const SkRect &dst, const SkImageFilter &input) {
-    return SkTileImageFilter::Make(src, dst, spFromConst(&input)).release();
+extern "C" SkImageFilter *C_SkTileImageFilter_Make(const SkRect &src, const SkRect &dst, SkImageFilter *input) {
+    return SkTileImageFilter::Make(src, dst, sp(input)).release();
 }
 
 //
@@ -2360,9 +2361,9 @@ extern "C" SkImageFilter *C_SkTileImageFilter_Make(const SkRect &src, const SkRe
 //
 
 extern "C" SkImageFilter *
-C_SkXfermodeImageFilter_Make(SkBlendMode mode, const SkImageFilter &background, const SkImageFilter *foreground,
+C_SkXfermodeImageFilter_Make(SkBlendMode mode, SkImageFilter *background, SkImageFilter *foreground,
                              const SkImageFilter::CropRect *cropRect) {
-    return SkXfermodeImageFilter::Make(mode, spFromConst(&background), spFromConst(foreground), cropRect).release();
+    return SkXfermodeImageFilter::Make(mode, sp(background), sp(foreground), cropRect).release();
 }
 
 //

--- a/skia-safe/examples/skia-org/main.rs
+++ b/skia-safe/examples/skia-org/main.rs
@@ -29,7 +29,7 @@ pub(crate) mod artifact {
     use skia_safe::{Budgeted, Canvas, EncodedImageFormat, ImageInfo, Surface};
     use std::fs;
     use std::io::Write;
-    use std::path::PathBuf;
+    use std::path::Path;
 
     #[cfg(feature = "vulkan")]
     use crate::drivers::skia_ash::AshGraphics;
@@ -43,11 +43,11 @@ pub(crate) mod artifact {
     pub trait DrawingDriver {
         const NAME: &'static str;
 
-        fn draw_image<F>(size: (i32, i32), path: &PathBuf, name: &str, func: F)
+        fn draw_image<F>(size: (i32, i32), path: &Path, name: &str, func: F)
         where
             F: Fn(&mut Canvas) -> ();
 
-        fn draw_image_256<F>(path: &PathBuf, name: &str, func: F)
+        fn draw_image_256<F>(path: &Path, name: &str, func: F)
         where
             F: Fn(&mut Canvas) -> (),
         {
@@ -67,7 +67,7 @@ pub(crate) mod artifact {
     impl DrawingDriver for CPU {
         const NAME: &'static str = "cpu";
 
-        fn draw_image<F>((width, height): (i32, i32), path: &PathBuf, name: &str, func: F)
+        fn draw_image<F>((width, height): (i32, i32), path: &Path, name: &str, func: F)
         where
             F: Fn(&mut Canvas) -> (),
         {
@@ -79,7 +79,7 @@ pub(crate) mod artifact {
     impl DrawingDriver for PDF {
         const NAME: &'static str = "pdf";
 
-        fn draw_image<F>(size: (i32, i32), path: &PathBuf, name: &str, func: F)
+        fn draw_image<F>(size: (i32, i32), path: &Path, name: &str, func: F)
         where
             F: Fn(&mut Canvas) -> (),
         {
@@ -94,7 +94,7 @@ pub(crate) mod artifact {
     impl DrawingDriver for SVG {
         const NAME: &'static str = "svg";
 
-        fn draw_image<F>(size: (i32, i32), path: &PathBuf, name: &str, func: F)
+        fn draw_image<F>(size: (i32, i32), path: &Path, name: &str, func: F)
         where
             F: Fn(&mut Canvas) -> (),
         {
@@ -109,7 +109,7 @@ pub(crate) mod artifact {
     impl DrawingDriver for OpenGL {
         const NAME: &'static str = "opengl";
 
-        fn draw_image<F>((width, height): (i32, i32), path: &PathBuf, name: &str, func: F)
+        fn draw_image<F>((width, height): (i32, i32), path: &Path, name: &str, func: F)
         where
             F: Fn(&mut Canvas) -> (),
         {
@@ -135,7 +135,7 @@ pub(crate) mod artifact {
     impl DrawingDriver for Vulkan {
         const NAME: &'static str = "vulkan";
 
-        fn draw_image<F>((width, height): (i32, i32), path: &PathBuf, name: &str, func: F)
+        fn draw_image<F>((width, height): (i32, i32), path: &Path, name: &str, func: F)
         where
             F: Fn(&mut Canvas) -> (),
         {
@@ -182,7 +182,7 @@ pub(crate) mod artifact {
         }
     }
 
-    fn draw_image_on_surface<F>(surface: &mut Surface, path: &PathBuf, name: &str, func: F)
+    fn draw_image_on_surface<F>(surface: &mut Surface, path: &Path, name: &str, func: F)
     where
         F: Fn(&mut Canvas) -> (),
     {
@@ -195,7 +195,7 @@ pub(crate) mod artifact {
         write_file(data.as_bytes(), path, name, "png");
     }
 
-    fn write_file(bytes: &[u8], path: &PathBuf, name: &str, ext: &str) {
+    fn write_file(bytes: &[u8], path: &Path, name: &str, ext: &str) {
         fs::create_dir_all(&path).expect("failed to create directory");
 
         let mut file_path = path.join(name);
@@ -245,7 +245,7 @@ fn main() {
         )
         .get_matches();
 
-    let out_path: PathBuf = PathBuf::from(matches.value_of(OUT_PATH).unwrap());
+    let out_path = PathBuf::from(matches.value_of(OUT_PATH).unwrap());
 
     let drivers = {
         let drivers = matches

--- a/skia-safe/examples/skia-org/main.rs
+++ b/skia-safe/examples/skia-org/main.rs
@@ -213,13 +213,13 @@ pub(crate) mod resources {
     pub fn color_wheel() -> Image {
         let bytes = include_bytes!("resources/color_wheel.png");
         let data = Data::new_copy(bytes);
-        Image::from_encoded(&data, None).unwrap()
+        Image::from_encoded(data, None).unwrap()
     }
 
     pub fn mandrill() -> Image {
         let bytes = include_bytes!("resources/mandrill_512.png");
         let data = Data::new_copy(bytes);
-        Image::from_encoded(&data, None).unwrap()
+        Image::from_encoded(data, None).unwrap()
     }
 }
 

--- a/skia-safe/examples/skia-org/skcanvas_overview.rs
+++ b/skia-safe/examples/skia-org/skcanvas_overview.rs
@@ -1,12 +1,11 @@
 use crate::artifact::DrawingDriver;
 use crate::resources;
 use skia_safe::{
-    scalar, BlendMode, Canvas, Color, Font, Paint, PaintStyle, Path, RRect, Rect, TextBlob,
-    Typeface,
+    paint, scalar, BlendMode, Canvas, Color, Font, Paint, Path, RRect, Rect, TextBlob, Typeface,
 };
-use std::path::PathBuf;
+use std::path;
 
-pub fn draw<Driver: DrawingDriver>(path: &PathBuf) {
+pub fn draw<Driver: DrawingDriver>(path: &path::Path) {
     let path = path.join("SkCanvas-Overview");
     Driver::draw_image_256(&path, "heptagram", draw_heptagram);
     Driver::draw_image_256(&path, "rotated-rectangle", draw_rotated_rectangle);
@@ -28,15 +27,15 @@ fn draw_heptagram(canvas: &mut Canvas) {
     path.close();
     let mut p = Paint::default();
     p.set_anti_alias(true);
-    canvas.clear(Color::WHITE);
-    canvas.translate((0.5 * SCALE, 0.5 * SCALE));
-    canvas.draw_path(&path, &p);
+    canvas
+        .clear(Color::WHITE)
+        .translate((0.5 * SCALE, 0.5 * SCALE))
+        .draw_path(&path, &p);
 }
 
 fn draw_rotated_rectangle(canvas: &mut Canvas) {
     canvas.save();
-    canvas.translate((128.0, 128.0));
-    canvas.rotate(45.0, None);
+    canvas.translate((128.0, 128.0)).rotate(45.0, None);
     let rect = Rect::from_point_and_size((-90.5, -90.5), (181.0, 181.0));
     let mut paint = Paint::default();
     paint.set_color(Color::BLUE);
@@ -50,9 +49,10 @@ fn draw_hello_skia(canvas: &mut Canvas) {
     canvas.draw_color(Color::WHITE, BlendMode::default());
 
     let mut paint = Paint::default();
-    paint.set_style(PaintStyle::Stroke);
-    paint.set_stroke_width(4.0);
-    paint.set_color(Color::RED);
+    paint
+        .set_style(paint::Style::Stroke)
+        .set_stroke_width(4.0)
+        .set_color(Color::RED);
 
     let mut rect = Rect::from_point_and_size((50.0, 50.0), (40.0, 60.0));
     canvas.draw_rect(rect, &paint);

--- a/skia-safe/examples/skia-org/skpaint_overview.rs
+++ b/skia-safe/examples/skia-org/skpaint_overview.rs
@@ -76,12 +76,12 @@ fn draw_three_paints(canvas: &mut Canvas) {
 
     let blob1 = TextBlob::from_str(
         "Skia!",
-        &Font::from_typeface_with_params(&Typeface::default(), 64.0, 1.0, 0.0),
+        &Font::from_typeface_with_params(Typeface::default(), 64.0, 1.0, 0.0),
     )
     .unwrap();
     let blob2 = TextBlob::from_str(
         "Skia!",
-        &Font::from_typeface_with_params(&Typeface::default(), 64.0, 1.5, 0.0),
+        &Font::from_typeface_with_params(Typeface::default(), 64.0, 1.5, 0.0),
     )
     .unwrap();
 
@@ -104,8 +104,7 @@ fn draw_fill_and_stroke(canvas: &mut Canvas) {
     stroke_paint.set_stroke_width(5.0);
     canvas.draw_oval(Rect::from_point_and_size((150, 10), (60, 20)), stroke_paint);
 
-    let blob =
-        TextBlob::from_str("SKIA", &Font::from_typeface(&Typeface::default(), 80.0)).unwrap();
+    let blob = TextBlob::from_str("SKIA", &Font::from_typeface(Typeface::default(), 80.0)).unwrap();
 
     fill_paint.set_color(Color::from_argb(0xFF, 0xFF, 0x00, 0x00));
     canvas.draw_text_blob(&blob, (20, 120), fill_paint);
@@ -173,7 +172,7 @@ fn draw_transfer_modes(canvas: &mut Canvas) {
         &mut Paint::default(),
     );
     stroke.set_style(PaintStyle::Stroke);
-    let font = &Font::from_typeface(&Typeface::default(), 24.0);
+    let font = &Font::from_typeface(Typeface::default(), 24.0);
     let src_points: (Point, Point) = ((0.0, 0.0).into(), (64.0, 0.0).into());
     let src_colors = [Color::MAGENTA & 0x00_FF_FF_FF, Color::MAGENTA];
     src.set_shader(gradient_shader::linear(
@@ -322,7 +321,7 @@ fn draw_mask_filter(canvas: &mut Canvas) {
     let paint = &mut Paint::default();
     paint.set_mask_filter(MaskFilter::blur(BlurStyle::Normal, 5.0, None));
     let blob =
-        &TextBlob::from_str("Skia", &Font::from_typeface(&Typeface::default(), 120.0)).unwrap();
+        &TextBlob::from_str("Skia", &Font::from_typeface(Typeface::default(), 120.0)).unwrap();
     canvas.draw_text_blob(blob, (0, 160), paint);
 }
 

--- a/skia-safe/examples/skia-org/skpaint_overview.rs
+++ b/skia-safe/examples/skia-org/skpaint_overview.rs
@@ -119,10 +119,14 @@ fn draw_gradient(canvas: &mut Canvas) {
     let colors = [Color::BLUE, Color::YELLOW];
     let paint = &mut Paint::default();
 
-    paint.set_shader(
-        gradient_shader::linear(points, colors.as_ref(), None, TileMode::Clamp, None, None)
-            .as_ref(),
-    );
+    paint.set_shader(gradient_shader::linear(
+        points,
+        colors.as_ref(),
+        None,
+        TileMode::Clamp,
+        None,
+        None,
+    ));
     canvas.draw_paint(paint);
 }
 
@@ -172,31 +176,25 @@ fn draw_transfer_modes(canvas: &mut Canvas) {
     let font = &Font::from_typeface(&Typeface::default(), 24.0);
     let src_points: (Point, Point) = ((0.0, 0.0).into(), (64.0, 0.0).into());
     let src_colors = [Color::MAGENTA & 0x00_FF_FF_FF, Color::MAGENTA];
-    src.set_shader(
-        gradient_shader::linear(
-            src_points,
-            src_colors.as_ref(),
-            None,
-            TileMode::Clamp,
-            None,
-            None,
-        )
-        .as_ref(),
-    );
+    src.set_shader(gradient_shader::linear(
+        src_points,
+        src_colors.as_ref(),
+        None,
+        TileMode::Clamp,
+        None,
+        None,
+    ));
 
     let dst_points: (Point, Point) = ((0.0, 0.0).into(), (0.0, 64.0).into());
     let dst_colors = [Color::CYAN & 0x00_FF_FF_FF, Color::CYAN];
-    dst.set_shader(
-        gradient_shader::linear(
-            dst_points,
-            dst_colors.as_ref(),
-            None,
-            TileMode::Clamp,
-            None,
-            None,
-        )
-        .as_ref(),
-    );
+    dst.set_shader(gradient_shader::linear(
+        dst_points,
+        dst_colors.as_ref(),
+        None,
+        TileMode::Clamp,
+        None,
+        None,
+    ));
     canvas.clear(Color::WHITE);
     let n = modes.len();
     let k = (n - 1) / 3 + 1;
@@ -225,18 +223,81 @@ fn draw_bitmap_shader(canvas: &mut Canvas) {
     matrix.set_scale((0.75, 0.75), None);
     matrix.pre_rotate(30.0, None);
     let paint = &mut Paint::default();
-    paint.set_shader(
-        image
-            .to_shader((TileMode::Repeat, TileMode::Repeat), &matrix)
-            .as_ref(),
-    );
+    paint.set_shader(image.to_shader((TileMode::Repeat, TileMode::Repeat), &matrix));
     canvas.draw_paint(paint);
 }
 
 fn draw_radial_gradient_shader(canvas: &mut Canvas) {
     let colors = [Color::BLUE, Color::YELLOW];
     let mut paint = Paint::default();
-    paint.set_shader(
+    paint.set_shader(gradient_shader::radial(
+        (128.0, 128.0),
+        180.0,
+        colors.as_ref(),
+        None,
+        TileMode::Clamp,
+        None,
+        None,
+    ));
+    canvas.draw_paint(&paint);
+}
+
+fn draw_two_point_conical_shader(canvas: &mut Canvas) {
+    let colors = [Color::BLUE, Color::YELLOW];
+    let paint = &mut Paint::default();
+    paint.set_shader(gradient_shader::two_point_conical(
+        (128.0, 128.0),
+        128.0,
+        (128.0, 16.0),
+        16.0,
+        colors.as_ref(),
+        None,
+        TileMode::Clamp,
+        None,
+        None,
+    ));
+    canvas.draw_paint(&paint);
+}
+
+fn draw_sweep_gradient_shader(canvas: &mut Canvas) {
+    let colors = [Color::CYAN, Color::MAGENTA, Color::YELLOW, Color::CYAN];
+    let paint = &mut Paint::default();
+    paint.set_shader(gradient_shader::sweep(
+        (128.0, 128.0),
+        colors.as_ref(),
+        None,
+        TileMode::default(),
+        None,
+        None,
+        None,
+    ));
+    canvas.draw_paint(paint);
+}
+
+fn draw_fractal_perlin_noise_shader(canvas: &mut Canvas) {
+    canvas.clear(Color::WHITE);
+    let paint = &mut Paint::default();
+    paint.set_shader(perlin_noise_shader::fractal_noise(
+        (0.05, 0.05),
+        4,
+        0.0,
+        None,
+    ));
+    canvas.draw_paint(paint);
+}
+
+fn draw_turbulence_perlin_noise_shader(canvas: &mut Canvas) {
+    canvas.clear(Color::WHITE);
+    let paint = &mut Paint::default();
+    paint.set_shader(perlin_noise_shader::turbulence((0.05, 0.05), 4, 0.0, None));
+    canvas.draw_paint(paint);
+}
+
+fn draw_compose_shader(canvas: &mut Canvas) {
+    let colors = [Color::BLUE, Color::YELLOW];
+    let paint = &mut Paint::default();
+    paint.set_shader(Shaders::blend(
+        BlendMode::Difference,
         gradient_shader::radial(
             (128.0, 128.0),
             180.0,
@@ -246,82 +307,8 @@ fn draw_radial_gradient_shader(canvas: &mut Canvas) {
             None,
             None,
         )
-        .as_ref(),
-    );
-    canvas.draw_paint(&paint);
-}
-
-fn draw_two_point_conical_shader(canvas: &mut Canvas) {
-    let colors = [Color::BLUE, Color::YELLOW];
-    let paint = &mut Paint::default();
-    paint.set_shader(
-        gradient_shader::two_point_conical(
-            (128.0, 128.0),
-            128.0,
-            (128.0, 16.0),
-            16.0,
-            colors.as_ref(),
-            None,
-            TileMode::Clamp,
-            None,
-            None,
-        )
-        .as_ref(),
-    );
-    canvas.draw_paint(&paint);
-}
-
-fn draw_sweep_gradient_shader(canvas: &mut Canvas) {
-    let colors = [Color::CYAN, Color::MAGENTA, Color::YELLOW, Color::CYAN];
-    let paint = &mut Paint::default();
-    paint.set_shader(
-        gradient_shader::sweep(
-            (128.0, 128.0),
-            colors.as_ref(),
-            None,
-            TileMode::default(),
-            None,
-            None,
-            None,
-        )
-        .as_ref(),
-    );
-    canvas.draw_paint(paint);
-}
-
-fn draw_fractal_perlin_noise_shader(canvas: &mut Canvas) {
-    canvas.clear(Color::WHITE);
-    let paint = &mut Paint::default();
-    paint.set_shader(perlin_noise_shader::fractal_noise((0.05, 0.05), 4, 0.0, None).as_ref());
-    canvas.draw_paint(paint);
-}
-
-fn draw_turbulence_perlin_noise_shader(canvas: &mut Canvas) {
-    canvas.clear(Color::WHITE);
-    let paint = &mut Paint::default();
-    paint.set_shader(perlin_noise_shader::turbulence((0.05, 0.05), 4, 0.0, None).as_ref());
-    canvas.draw_paint(paint);
-}
-
-fn draw_compose_shader(canvas: &mut Canvas) {
-    let colors = [Color::BLUE, Color::YELLOW];
-    let paint = &mut Paint::default();
-    paint.set_shader(Some(
-        Shaders::blend(
-            BlendMode::Difference,
-            &gradient_shader::radial(
-                (128.0, 128.0),
-                180.0,
-                colors.as_ref(),
-                None,
-                TileMode::Clamp,
-                None,
-                None,
-            )
-            .unwrap(),
-            &perlin_noise_shader::turbulence((0.025, 0.025), 2, 0.0, None).unwrap(),
-        )
-        .as_ref(),
+        .unwrap(),
+        perlin_noise_shader::turbulence((0.025, 0.025), 2, 0.0, None).unwrap(),
     ));
     canvas.draw_paint(paint);
 }
@@ -333,7 +320,7 @@ fn draw_mask_filter(canvas: &mut Canvas) {
         BlendMode::default(),
     );
     let paint = &mut Paint::default();
-    paint.set_mask_filter(&MaskFilter::blur(BlurStyle::Normal, 5.0, None));
+    paint.set_mask_filter(MaskFilter::blur(BlurStyle::Normal, 5.0, None));
     let blob =
         &TextBlob::from_str("Skia", &Font::from_typeface(&Typeface::default(), 120.0)).unwrap();
     canvas.draw_text_blob(blob, (0, 160), paint);
@@ -342,7 +329,7 @@ fn draw_mask_filter(canvas: &mut Canvas) {
 fn draw_color_filter(c: &mut Canvas) {
     fn f(c: &mut Canvas, (x, y): (scalar, scalar), color_matrix: &[scalar; 20]) {
         let paint = &mut Paint::default();
-        paint.set_color_filter(&ColorFilters::matrix_row_major(color_matrix));
+        paint.set_color_filter(ColorFilters::matrix_row_major(color_matrix));
 
         let image = &resources::mandrill();
 
@@ -373,7 +360,7 @@ fn draw_color_table_color_filter(canvas: &mut Canvas) {
         *v = x.max(0).min(255) as _;
     }
     let mut paint = Paint::default();
-    paint.set_color_filter(&table_color_filter::from_argb(
+    paint.set_color_filter(table_color_filter::from_argb(
         None,
         Some(ct),
         Some(ct),
@@ -399,7 +386,7 @@ fn draw_path_2d_effect(canvas: &mut Canvas) {
     let matrix = &Matrix::new_scale((4.0 * scale, 4.0 * scale));
     let paint = &mut Paint::default();
     paint
-        .set_path_effect(&path_2d_path_effect::new(matrix, path))
+        .set_path_effect(path_2d_path_effect::new(matrix, path))
         .set_anti_alias(true);
     canvas.clear(Color::WHITE);
     let bounds = Rect::new(-4.0 * scale, -4.0 * scale, 256.0, 256.0);
@@ -411,7 +398,7 @@ fn draw_line_2d_effect(canvas: &mut Canvas) {
     let lattice = &mut Matrix::default();
     lattice.set_scale((8.0, 8.0), None).pre_rotate(30.0, None);
     paint
-        .set_path_effect(line_2d_path_effect::new(0.0, lattice).as_ref())
+        .set_path_effect(line_2d_path_effect::new(0.0, lattice))
         .set_anti_alias(true);
     let bounds = Rect::from_size((256, 256)).with_outset((8.0, 8.0));
     canvas.clear(Color::WHITE);
@@ -423,9 +410,12 @@ fn draw_path_1d_effect(canvas: &mut Canvas) {
     let path = &mut Path::default();
     path.add_oval(Rect::from_size((16.0, 6.0)), None);
     paint
-        .set_path_effect(
-            path_1d_path_effect::new(path, 32.0, 0.0, path_1d_path_effect::Style::Rotate).as_ref(),
-        )
+        .set_path_effect(path_1d_path_effect::new(
+            path,
+            32.0,
+            0.0,
+            path_1d_path_effect::Style::Rotate,
+        ))
         .set_anti_alias(true);
     canvas.clear(Color::WHITE);
     canvas.draw_circle((128.0, 128.0), 122.0, paint);
@@ -448,7 +438,7 @@ fn star() -> Path {
 fn draw_corner_path_effect(canvas: &mut Canvas) {
     let paint = &mut Paint::default();
     paint
-        .set_path_effect(corner_path_effect::new(32.0).as_ref())
+        .set_path_effect(corner_path_effect::new(32.0))
         .set_style(PaintStyle::Stroke)
         .set_anti_alias(true);
     canvas.clear(Color::WHITE);
@@ -459,7 +449,7 @@ fn draw_dash_path_effect(canvas: &mut Canvas) {
     const INTERVALS: [scalar; 4] = [10.0, 5.0, 2.0, 5.0];
     let paint = &mut Paint::default();
     paint
-        .set_path_effect(dash_path_effect::new(&INTERVALS, 0.0).as_ref())
+        .set_path_effect(dash_path_effect::new(&INTERVALS, 0.0))
         .set_style(PaintStyle::Stroke)
         .set_stroke_width(2.0)
         .set_anti_alias(true);
@@ -470,7 +460,7 @@ fn draw_dash_path_effect(canvas: &mut Canvas) {
 fn draw_discrete_path_effect(canvas: &mut Canvas) {
     let paint = &mut Paint::default();
     paint
-        .set_path_effect(discrete_path_effect::new(10.0, 4.0, None).as_ref())
+        .set_path_effect(discrete_path_effect::new(10.0, 4.0, None))
         .set_style(PaintStyle::Stroke)
         .set_stroke_width(2.0)
         .set_anti_alias(true);
@@ -482,9 +472,9 @@ fn draw_compose_path_effect(canvas: &mut Canvas) {
     const INTERVALS: [scalar; 4] = [10.0, 5.0, 2.0, 5.0];
     let paint = &mut Paint::default();
     paint
-        .set_path_effect(&PathEffect::compose(
-            &dash_path_effect::new(&INTERVALS, 0.0).unwrap(),
-            &discrete_path_effect::new(10.0, 4.0, None).unwrap(),
+        .set_path_effect(PathEffect::compose(
+            dash_path_effect::new(&INTERVALS, 0.0).unwrap(),
+            discrete_path_effect::new(10.0, 4.0, None).unwrap(),
         ))
         .set_style(PaintStyle::Stroke)
         .set_stroke_width(2.0)
@@ -496,9 +486,9 @@ fn draw_compose_path_effect(canvas: &mut Canvas) {
 fn draw_sum_path_effect(canvas: &mut Canvas) {
     let paint = &mut Paint::default();
     paint
-        .set_path_effect(&PathEffect::sum(
-            &discrete_path_effect::new(10.0, 4.0, None).unwrap(),
-            &discrete_path_effect::new(10.0, 4.0, Some(1245)).unwrap(),
+        .set_path_effect(PathEffect::sum(
+            discrete_path_effect::new(10.0, 4.0, None).unwrap(),
+            discrete_path_effect::new(10.0, 4.0, Some(1245)).unwrap(),
         ))
         .set_style(PaintStyle::Stroke)
         .set_stroke_width(2.0)

--- a/skia-safe/examples/skia-org/skpath_overview.rs
+++ b/skia-safe/examples/skia-org/skpath_overview.rs
@@ -1,8 +1,8 @@
 use crate::artifact::DrawingDriver;
 use skia_safe::{paint, Canvas, Color, Font, Paint, Path};
-use std::path::PathBuf;
+use std::path;
 
-pub fn draw<Driver: DrawingDriver>(path: &PathBuf) {
+pub fn draw<Driver: DrawingDriver>(path: &path::Path) {
     let path = path.join("SkPath-Overview");
 
     Driver::draw_image_256(&path, "example1", draw_example1);
@@ -16,15 +16,16 @@ fn draw_example1(canvas: &mut Canvas) {
     let mut paint = Paint::default();
     paint.set_anti_alias(true);
     let mut path = Path::default();
-    path.move_to((124, 108));
-    path.line_to((172, 24));
-    path.add_circle((50, 50), 30.0, None);
-    path.move_to((36, 148));
-    path.quad_to((66, 188), (120, 136));
+    path.move_to((124, 108))
+        .line_to((172, 24))
+        .add_circle((50, 50), 30.0, None)
+        .move_to((36, 148))
+        .quad_to((66, 188), (120, 136));
     canvas.draw_path(&path, &paint);
-    paint.set_style(paint::Style::Stroke);
-    paint.set_color(Color::BLUE);
-    paint.set_stroke_width(3.0);
+    paint
+        .set_style(paint::Style::Stroke)
+        .set_color(Color::BLUE)
+        .set_stroke_width(3.0);
     canvas.draw_path(&path, &paint);
 }
 
@@ -32,16 +33,16 @@ fn draw_example2(canvas: &mut Canvas) {
     let mut paint = Paint::default();
     paint.set_anti_alias(true);
     let mut path = Path::default();
-    path.move_to((36, 48));
-    path.quad_to((66, 88), (120, 36));
+    path.move_to((36, 48)).quad_to((66, 88), (120, 36));
     canvas.draw_path(&path, &paint);
-    paint.set_style(paint::Style::Stroke);
-    paint.set_color(Color::BLUE);
-    paint.set_stroke_width(8.0);
-    canvas.translate((0, 50));
-    canvas.draw_path(&path, &paint);
-    paint.set_style(paint::Style::StrokeAndFill);
-    paint.set_color(Color::RED);
+    paint
+        .set_style(paint::Style::Stroke)
+        .set_color(Color::BLUE)
+        .set_stroke_width(8.0);
+    canvas.translate((0, 50)).draw_path(&path, &paint);
+    paint
+        .set_style(paint::Style::StrokeAndFill)
+        .set_color(Color::RED);
     canvas.translate((0, 50));
     canvas.draw_path(&path, &paint);
 }
@@ -49,28 +50,29 @@ fn draw_example2(canvas: &mut Canvas) {
 fn draw_example3(canvas: &mut Canvas) {
     let mut paint = Paint::default();
     paint.set_anti_alias(true);
-    canvas.draw_str("1st contour", (150, 100), &Font::default(), &paint);
-    canvas.draw_str("2nd contour", (130, 160), &Font::default(), &paint);
-    canvas.draw_str("3rd contour", (40, 30), &Font::default(), &paint);
+    canvas
+        .draw_str("1st contour", (150, 100), &Font::default(), &paint)
+        .draw_str("2nd contour", (130, 160), &Font::default(), &paint)
+        .draw_str("3rd contour", (40, 30), &Font::default(), &paint);
     paint.set_style(paint::Style::Stroke);
     let mut path = Path::default();
-    path.move_to((124, 108));
-    path.line_to((172, 24));
-    path.move_to((36, 148));
-    path.quad_to((66, 188), (120, 136));
-    path.close();
-    path.conic_to((70, 20), (110, 40), 0.6);
+    path.move_to((124, 108))
+        .line_to((172, 24))
+        .move_to((36, 148))
+        .quad_to((66, 188), (120, 136))
+        .close()
+        .conic_to((70, 20), (110, 40), 0.6);
     canvas.draw_path(&path, &paint);
 }
 
 fn draw_example4(canvas: &mut Canvas) {
     let mut paint = Paint::default();
-    paint.set_anti_alias(true);
-    paint.set_style(paint::Style::Stroke);
-    paint.set_stroke_width(8.0);
+    paint
+        .set_anti_alias(true)
+        .set_style(paint::Style::Stroke)
+        .set_stroke_width(8.0);
     let mut path = Path::default();
-    path.move_to((36, 48));
-    path.quad_to((66, 88), (120, 36));
+    path.move_to((36, 48)).quad_to((66, 88), (120, 36));
     canvas.draw_path(&path, &paint);
     path.close();
     canvas.translate((0, 50));
@@ -79,17 +81,16 @@ fn draw_example4(canvas: &mut Canvas) {
 
 fn draw_example5(canvas: &mut Canvas) {
     let mut paint = Paint::default();
-    paint.set_anti_alias(true);
-    paint.set_style(paint::Style::Stroke);
-    paint.set_stroke_width(8.0);
-    paint.set_stroke_cap(paint::Cap::Round);
+    paint
+        .set_anti_alias(true)
+        .set_style(paint::Style::Stroke)
+        .set_stroke_width(8.0)
+        .set_stroke_cap(paint::Cap::Round);
     let mut path = Path::default();
-    path.move_to((36, 48));
-    path.line_to((36, 48));
+    path.move_to((36, 48)).line_to((36, 48));
     canvas.draw_path(&path, &paint);
     path.reset();
     paint.set_stroke_cap(paint::Cap::Square);
-    path.move_to((56, 48));
-    path.close();
+    path.move_to((56, 48)).close();
     canvas.draw_path(&path, &paint);
 }

--- a/skia-safe/examples/skia-org/skshaper_example.rs
+++ b/skia-safe/examples/skia-org/skshaper_example.rs
@@ -18,7 +18,7 @@ fn draw_rtl_shaped(canvas: &mut Canvas) {
     let mut paint = Paint::default();
     paint.set_anti_alias(true);
 
-    let font = &Font::from_typeface(&Typeface::default(), 64.0);
+    let font = &Font::from_typeface(Typeface::default(), 64.0);
 
     let shaper = Shaper::new();
     if let Some((blob, _)) =
@@ -32,7 +32,7 @@ fn draw_rtl_unshaped(canvas: &mut Canvas) {
     let mut paint = Paint::default();
     paint.set_anti_alias(true);
 
-    let font = &Font::from_typeface(&Typeface::default(), 64.0);
+    let font = &Font::from_typeface(Typeface::default(), 64.0);
 
     let shaper = Shaper::new_primitive();
     if let Some((blob, _)) =

--- a/skia-safe/examples/skia-org/skshaper_example.rs
+++ b/skia-safe/examples/skia-org/skshaper_example.rs
@@ -1,8 +1,8 @@
 use crate::artifact::DrawingDriver;
 use skia_safe::{icu, Canvas, Font, Paint, Point, Shaper, Typeface};
-use std::path::PathBuf;
+use std::path;
 
-pub fn draw<Driver: DrawingDriver>(path: &PathBuf) {
+pub fn draw<Driver: DrawingDriver>(path: &path::Path) {
     let path = path.join("SkShaper-Example");
 
     icu::init();
@@ -24,7 +24,7 @@ fn draw_rtl_shaped(canvas: &mut Canvas) {
     if let Some((blob, _)) =
         shaper.shape_text_blob(RTL_TEXT, font, false, 10000.0, Point::default())
     {
-        canvas.draw_text_blob(&blob, TEXT_POS, &paint)
+        canvas.draw_text_blob(&blob, TEXT_POS, &paint);
     }
 }
 
@@ -38,6 +38,6 @@ fn draw_rtl_unshaped(canvas: &mut Canvas) {
     if let Some((blob, _)) =
         shaper.shape_text_blob(RTL_TEXT, font, false, 10000.0, Point::default())
     {
-        canvas.draw_text_blob(&blob, TEXT_POS, &paint)
+        canvas.draw_text_blob(&blob, TEXT_POS, &paint);
     }
 }

--- a/skia-safe/src/core/bitmap.rs
+++ b/skia-safe/src/core/bitmap.rs
@@ -175,7 +175,7 @@ impl Handle<SkBitmap> {
 
     pub fn alloc_pixels_flags(&mut self, image_info: &ImageInfo) {
         self.try_alloc_pixels_flags(image_info)
-            .to_option()
+            .into_option()
             .expect("Bitmap::alloc_pixels_flags failed");
     }
 
@@ -200,7 +200,7 @@ impl Handle<SkBitmap> {
         row_bytes: impl Into<Option<usize>>,
     ) {
         self.try_alloc_pixels_info(image_info, row_bytes.into())
-            .to_option()
+            .into_option()
             .expect("Bitmap::alloc_pixels_info failed");
     }
 
@@ -226,7 +226,7 @@ impl Handle<SkBitmap> {
         is_opaque: impl Into<Option<bool>>,
     ) {
         self.try_alloc_n32_pixels((width, height), is_opaque.into().unwrap_or(false))
-            .to_option()
+            .into_option()
             .expect("Bitmap::alloc_n32_pixels_failed")
     }
 
@@ -254,7 +254,7 @@ impl Handle<SkBitmap> {
 
     pub fn alloc_pixels(&mut self) {
         self.try_alloc_pixels()
-            .to_option()
+            .into_option()
             .expect("Bitmap::alloc_pixels failed")
     }
 

--- a/skia-safe/src/core/bitmap.rs
+++ b/skia-safe/src/core/bitmap.rs
@@ -269,12 +269,16 @@ impl Handle<SkBitmap> {
         IPoint::from_native(unsafe { self.native().pixelRefOrigin() })
     }
 
-    pub fn set_pixel_ref(&mut self, pixel_ref: Option<&PixelRef>, offset: impl Into<IPoint>) {
+    pub fn set_pixel_ref(
+        &mut self,
+        pixel_ref: impl Into<Option<PixelRef>>,
+        offset: impl Into<IPoint>,
+    ) {
         let offset = offset.into();
         unsafe {
             C_SkBitmap_setPixelRef(
                 self.native_mut(),
-                pixel_ref.shared_ptr(),
+                pixel_ref.into().into_ptr_or_null(),
                 offset.x,
                 offset.y,
             )

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -912,23 +912,32 @@ impl Canvas {
         self
     }
 
-    pub fn draw_text_blob(&mut self, blob: &TextBlob, origin: impl Into<Point>, paint: &Paint) {
+    pub fn draw_text_blob(
+        &mut self,
+        blob: impl AsRef<TextBlob>,
+        origin: impl Into<Point>,
+        paint: &Paint,
+    ) {
         let origin = origin.into();
         unsafe {
-            self.native_mut()
-                .drawTextBlob(blob.native(), origin.x, origin.y, paint.native())
+            self.native_mut().drawTextBlob(
+                blob.as_ref().native(),
+                origin.x,
+                origin.y,
+                paint.native(),
+            )
         }
     }
 
     pub fn draw_picture(
         &mut self,
-        picture: &Picture,
+        picture: impl AsRef<Picture>,
         matrix: Option<&Matrix>,
         paint: Option<&Paint>,
     ) -> &mut Self {
         unsafe {
             self.native_mut().drawPicture(
-                picture.native(),
+                picture.as_ref().native(),
                 matrix.native_ptr_or_null(),
                 paint.native_ptr_or_null(),
             )

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -720,14 +720,14 @@ impl Canvas {
 
     pub fn draw_image(
         &mut self,
-        image: &Image,
+        image: impl AsRef<Image>,
         left_top: impl Into<Point>,
         paint: Option<&Paint>,
     ) -> &mut Self {
         let left_top = left_top.into();
         unsafe {
             self.native_mut().drawImage(
-                image.native(),
+                image.as_ref().native(),
                 left_top.x,
                 left_top.y,
                 paint.native_ptr_or_null(),
@@ -738,7 +738,7 @@ impl Canvas {
 
     pub fn draw_image_rect(
         &mut self,
-        image: &Image,
+        image: impl AsRef<Image>,
         src: Option<(&Rect, SrcRectConstraint)>,
         dst: impl AsRef<Rect>,
         paint: &Paint,
@@ -746,7 +746,7 @@ impl Canvas {
         match src {
             Some((src, constraint)) => unsafe {
                 self.native_mut().drawImageRect(
-                    image.native(),
+                    image.as_ref().native(),
                     src.native(),
                     dst.as_ref().native(),
                     paint.native(),
@@ -755,7 +755,7 @@ impl Canvas {
             },
             None => unsafe {
                 self.native_mut().drawImageRect2(
-                    image.native(),
+                    image.as_ref().native(),
                     dst.as_ref().native(),
                     paint.native(),
                 )
@@ -766,14 +766,14 @@ impl Canvas {
 
     pub fn draw_image_nine(
         &mut self,
-        image: &Image,
+        image: impl AsRef<Image>,
         center: impl AsRef<IRect>,
         dst: impl AsRef<Rect>,
         paint: Option<&Paint>,
     ) -> &mut Self {
         unsafe {
             self.native_mut().drawImageNine(
-                image.native(),
+                image.as_ref().native(),
                 center.as_ref().native(),
                 dst.as_ref().native(),
                 paint.native_ptr_or_null(),
@@ -869,14 +869,14 @@ impl Canvas {
 
     pub fn draw_image_lattice(
         &mut self,
-        image: &Image,
+        image: impl AsRef<Image>,
         lattice: &Lattice,
         dst: impl AsRef<Rect>,
         paint: Option<&Paint>,
     ) -> &mut Self {
         unsafe {
             self.native_mut().drawImageLattice(
-                image.native(),
+                image.as_ref().native(),
                 &lattice.native().native,
                 dst.as_ref().native(),
                 paint.native_ptr_or_null(),

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -917,7 +917,7 @@ impl Canvas {
         blob: impl AsRef<TextBlob>,
         origin: impl Into<Point>,
         paint: &Paint,
-    ) {
+    ) -> &mut Self {
         let origin = origin.into();
         unsafe {
             self.native_mut().drawTextBlob(
@@ -927,6 +927,7 @@ impl Canvas {
                 paint.native(),
             )
         }
+        self
     }
 
     pub fn draw_picture(

--- a/skia-safe/src/core/color.rs
+++ b/skia-safe/src/core/color.rs
@@ -70,7 +70,6 @@ impl BitAnd<u32> for Color {
 }
 
 impl Color {
-    // This is the canonical Rust idiomatic new implementation:
     pub const fn new(argb: u32) -> Self {
         Self(argb)
     }

--- a/skia-safe/src/core/color_filter.rs
+++ b/skia-safe/src/core/color_filter.rs
@@ -73,9 +73,9 @@ impl RCHandle<SkColorFilter> {
     }
 
     #[must_use]
-    pub fn composed(&self, inner: &ColorFilter) -> Option<Self> {
+    pub fn composed(&self, inner: impl Into<ColorFilter>) -> Option<Self> {
         ColorFilter::from_ptr(unsafe {
-            C_SkColorFilter_makeComposed(self.native(), inner.shared_native())
+            C_SkColorFilter_makeComposed(self.native(), inner.into().into_ptr())
         })
     }
 
@@ -92,9 +92,9 @@ pub mod color_filters {
         C_SkColorFilters_MatrixRowMajor, C_SkColorFilters_SRGBToLinearGamma,
     };
 
-    pub fn compose(outer: &ColorFilter, inner: &ColorFilter) -> Option<ColorFilter> {
+    pub fn compose(outer: ColorFilter, inner: ColorFilter) -> Option<ColorFilter> {
         ColorFilter::from_ptr(unsafe {
-            C_SkColorFilters_Compose(outer.shared_native(), inner.shared_native())
+            C_SkColorFilters_Compose(outer.into_ptr(), inner.into_ptr())
         })
     }
 
@@ -125,10 +125,8 @@ pub mod color_filters {
         ColorFilter::from_ptr(unsafe { C_SkColorFilters_SRGBToLinearGamma() }).unwrap()
     }
 
-    pub fn lerp(t: f32, dst: &ColorFilter, src: &ColorFilter) -> Option<ColorFilter> {
-        ColorFilter::from_ptr(unsafe {
-            C_SkColorFilters_Lerp(t, dst.shared_native(), src.shared_native())
-        })
+    pub fn lerp(t: f32, dst: ColorFilter, src: ColorFilter) -> Option<ColorFilter> {
+        ColorFilter::from_ptr(unsafe { C_SkColorFilters_Lerp(t, dst.into_ptr(), src.into_ptr()) })
     }
 }
 

--- a/skia-safe/src/core/deferred_display_list_recorder.rs
+++ b/skia-safe/src/core/deferred_display_list_recorder.rs
@@ -27,8 +27,9 @@ impl Handle<SkDeferredDisplayListRecorder> {
     }
 
     pub fn detach(mut self) -> Option<DeferredDisplayList> {
-        let ptr = unsafe { C_SkDeferredDisplayListRecorder_detach(self.native_mut()) };
-        Some(DeferredDisplayList(ptr.to_option()?))
+        DeferredDisplayList::from_ptr(unsafe {
+            C_SkDeferredDisplayListRecorder_detach(self.native_mut())
+        })
     }
 
     // TODO: makePromiseTexture()?
@@ -39,22 +40,11 @@ pub(crate) mod private {
     use crate::prelude::*;
     use skia_bindings::{C_SkDeferredDisplayList_delete, SkDeferredDisplayList};
 
-    #[repr(transparent)]
-    pub struct DeferredDisplayList(pub(crate) *mut SkDeferredDisplayList);
+    pub type DeferredDisplayList = RefHandle<SkDeferredDisplayList>;
 
-    impl NativeAccess<SkDeferredDisplayList> for DeferredDisplayList {
-        fn native(&self) -> &SkDeferredDisplayList {
-            unsafe { &*self.0 }
-        }
-
-        fn native_mut(&mut self) -> &mut SkDeferredDisplayList {
-            unsafe { &mut *self.0 }
-        }
-    }
-
-    impl Drop for DeferredDisplayList {
+    impl NativeDrop for SkDeferredDisplayList {
         fn drop(&mut self) {
-            unsafe { C_SkDeferredDisplayList_delete(self.0) }
+            unsafe { C_SkDeferredDisplayList_delete(self) }
         }
     }
 }

--- a/skia-safe/src/core/font.rs
+++ b/skia-safe/src/core/font.rs
@@ -48,32 +48,31 @@ impl Default for Font {
 }
 
 impl Handle<SkFont> {
-    // Canonical new.
-    pub fn new(typeface: &Typeface, size: impl Into<Option<scalar>>) -> Self {
+    pub fn new(typeface: impl Into<Typeface>, size: impl Into<Option<scalar>>) -> Self {
         Self::from_typeface(typeface, size)
     }
 
-    pub fn from_typeface(typeface: &Typeface, size: impl Into<Option<scalar>>) -> Self {
+    pub fn from_typeface(typeface: impl Into<Typeface>, size: impl Into<Option<scalar>>) -> Self {
         match size.into() {
             None => Self::construct(|font| unsafe {
-                C_SkFont_ConstructFromTypeface(font, typeface.shared_native())
+                C_SkFont_ConstructFromTypeface(font, typeface.into().into_ptr())
             }),
             Some(size) => Self::construct(|font| unsafe {
-                C_SkFont_ConstructFromTypefaceWithSize(font, typeface.shared_native(), size)
+                C_SkFont_ConstructFromTypefaceWithSize(font, typeface.into().into_ptr(), size)
             }),
         }
     }
 
     #[deprecated(since = "0.12.0", note = "use from_typeface() or new()")]
-    pub fn from_typeface_with_size(typeface: &Typeface, size: scalar) -> Self {
+    pub fn from_typeface_with_size(typeface: impl Into<Typeface>, size: scalar) -> Self {
         Self::construct(|font| unsafe {
-            C_SkFont_ConstructFromTypefaceWithSize(font, typeface.shared_native(), size)
+            C_SkFont_ConstructFromTypefaceWithSize(font, typeface.into().into_ptr(), size)
         })
     }
 
     #[deprecated(since = "0.12.0", note = "use from_typeface_with_params()")]
     pub fn from_typeface_with_size_scale_and_skew(
-        typeface: &Typeface,
+        typeface: impl Into<Typeface>,
         size: scalar,
         scale: scalar,
         skew: scalar,
@@ -81,7 +80,7 @@ impl Handle<SkFont> {
         Self::construct(|font| unsafe {
             C_SkFont_ConstructFromTypefaceWithSizeScaleAndSkew(
                 font,
-                typeface.shared_native(),
+                typeface.into().into_ptr(),
                 size,
                 scale,
                 skew,
@@ -90,7 +89,7 @@ impl Handle<SkFont> {
     }
 
     pub fn from_typeface_with_params(
-        typeface: &Typeface,
+        typeface: impl Into<Typeface>,
         size: scalar,
         scale: scalar,
         skew: scalar,
@@ -98,7 +97,7 @@ impl Handle<SkFont> {
         Self::construct(|font| unsafe {
             C_SkFont_ConstructFromTypefaceWithSizeScaleAndSkew(
                 font,
-                typeface.shared_native(),
+                typeface.into().into_ptr(),
                 size,
                 scale,
                 skew,
@@ -209,8 +208,8 @@ impl Handle<SkFont> {
         self.native().fSkewX
     }
 
-    pub fn set_typeface(&mut self, tf: &Typeface) -> &mut Self {
-        unsafe { C_SkFont_setTypeface(self.native_mut(), tf.shared_native()) }
+    pub fn set_typeface(&mut self, tf: impl Into<Typeface>) -> &mut Self {
+        unsafe { C_SkFont_setTypeface(self.native_mut(), tf.into().into_ptr()) }
         self
     }
 
@@ -461,8 +460,7 @@ impl Handle<SkFont> {
 
 #[test]
 fn test_flags() {
-    let tf = Typeface::default();
-    let mut font = Font::new(&tf, 10.0);
+    let mut font = Font::new(Typeface::default(), 10.0);
 
     font.set_force_auto_hinting(true);
     assert!(font.is_force_auto_hinting());

--- a/skia-safe/src/core/font_metrics.rs
+++ b/skia-safe/src/core/font_metrics.rs
@@ -62,7 +62,7 @@ impl FontMetrics {
         self.if_valid(Flags::STRIKEOUT_POSITION_IS_VALID, self.strikeout_position)
     }
 
-    fn if_valid(&self, flag: Flags, value: scalar) -> Option<scalar> {
+    fn if_valid(&self, flag: self::Flags, value: scalar) -> Option<scalar> {
         self.flags.contains(flag).if_true_some(value)
     }
 }

--- a/skia-safe/src/core/font_mgr.rs
+++ b/skia-safe/src/core/font_mgr.rs
@@ -163,10 +163,14 @@ impl RCHandle<SkFontMgr> {
         })
     }
 
-    pub fn match_face_style(&self, typeface: &Typeface, style: FontStyle) -> Option<Typeface> {
+    pub fn match_face_style(
+        &self,
+        typeface: impl AsRef<Typeface>,
+        style: FontStyle,
+    ) -> Option<Typeface> {
         Typeface::from_ptr(unsafe {
             self.native()
-                .matchFaceStyle(typeface.native(), style.native())
+                .matchFaceStyle(typeface.as_ref().native(), style.native())
         })
     }
 

--- a/skia-safe/src/core/image.rs
+++ b/skia-safe/src/core/image.rs
@@ -72,9 +72,9 @@ impl NativeRefCountedBase for SkImage {
 impl RCHandle<SkImage> {
     // TODO: MakeRasterCopy()
 
-    pub fn from_raster_data(info: &ImageInfo, pixels: &Data, row_bytes: usize) -> Option<Image> {
+    pub fn from_raster_data(info: &ImageInfo, pixels: Data, row_bytes: usize) -> Option<Image> {
         Image::from_ptr(unsafe {
-            C_SkImage_MakeRasterData(info.native(), pixels.shared_native(), row_bytes)
+            C_SkImage_MakeRasterData(info.native(), pixels.into_ptr(), row_bytes)
         })
     }
 
@@ -95,16 +95,16 @@ impl RCHandle<SkImage> {
         image
     }
 
-    pub fn from_encoded(data: &Data, subset: Option<IRect>) -> Option<Image> {
+    pub fn from_encoded(data: Data, subset: Option<IRect>) -> Option<Image> {
         Image::from_ptr(unsafe {
-            C_SkImage_MakeFromEncoded(data.shared_native(), subset.native().as_ptr_or_null())
+            C_SkImage_MakeFromEncoded(data.into_ptr(), subset.native().as_ptr_or_null())
         })
     }
 
     // TODO: this is experimental, should probably be removed.
     pub fn from_compressed(
         context: &mut gpu::Context,
-        data: &Data,
+        data: Data,
         size: impl Into<ISize>,
         c_type: CompressionType,
     ) -> Option<Image> {
@@ -112,7 +112,7 @@ impl RCHandle<SkImage> {
         Image::from_ptr(unsafe {
             C_SkImage_MakeFromCompressed(
                 context.native_mut(),
-                data.shared_native(),
+                data.into_ptr(),
                 size.width,
                 size.height,
                 c_type.into_native(),
@@ -128,7 +128,7 @@ impl RCHandle<SkImage> {
         origin: gpu::SurfaceOrigin,
         color_type: ColorType,
         alpha_type: AlphaType,
-        color_space: Option<&ColorSpace>,
+        color_space: impl Into<Option<ColorSpace>>,
     ) -> Option<Image> {
         Image::from_ptr(unsafe {
             C_SkImage_MakeFromTexture(
@@ -137,14 +137,14 @@ impl RCHandle<SkImage> {
                 origin.into_native(),
                 color_type.into_native(),
                 alpha_type.into_native(),
-                color_space.shared_ptr(),
+                color_space.into().into_ptr_or_null(),
             )
         })
     }
 
     pub fn from_encoded_cross_context(
         context: &mut gpu::Context,
-        data: &Data,
+        data: Data,
         build_mips: bool,
         // not mentions in the docs, but implementation indicates that
         // this can be null.
@@ -154,7 +154,7 @@ impl RCHandle<SkImage> {
         Image::from_ptr(unsafe {
             C_SkImage_MakeCrossContextFromEncoded(
                 context.native_mut(),
-                data.shared_native(),
+                data.into_ptr(),
                 build_mips,
                 color_space.native_ptr_or_null(),
                 limit_to_max_texture_size.into().unwrap_or_default(),
@@ -170,7 +170,7 @@ impl RCHandle<SkImage> {
         origin: gpu::SurfaceOrigin,
         color_type: ColorType,
         alpha_type: AlphaType,
-        color_space: Option<&ColorSpace>,
+        color_space: impl Into<Option<ColorSpace>>,
     ) -> Option<Image> {
         Image::from_ptr(unsafe {
             C_SkImage_MakeFromAdoptedTexture(
@@ -179,7 +179,7 @@ impl RCHandle<SkImage> {
                 origin.into_native(),
                 color_type.into_native(),
                 alpha_type.into_native(),
-                color_space.shared_ptr(),
+                color_space.into().into_ptr_or_null(),
             )
         })
     }
@@ -192,7 +192,7 @@ impl RCHandle<SkImage> {
         yuva_indices: &[YUVAIndex; 4],
         image_size: impl Into<ISize>,
         image_origin: gpu::SurfaceOrigin,
-        image_color_space: Option<&ColorSpace>,
+        image_color_space: impl Into<Option<ColorSpace>>,
     ) -> Option<Image> {
         Image::from_ptr(unsafe {
             C_SkImage_MakeFromYUVATexturesCopy(
@@ -202,7 +202,7 @@ impl RCHandle<SkImage> {
                 yuva_indices.native().as_ptr(),
                 image_size.into().into_native(),
                 image_origin.into_native(),
-                image_color_space.shared_ptr(),
+                image_color_space.into().into_ptr_or_null(),
             )
         })
     }
@@ -216,7 +216,7 @@ impl RCHandle<SkImage> {
         image_size: impl Into<ISize>,
         image_origin: gpu::SurfaceOrigin,
         backend_texture: &gpu::BackendTexture,
-        image_color_space: Option<&ColorSpace>,
+        image_color_space: impl Into<Option<ColorSpace>>,
     ) -> Option<Image> {
         Image::from_ptr(unsafe {
             C_SkImage_MakeFromYUVATexturesCopyWithExternalBackend(
@@ -227,7 +227,7 @@ impl RCHandle<SkImage> {
                 image_size.into().into_native(),
                 image_origin.into_native(),
                 backend_texture.native(),
-                image_color_space.shared_ptr(),
+                image_color_space.into().into_ptr_or_null(),
             )
         })
     }
@@ -239,7 +239,7 @@ impl RCHandle<SkImage> {
         yuva_indices: &[YUVAIndex; 4],
         image_size: impl Into<ISize>,
         image_origin: gpu::SurfaceOrigin,
-        image_color_space: Option<&ColorSpace>,
+        image_color_space: impl Into<Option<ColorSpace>>,
     ) -> Option<Image> {
         Image::from_ptr(unsafe {
             C_SkImage_MakeFromYUVATextures(
@@ -249,7 +249,7 @@ impl RCHandle<SkImage> {
                 yuva_indices.native().as_ptr(),
                 image_size.into().into_native(),
                 image_origin.into_native(),
-                image_color_space.shared_ptr(),
+                image_color_space.into().into_ptr_or_null(),
             )
         })
     }
@@ -261,7 +261,7 @@ impl RCHandle<SkImage> {
         yuv_color_space: YUVColorSpace,
         nv12_textures: &[gpu::BackendTexture; 2],
         image_origin: gpu::SurfaceOrigin,
-        image_color_space: Option<&ColorSpace>,
+        image_color_space: impl Into<Option<ColorSpace>>,
     ) -> Option<Image> {
         Image::from_ptr(unsafe {
             C_SkImage_MakeFromNV12TexturesCopy(
@@ -269,7 +269,7 @@ impl RCHandle<SkImage> {
                 yuv_color_space.into_native(),
                 nv12_textures.native().as_ptr(),
                 image_origin.into_native(),
-                image_color_space.shared_ptr(),
+                image_color_space.into().into_ptr_or_null(),
             )
         })
     }
@@ -280,7 +280,7 @@ impl RCHandle<SkImage> {
         nv12_textures: &[gpu::BackendTexture; 2],
         image_origin: gpu::SurfaceOrigin,
         backend_texture: &gpu::BackendTexture,
-        image_color_space: Option<&ColorSpace>,
+        image_color_space: impl Into<Option<ColorSpace>>,
     ) -> Option<Image> {
         Image::from_ptr(unsafe {
             C_SkImage_MakeFromNV12TexturesCopyWithExternalBackend(
@@ -289,27 +289,27 @@ impl RCHandle<SkImage> {
                 nv12_textures.native().as_ptr(),
                 image_origin.into_native(),
                 backend_texture.native(),
-                image_color_space.shared_ptr(),
+                image_color_space.into().into_ptr_or_null(),
             )
         })
     }
 
     pub fn from_picture(
-        picture: &Picture,
+        picture: Picture,
         dimensions: impl Into<ISize>,
         matrix: Option<&Matrix>,
         paint: Option<&Paint>,
         bit_depth: BitDepth,
-        color_space: Option<&ColorSpace>,
+        color_space: impl Into<Option<ColorSpace>>,
     ) -> Option<Image> {
         Image::from_ptr(unsafe {
             C_SkImage_MakeFromPicture(
-                picture.shared_native(),
+                picture.into_ptr(),
                 dimensions.into().native(),
                 matrix.native_ptr_or_null(),
                 paint.native_ptr_or_null(),
                 bit_depth.into_native(),
-                color_space.shared_ptr(),
+                color_space.into().into_ptr_or_null(),
             )
         })
     }
@@ -525,9 +525,9 @@ impl RCHandle<SkImage> {
         unsafe { self.native().isLazyGenerated() }
     }
 
-    pub fn new_color_space(&self, color_space: Option<&ColorSpace>) -> Option<Image> {
+    pub fn new_color_space(&self, color_space: impl Into<Option<ColorSpace>>) -> Option<Image> {
         Image::from_ptr(unsafe {
-            C_SkImage_makeColorSpace(self.native(), color_space.shared_ptr())
+            C_SkImage_makeColorSpace(self.native(), color_space.into().into_ptr_or_null())
         })
     }
 }

--- a/skia-safe/src/core/image_filter.rs
+++ b/skia-safe/src/core/image_filter.rs
@@ -287,12 +287,12 @@ impl RCHandle<SkImageFilter> {
         unsafe { self.native().canHandleComplexCTM() }
     }
 
-    pub fn with_matrix(&self, matrix: &Matrix, quality: FilterQuality) -> ImageFilter {
+    pub fn with_matrix(self, matrix: &Matrix, quality: FilterQuality) -> ImageFilter {
         ImageFilter::from_ptr(unsafe {
             C_SkImageFilter_MakeMatrixFilter(
                 matrix.native(),
                 quality.into_native(),
-                self.shared_native(),
+                self.into_ptr(),
             )
         })
         .unwrap()

--- a/skia-safe/src/core/image_generator.rs
+++ b/skia-safe/src/core/image_generator.rs
@@ -105,26 +105,26 @@ impl RefHandle<SkImageGenerator> {
 
     // TODO: generateTexture()
 
-    pub fn from_encoded(encoded: &Data) -> Option<Self> {
-        Self::from_ptr(unsafe { C_SkImageGenerator_MakeFromEncoded(encoded.shared_native()) })
+    pub fn from_encoded(encoded: Data) -> Option<Self> {
+        Self::from_ptr(unsafe { C_SkImageGenerator_MakeFromEncoded(encoded.into_ptr()) })
     }
 
     pub fn from_picture(
         size: ISize,
-        picture: &Picture,
+        picture: Picture,
         matrix: Option<&Matrix>,
         paint: Option<&Paint>,
         bit_depth: image::BitDepth,
-        color_space: Option<&ColorSpace>,
+        color_space: impl Into<Option<ColorSpace>>,
     ) -> Option<Self> {
         Self::from_ptr(unsafe {
             C_SkImageGenerator_MakeFromPicture(
                 size.native(),
-                picture.native(),
+                picture.into_ptr(),
                 matrix.native_ptr_or_null(),
                 paint.native_ptr_or_null(),
                 bit_depth.into_native(),
-                color_space.native_ptr_or_null(),
+                color_space.into().into_ptr_or_null(),
             )
         })
     }

--- a/skia-safe/src/core/image_info.rs
+++ b/skia-safe/src/core/image_info.rs
@@ -145,7 +145,7 @@ impl Handle<SkImageInfo> {
         dimensions: impl Into<ISize>,
         ct: ColorType,
         at: AlphaType,
-        cs: Option<&ColorSpace>,
+        cs: impl Into<Option<ColorSpace>>,
     ) -> Self {
         let dimensions = dimensions.into();
         let mut image_info = Self::default();
@@ -157,7 +157,7 @@ impl Handle<SkImageInfo> {
                 dimensions.height,
                 ct.into_native(),
                 at.into_native(),
-                cs.shared_ptr(),
+                cs.into().into_ptr_or_null(),
             )
         }
         image_info
@@ -166,7 +166,7 @@ impl Handle<SkImageInfo> {
     pub fn new_n32(
         dimensions: impl Into<ISize>,
         at: AlphaType,
-        cs: Option<&ColorSpace>,
+        cs: impl Into<Option<ColorSpace>>,
     ) -> ImageInfo {
         Self::new(dimensions, ColorType::n32(), at, cs)
     }
@@ -185,7 +185,10 @@ impl Handle<SkImageInfo> {
         image_info
     }
 
-    pub fn new_n32_premul(dimensions: impl Into<ISize>, cs: Option<&ColorSpace>) -> ImageInfo {
+    pub fn new_n32_premul(
+        dimensions: impl Into<ISize>,
+        cs: impl Into<Option<ColorSpace>>,
+    ) -> ImageInfo {
         Self::new(dimensions, ColorType::n32(), AlphaType::Premul, cs)
     }
 
@@ -247,7 +250,7 @@ impl Handle<SkImageInfo> {
             new_dimensions,
             self.color_type(),
             self.alpha_type(),
-            self.color_space().as_ref(),
+            self.color_space(),
         )
     }
 
@@ -256,7 +259,7 @@ impl Handle<SkImageInfo> {
             self.dimensions(),
             self.color_type(),
             new_alpha_type,
-            self.color_space().as_ref(),
+            self.color_space(),
         )
     }
 
@@ -265,11 +268,11 @@ impl Handle<SkImageInfo> {
             self.dimensions(),
             new_color_type,
             self.alpha_type(),
-            self.color_space().as_ref(),
+            self.color_space(),
         )
     }
 
-    pub fn with_color_space(&self, new_color_space: Option<&ColorSpace>) -> Self {
+    pub fn with_color_space(&self, new_color_space: impl Into<Option<ColorSpace>>) -> Self {
         Self::new(
             self.dimensions(),
             self.color_type(),
@@ -318,7 +321,7 @@ fn ref_cnt_in_relation_to_color_space() {
     let cs = ColorSpace::new_srgb();
     let before = cs.native().ref_cnt();
     {
-        let ii = ImageInfo::new_n32((10, 10), AlphaType::Premul, Some(&cs));
+        let ii = ImageInfo::new_n32((10, 10), AlphaType::Premul, Some(cs.clone()));
         // one for the capture in image info
         assert_eq!(before + 1, cs.native().ref_cnt());
         let cs2 = ii.color_space();

--- a/skia-safe/src/core/mask_filter.rs
+++ b/skia-safe/src/core/mask_filter.rs
@@ -38,19 +38,13 @@ impl RCHandle<SkMaskFilter> {
         .unwrap()
     }
 
-    pub fn compose(outer: &Self, inner: &Self) -> Option<Self> {
-        Self::from_ptr(unsafe {
-            C_SkMaskFilter_Compose(outer.shared_native(), inner.shared_native())
-        })
+    pub fn compose(outer: Self, inner: Self) -> Option<Self> {
+        Self::from_ptr(unsafe { C_SkMaskFilter_Compose(outer.into_ptr(), inner.into_ptr()) })
     }
 
-    pub fn combine(filter_a: &Self, filter_b: &Self, mode: CoverageMode) -> Option<Self> {
+    pub fn combine(filter_a: Self, filter_b: Self, mode: CoverageMode) -> Option<Self> {
         Self::from_ptr(unsafe {
-            C_SkMaskFilter_Combine(
-                filter_a.shared_native(),
-                filter_b.shared_native(),
-                mode.into_native(),
-            )
+            C_SkMaskFilter_Combine(filter_a.into_ptr(), filter_b.into_ptr(), mode.into_native())
         })
     }
 

--- a/skia-safe/src/core/paint.rs
+++ b/skia-safe/src/core/paint.rs
@@ -276,8 +276,8 @@ impl Handle<SkPaint> {
         Shader::from_unshared_ptr(self.native().fShader.fPtr)
     }
 
-    pub fn set_shader<'a>(&mut self, shader: impl Into<Option<&'a Shader>>) -> &mut Self {
-        unsafe { C_SkPaint_setShader(self.native_mut(), shader.into().shared_ptr()) }
+    pub fn set_shader(&mut self, shader: impl Into<Option<Shader>>) -> &mut Self {
+        unsafe { C_SkPaint_setShader(self.native_mut(), shader.into().into_ptr_or_null()) }
         self
     }
 
@@ -285,11 +285,10 @@ impl Handle<SkPaint> {
         ColorFilter::from_unshared_ptr(self.native().fColorFilter.fPtr)
     }
 
-    pub fn set_color_filter<'a>(
-        &mut self,
-        color_filter: impl Into<Option<&'a ColorFilter>>,
-    ) -> &mut Self {
-        unsafe { C_SkPaint_setColorFilter(self.native_mut(), color_filter.into().shared_ptr()) }
+    pub fn set_color_filter(&mut self, color_filter: impl Into<Option<ColorFilter>>) -> &mut Self {
+        unsafe {
+            C_SkPaint_setColorFilter(self.native_mut(), color_filter.into().into_ptr_or_null())
+        }
         self
     }
 
@@ -315,11 +314,8 @@ impl Handle<SkPaint> {
         PathEffect::from_unshared_ptr(self.native().fPathEffect.fPtr)
     }
 
-    pub fn set_path_effect<'a>(
-        &mut self,
-        path_effect: impl Into<Option<&'a PathEffect>>,
-    ) -> &mut Self {
-        unsafe { C_SkPaint_setPathEffect(self.native_mut(), path_effect.into().shared_ptr()) }
+    pub fn set_path_effect(&mut self, path_effect: impl Into<Option<PathEffect>>) -> &mut Self {
+        unsafe { C_SkPaint_setPathEffect(self.native_mut(), path_effect.into().into_ptr_or_null()) }
         self
     }
 
@@ -327,11 +323,8 @@ impl Handle<SkPaint> {
         MaskFilter::from_unshared_ptr(self.native().fMaskFilter.fPtr)
     }
 
-    pub fn set_mask_filter<'a>(
-        &mut self,
-        mask_filter: impl Into<Option<&'a MaskFilter>>,
-    ) -> &mut Self {
-        unsafe { C_SkPaint_setMaskFilter(self.native_mut(), mask_filter.into().shared_ptr()) }
+    pub fn set_mask_filter(&mut self, mask_filter: impl Into<Option<MaskFilter>>) -> &mut Self {
+        unsafe { C_SkPaint_setMaskFilter(self.native_mut(), mask_filter.into().into_ptr_or_null()) }
         self
     }
 
@@ -339,11 +332,10 @@ impl Handle<SkPaint> {
         ImageFilter::from_unshared_ptr(self.native().fImageFilter.fPtr)
     }
 
-    pub fn set_image_filter<'a>(
-        &mut self,
-        image_filter: impl Into<Option<&'a ImageFilter>>,
-    ) -> &mut Self {
-        unsafe { C_SkPaint_setImageFilter(self.native_mut(), image_filter.into().shared_ptr()) }
+    pub fn set_image_filter(&mut self, image_filter: impl Into<Option<ImageFilter>>) -> &mut Self {
+        unsafe {
+            C_SkPaint_setImageFilter(self.native_mut(), image_filter.into().into_ptr_or_null())
+        }
         self
     }
 
@@ -351,12 +343,9 @@ impl Handle<SkPaint> {
         DrawLooper::from_unshared_ptr(unsafe { C_SkPaint_getDrawLooper(self.native()) })
     }
 
-    pub fn set_draw_looper<'a>(
-        &mut self,
-        draw_looper: impl Into<Option<&'a DrawLooper>>,
-    ) -> &mut Self {
+    pub fn set_draw_looper(&mut self, draw_looper: impl Into<Option<DrawLooper>>) -> &mut Self {
         unsafe {
-            C_SkPaint_setDrawLooper(self.native_mut(), draw_looper.into().shared_ptr());
+            C_SkPaint_setDrawLooper(self.native_mut(), draw_looper.into().into_ptr_or_null());
         }
         self
     }

--- a/skia-safe/src/core/path.rs
+++ b/skia-safe/src/core/path.rs
@@ -205,7 +205,7 @@ impl<'a> Iter<'a> {
         #[allow(clippy::map_clone)]
         self.native()
             .fConicWeights
-            .to_option()
+            .into_option()
             .map(|p| unsafe { *p })
     }
 
@@ -279,7 +279,7 @@ impl<'a> RawIter<'a> {
         self.native()
             .fRawIter
             .fConicWeights
-            .to_option()
+            .into_option()
             .map(|cw| unsafe { *cw })
     }
 }

--- a/skia-safe/src/core/path_effect.rs
+++ b/skia-safe/src/core/path_effect.rs
@@ -90,16 +90,14 @@ impl NativeFlattenable for SkPathEffect {
 }
 
 impl RCHandle<SkPathEffect> {
-    pub fn sum(first: &PathEffect, second: &PathEffect) -> PathEffect {
-        PathEffect::from_ptr(unsafe {
-            C_SkPathEffect_MakeSum(first.shared_native(), second.shared_native())
-        })
-        .unwrap()
+    pub fn sum(first: PathEffect, second: PathEffect) -> PathEffect {
+        PathEffect::from_ptr(unsafe { C_SkPathEffect_MakeSum(first.into_ptr(), second.into_ptr()) })
+            .unwrap()
     }
 
-    pub fn compose(first: &PathEffect, second: &PathEffect) -> PathEffect {
+    pub fn compose(first: PathEffect, second: PathEffect) -> PathEffect {
         PathEffect::from_ptr(unsafe {
-            C_SkPathEffect_MakeCompose(first.shared_native(), second.shared_native())
+            C_SkPathEffect_MakeCompose(first.into_ptr(), second.into_ptr())
         })
         .unwrap()
     }

--- a/skia-safe/src/core/pixmap.rs
+++ b/skia-safe/src/core/pixmap.rs
@@ -55,11 +55,10 @@ impl Handle<SkPixmap> {
 
     // TODO: Add reset function that borrows pixels?
 
-    pub fn set_color_space<'a>(
-        &mut self,
-        color_space: impl Into<Option<&'a ColorSpace>>,
-    ) -> &mut Self {
-        unsafe { C_SkPixmap_setColorSpace(self.native_mut(), color_space.into().shared_ptr()) }
+    pub fn set_color_space(&mut self, color_space: impl Into<Option<ColorSpace>>) -> &mut Self {
+        unsafe {
+            C_SkPixmap_setColorSpace(self.native_mut(), color_space.into().into_ptr_or_null())
+        }
         self
     }
 

--- a/skia-safe/src/core/region.rs
+++ b/skia-safe/src/core/region.rs
@@ -399,7 +399,7 @@ impl<'a> Iterator<'a> {
 
     pub fn rgn(&self) -> Option<&Region> {
         unsafe {
-            let r = C_SkRegion_Iterator_rgn(self.native()).to_option()?;
+            let r = C_SkRegion_Iterator_rgn(self.native()).into_option()?;
             Some(transmute_ref(&*r))
         }
     }

--- a/skia-safe/src/core/shader.rs
+++ b/skia-safe/src/core/shader.rs
@@ -159,9 +159,9 @@ impl RCHandle<SkShader> {
             .unwrap()
     }
 
-    pub fn with_color_filter(&self, color_filter: &ColorFilter) -> Self {
+    pub fn with_color_filter(&self, color_filter: ColorFilter) -> Self {
         Self::from_ptr(unsafe {
-            C_SkShader_makeWithColorFilter(self.native(), color_filter.shared_native())
+            C_SkShader_makeWithColorFilter(self.native(), color_filter.into_ptr())
         })
         .unwrap()
     }
@@ -184,32 +184,26 @@ pub mod shaders {
         Shader::from_ptr(unsafe { C_SkShaders_Color(color.into_native()) }).unwrap()
     }
 
-    pub fn color_in_space(color: impl AsRef<Color4f>, space: &ColorSpace) -> Shader {
+    pub fn color_in_space(color: impl AsRef<Color4f>, space: ColorSpace) -> Shader {
+        Shader::from_ptr(unsafe { C_SkShaders_Color2(color.as_ref().native(), space.into_ptr()) })
+            .unwrap()
+    }
+
+    pub fn blend(mode: BlendMode, dst: Shader, src: Shader) -> Shader {
         Shader::from_ptr(unsafe {
-            C_SkShaders_Color2(color.as_ref().native(), space.shared_native())
+            C_SkShaders_Blend(mode.into_native(), dst.into_ptr(), src.into_ptr())
         })
         .unwrap()
     }
 
-    pub fn blend(mode: BlendMode, dst: &Shader, src: &Shader) -> Shader {
-        Shader::from_ptr(unsafe {
-            C_SkShaders_Blend(mode.into_native(), dst.shared_native(), src.shared_native())
-        })
-        .unwrap()
-    }
-
-    pub fn lerp(t: f32, dst: &Shader, src: &Shader) -> Option<Shader> {
-        Shader::from_ptr(unsafe { C_SkShaders_Lerp(t, dst.shared_native(), src.shared_native()) })
+    pub fn lerp(t: f32, dst: Shader, src: Shader) -> Option<Shader> {
+        Shader::from_ptr(unsafe { C_SkShaders_Lerp(t, dst.into_ptr(), src.into_ptr()) })
     }
 
     // TODO: rename as soon it's clear from the documentation what it does.
-    pub fn lerp2(red: &Shader, dst: &Shader, src: &Shader) -> Shader {
+    pub fn lerp2(red: Shader, dst: Shader, src: Shader) -> Shader {
         Shader::from_ptr(unsafe {
-            C_SkShaders_Lerp2(
-                red.shared_native(),
-                dst.shared_native(),
-                src.shared_native(),
-            )
+            C_SkShaders_Lerp2(red.into_ptr(), dst.into_ptr(), src.into_ptr())
         })
         .unwrap()
     }

--- a/skia-safe/src/core/surface.rs
+++ b/skia-safe/src/core/surface.rs
@@ -99,7 +99,7 @@ impl RCHandle<SkSurface> {
         origin: SurfaceOrigin,
         sample_count: impl Into<Option<usize>>,
         color_type: ColorType,
-        color_space: Option<&ColorSpace>,
+        color_space: impl Into<Option<ColorSpace>>,
         surface_props: Option<&SurfaceProps>,
     ) -> Option<Self> {
         Self::from_ptr(unsafe {
@@ -109,7 +109,7 @@ impl RCHandle<SkSurface> {
                 origin.into_native(),
                 sample_count.into().unwrap_or(0).try_into().unwrap(),
                 color_type.into_native(),
-                color_space.shared_ptr(),
+                color_space.into().into_ptr_or_null(),
                 surface_props.native_ptr_or_null(),
             )
         })
@@ -120,7 +120,7 @@ impl RCHandle<SkSurface> {
         backend_render_target: &BackendRenderTarget,
         origin: SurfaceOrigin,
         color_type: ColorType,
-        color_space: Option<&ColorSpace>,
+        color_space: impl Into<Option<ColorSpace>>,
         surface_props: Option<&SurfaceProps>,
     ) -> Option<Self> {
         Self::from_ptr(unsafe {
@@ -129,7 +129,7 @@ impl RCHandle<SkSurface> {
                 backend_render_target.native(),
                 origin.into_native(),
                 color_type.into_native(),
-                color_space.shared_ptr(),
+                color_space.into().into_ptr_or_null(),
                 surface_props.native_ptr_or_null(),
             )
         })
@@ -141,7 +141,7 @@ impl RCHandle<SkSurface> {
         origin: SurfaceOrigin,
         sample_count: impl Into<Option<usize>>,
         color_type: ColorType,
-        color_space: Option<&ColorSpace>,
+        color_space: impl Into<Option<ColorSpace>>,
         surface_props: Option<&SurfaceProps>,
     ) -> Option<Self> {
         Self::from_ptr(unsafe {
@@ -151,7 +151,7 @@ impl RCHandle<SkSurface> {
                 origin.into_native(),
                 sample_count.into().unwrap_or(0).try_into().unwrap(),
                 color_type.into_native(),
-                color_space.shared_ptr(),
+                color_space.into().into_ptr_or_null(),
                 surface_props.native_ptr_or_null(),
             )
         })

--- a/skia-safe/src/core/typeface.rs
+++ b/skia-safe/src/core/typeface.rs
@@ -128,10 +128,10 @@ impl RCHandle<SkTypeface> {
 
     // TODO: MakeFromStream()?
 
-    pub fn from_data(data: &Data, index: impl Into<Option<usize>>) -> Option<Typeface> {
+    pub fn from_data(data: Data, index: impl Into<Option<usize>>) -> Option<Typeface> {
         Typeface::from_ptr(unsafe {
             C_SkTypeface_MakeFromData(
-                data.shared_native(),
+                data.into_ptr(),
                 index.into().unwrap_or_default().try_into().unwrap(),
             )
         })

--- a/skia-safe/src/core/typeface.rs
+++ b/skia-safe/src/core/typeface.rs
@@ -112,8 +112,8 @@ impl RCHandle<SkTypeface> {
 
     // Decided not to support PartialEq instead of this function,
     // because Skia does not support the operator ==.
-    pub fn equal(face_a: &Typeface, face_b: &Typeface) -> bool {
-        unsafe { SkTypeface::Equal(face_a.native(), face_b.native()) }
+    pub fn equal(face_a: impl AsRef<Typeface>, face_b: impl AsRef<Typeface>) -> bool {
+        unsafe { SkTypeface::Equal(face_a.as_ref().native(), face_b.as_ref().native()) }
     }
 
     pub fn from_name(family_name: impl AsRef<str>, font_style: FontStyle) -> Option<Typeface> {

--- a/skia-safe/src/core/typeface.rs
+++ b/skia-safe/src/core/typeface.rs
@@ -243,7 +243,7 @@ impl RCHandle<SkTypeface> {
     }
 
     pub fn new_family_name_iterator(&self) -> impl Iterator<Item = LocalizedString> {
-        LocalizedStringsIter(unsafe { self.native().createFamilyNameIterator() })
+        LocalizedStringsIter::from_ptr(unsafe { self.native().createFamilyNameIterator() }).unwrap()
     }
 
     pub fn family_name(&self) -> String {
@@ -263,26 +263,15 @@ impl RCHandle<SkTypeface> {
     }
 }
 
-#[repr(transparent)]
-struct LocalizedStringsIter(*mut SkTypeface_LocalizedStrings);
+pub type LocalizedStringsIter = RefHandle<SkTypeface_LocalizedStrings>;
 
-impl NativeAccess<SkTypeface_LocalizedStrings> for LocalizedStringsIter {
-    fn native(&self) -> &SkTypeface_LocalizedStrings {
-        unsafe { &*self.0 }
-    }
-
-    fn native_mut(&mut self) -> &mut SkTypeface_LocalizedStrings {
-        unsafe { &mut *self.0 }
-    }
-}
-
-impl Drop for LocalizedStringsIter {
+impl NativeDrop for SkTypeface_LocalizedStrings {
     fn drop(&mut self) {
-        unsafe { C_SkTypeface_LocalizedStrings_unref(self.0) }
+        unsafe { C_SkTypeface_LocalizedStrings_unref(self) }
     }
 }
 
-impl Iterator for LocalizedStringsIter {
+impl Iterator for RefHandle<SkTypeface_LocalizedStrings> {
     type Item = LocalizedString;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/skia-safe/src/core/vertices.rs
+++ b/skia-safe/src/core/vertices.rs
@@ -190,22 +190,22 @@ impl RCHandle<SkVertices> {
     }
 
     pub fn tex_coords(&self) -> Option<&[Point]> {
-        let texs: *const SkPoint = self.native().fTexs.to_option()?;
+        let texs: *const SkPoint = self.native().fTexs.into_option()?;
         Some(unsafe { slice::from_raw_parts(texs as _, self.vertex_count()) })
     }
 
     pub fn colors(&self) -> Option<&[Color]> {
-        let colors: *const SkColor = self.native().fColors.to_option()?;
+        let colors: *const SkColor = self.native().fColors.into_option()?;
         Some(unsafe { slice::from_raw_parts(colors as _, self.vertex_count()) })
     }
 
     pub fn bone_indices(&self) -> Option<&[BoneIndices]> {
-        let indices = self.native().fBoneIndices.to_option()?;
+        let indices = self.native().fBoneIndices.into_option()?;
         Some(unsafe { slice::from_raw_parts(indices as _, self.vertex_count()) })
     }
 
     pub fn bone_weights(&self) -> Option<&[BoneWeights]> {
-        let weights = self.native().fBoneWeights.to_option()?;
+        let weights = self.native().fBoneWeights.into_option()?;
         Some(unsafe { slice::from_raw_parts(weights as _, self.vertex_count()) })
     }
 
@@ -214,7 +214,7 @@ impl RCHandle<SkVertices> {
     }
 
     pub fn indices(&self) -> Option<&[u16]> {
-        let indices = self.native().fIndices.to_option()?;
+        let indices = self.native().fIndices.into_option()?;
         Some(unsafe { slice::from_raw_parts_mut(indices as _, self.index_count()) })
     }
 
@@ -305,35 +305,35 @@ impl Handle<SkVertices_Builder> {
 
     pub fn tex_coords(&mut self) -> Option<&mut [Point]> {
         unsafe {
-            let coords: *mut SkPoint = self.native_mut().texCoords().to_option()?;
+            let coords: *mut SkPoint = self.native_mut().texCoords().into_option()?;
             Some(slice::from_raw_parts_mut(coords as _, self.vertex_count()))
         }
     }
 
     pub fn colors(&mut self) -> Option<&mut [Color]> {
         unsafe {
-            let colors: *mut SkColor = self.native_mut().colors().to_option()?;
+            let colors: *mut SkColor = self.native_mut().colors().into_option()?;
             Some(slice::from_raw_parts_mut(colors as _, self.vertex_count()))
         }
     }
 
     pub fn bone_indices(&mut self) -> Option<&mut [BoneIndices]> {
         unsafe {
-            let indices = self.native_mut().boneIndices().to_option()?;
+            let indices = self.native_mut().boneIndices().into_option()?;
             Some(slice::from_raw_parts_mut(indices as _, self.vertex_count()))
         }
     }
 
     pub fn bone_weights(&mut self) -> Option<&mut [BoneWeights]> {
         unsafe {
-            let weights = self.native_mut().boneWeights().to_option()?;
+            let weights = self.native_mut().boneWeights().into_option()?;
             Some(slice::from_raw_parts_mut(weights as _, self.vertex_count()))
         }
     }
 
     pub fn indices(&mut self) -> Option<&mut [u16]> {
         unsafe {
-            let indices = self.native_mut().indices().to_option()?;
+            let indices = self.native_mut().indices().into_option()?;
             Some(slice::from_raw_parts_mut(indices as _, self.index_count()))
         }
     }

--- a/skia-safe/src/effects/alpha_threshold_filter.rs
+++ b/skia-safe/src/effects/alpha_threshold_filter.rs
@@ -4,7 +4,7 @@ use skia_bindings::{C_SkAlphaThresholdFilter_Make, SkImageFilter};
 
 impl RCHandle<SkImageFilter> {
     pub fn alpha_threshold<'a>(
-        &self,
+        self,
         crop_rect: impl Into<Option<&'a CropRect>>,
         region: &Region,
         inner_min: scalar,
@@ -18,7 +18,7 @@ pub fn new<'a>(
     region: &Region,
     inner_min: scalar,
     outer_max: scalar,
-    input: &ImageFilter,
+    input: ImageFilter,
     crop_rect: impl Into<Option<&'a CropRect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
@@ -26,7 +26,7 @@ pub fn new<'a>(
             region.native(),
             inner_min,
             outer_max,
-            input.shared_native(),
+            input.into_ptr(),
             crop_rect.into().native_ptr_or_null(),
         )
     })

--- a/skia-safe/src/effects/arithmetic_image_filter.rs
+++ b/skia-safe/src/effects/arithmetic_image_filter.rs
@@ -6,8 +6,8 @@ impl RCHandle<SkImageFilter> {
     #[allow(clippy::too_many_arguments)]
     pub fn arithmetic<'a>(
         inputs: impl Into<ArithmeticFPInputs>,
-        background: &Self,
-        foreground: &Self,
+        background: Self,
+        foreground: Self,
         crop_rect: impl Into<Option<&'a image_filter::CropRect>>,
     ) -> Option<Self> {
         new(inputs, background, foreground, crop_rect)
@@ -32,8 +32,8 @@ impl From<([f32; 4], bool)> for ArithmeticFPInputs {
 #[allow(clippy::too_many_arguments)]
 pub fn new<'a>(
     inputs: impl Into<ArithmeticFPInputs>,
-    background: &ImageFilter,
-    foreground: &ImageFilter,
+    background: ImageFilter,
+    foreground: ImageFilter,
     crop_rect: impl Into<Option<&'a image_filter::CropRect>>,
 ) -> Option<ImageFilter> {
     let inputs = inputs.into();
@@ -44,8 +44,8 @@ pub fn new<'a>(
             inputs.k[2],
             inputs.k[3],
             inputs.enforce_pm_color,
-            background.shared_native(),
-            foreground.shared_native(),
+            background.into_ptr(),
+            foreground.into_ptr(),
             crop_rect.into().native_ptr_or_null(),
         )
     })

--- a/skia-safe/src/effects/blur_image_filter.rs
+++ b/skia-safe/src/effects/blur_image_filter.rs
@@ -4,7 +4,7 @@ use skia_bindings::{C_SkBlurImageFilter_Make, SkBlurImageFilter_TileMode, SkImag
 
 impl RCHandle<SkImageFilter> {
     pub fn blur<'a>(
-        &self,
+        self,
         crop_rect: impl Into<Option<&'a CropRect>>,
         sigma: (scalar, scalar),
         tile_mode: impl Into<Option<TileMode>>,
@@ -29,7 +29,7 @@ fn test_tile_mode_layout() {
 
 pub fn new<'a>(
     (sigma_x, sigma_y): (scalar, scalar),
-    input: &ImageFilter,
+    input: ImageFilter,
     crop_rect: impl Into<Option<&'a CropRect>>,
     tile_mode: impl Into<Option<TileMode>>,
 ) -> Option<ImageFilter> {
@@ -37,7 +37,7 @@ pub fn new<'a>(
         C_SkBlurImageFilter_Make(
             sigma_x,
             sigma_y,
-            input.shared_native(),
+            input.into_ptr(),
             crop_rect.into().native_ptr_or_null(),
             tile_mode
                 .into()

--- a/skia-safe/src/effects/color_filter_image_filter.rs
+++ b/skia-safe/src/effects/color_filter_image_filter.rs
@@ -4,23 +4,23 @@ use skia_bindings::{C_SkColorFilterImageFilter_Make, SkImageFilter};
 
 impl RCHandle<SkImageFilter> {
     pub fn color_filter<'a>(
-        &self,
+        self,
         crop_rect: impl Into<Option<&'a CropRect>>,
-        cf: &ColorFilter,
+        cf: ColorFilter,
     ) -> Option<Self> {
         new(cf, self, crop_rect)
     }
 }
 
 pub fn new<'a>(
-    cf: &ColorFilter,
-    input: &ImageFilter,
+    cf: ColorFilter,
+    input: ImageFilter,
     crop_rect: impl Into<Option<&'a CropRect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
         C_SkColorFilterImageFilter_Make(
-            cf.shared_native(),
-            input.shared_native(),
+            cf.into_ptr(),
+            input.into_ptr(),
             crop_rect.into().native_ptr_or_null(),
         )
     })

--- a/skia-safe/src/effects/compose_image_filter.rs
+++ b/skia-safe/src/effects/compose_image_filter.rs
@@ -3,13 +3,13 @@ use crate::ImageFilter;
 use skia_bindings::{C_SkComposeImageFilter_Make, SkImageFilter};
 
 impl RCHandle<SkImageFilter> {
-    pub fn compose(outer: &ImageFilter, inner: &ImageFilter) -> Option<Self> {
+    pub fn compose(outer: ImageFilter, inner: ImageFilter) -> Option<Self> {
         new(outer, inner)
     }
 }
 
-pub fn new(outer: &ImageFilter, inner: &ImageFilter) -> Option<ImageFilter> {
+pub fn new(outer: ImageFilter, inner: ImageFilter) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
-        C_SkComposeImageFilter_Make(outer.shared_native(), inner.shared_native())
+        C_SkComposeImageFilter_Make(outer.into_ptr(), inner.into_ptr())
     })
 }

--- a/skia-safe/src/effects/displacement_map_effect.rs
+++ b/skia-safe/src/effects/displacement_map_effect.rs
@@ -8,8 +8,8 @@ impl RCHandle<SkImageFilter> {
     pub fn displacement_map_effect<'a>(
         channel_selectors: (ChannelSelector, ChannelSelector),
         scale: scalar,
-        displacement: &ImageFilter,
-        color: &ImageFilter,
+        displacement: ImageFilter,
+        color: ImageFilter,
         crop_rect: impl Into<Option<&'a CropRect>>,
     ) -> Option<Self> {
         new(channel_selectors, scale, displacement, color, crop_rect)
@@ -35,8 +35,8 @@ fn test_channel_selector_type_layout() {
 pub fn new<'a>(
     (x_channel_selector, y_channel_selector): (ChannelSelector, ChannelSelector),
     scale: scalar,
-    displacement: &ImageFilter,
-    color: &ImageFilter,
+    displacement: ImageFilter,
+    color: ImageFilter,
     crop_rect: impl Into<Option<&'a CropRect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
@@ -44,8 +44,8 @@ pub fn new<'a>(
             x_channel_selector.into_native(),
             y_channel_selector.into_native(),
             scale,
-            displacement.shared_native(),
-            color.shared_native(),
+            displacement.into_ptr(),
+            color.into_ptr(),
             crop_rect.into().native_ptr_or_null(),
         )
     })

--- a/skia-safe/src/effects/drop_shadow_image_filter.rs
+++ b/skia-safe/src/effects/drop_shadow_image_filter.rs
@@ -6,7 +6,7 @@ use skia_bindings::{
 
 impl RCHandle<SkImageFilter> {
     pub fn drop_shadow<'a>(
-        &self,
+        self,
         crop_rect: impl Into<Option<&'a CropRect>>,
         delta: impl Into<Vector>,
         sigma: (scalar, scalar),
@@ -36,7 +36,7 @@ pub fn new<'a>(
     (sigma_x, sigma_y): (scalar, scalar),
     color: impl Into<Color>,
     shadow_mode: ShadowMode,
-    input: &ImageFilter,
+    input: ImageFilter,
     crop_rect: impl Into<Option<&'a CropRect>>,
 ) -> Option<ImageFilter> {
     let delta = delta.into();
@@ -49,7 +49,7 @@ pub fn new<'a>(
             sigma_y,
             color.into_native(),
             shadow_mode.into_native(),
-            input.shared_native(),
+            input.into_ptr(),
             crop_rect.into().native_ptr_or_null(),
         )
     })

--- a/skia-safe/src/effects/gradient_shader.rs
+++ b/skia-safe/src/effects/gradient_shader.rs
@@ -112,7 +112,7 @@ pub fn linear<'a>(
                 C_SkGradientShader_MakeLinear2(
                     points.native().as_ptr(),
                     colors.native().as_ptr(),
-                    color_space.shared_native(),
+                    color_space.into_ptr(),
                     pos.as_ptr_or_null(),
                     colors.len().try_into().unwrap(),
                     mode.into_native(),
@@ -158,7 +158,7 @@ pub fn radial<'a>(
                     center.native(),
                     radius,
                     colors.native().as_ptr(),
-                    color_space.shared_native(),
+                    color_space.into_ptr(),
                     pos.as_ptr_or_null(),
                     colors.len().try_into().unwrap(),
                     mode.into_native(),
@@ -212,7 +212,7 @@ pub fn two_point_conical<'a>(
                     end.native(),
                     end_radius,
                     colors.native().as_ptr(),
-                    color_space.shared_native(),
+                    color_space.into_ptr(),
                     pos.as_ptr_or_null(),
                     colors.len().try_into().unwrap(),
                     mode.into_native(),
@@ -266,7 +266,7 @@ pub fn sweep<'a>(
                     center.x,
                     center.y,
                     colors.native().as_ptr(),
-                    color_space.shared_native(),
+                    color_space.into_ptr(),
                     pos.as_ptr_or_null(),
                     colors.len().try_into().unwrap(),
                     mode.into_native(),
@@ -285,7 +285,7 @@ pub fn sweep<'a>(
 /// a tuple of type (&[Color4f], &ColorSpace).
 pub enum GradientShaderColors<'a> {
     Colors(&'a [Color]),
-    ColorsInSpace(&'a [Color4f], &'a ColorSpace),
+    ColorsInSpace(&'a [Color4f], ColorSpace),
 }
 
 impl<'a> GradientShaderColors<'a> {
@@ -308,8 +308,8 @@ impl<'a> From<&'a [Color]> for GradientShaderColors<'a> {
     }
 }
 
-impl<'a> From<(&'a [Color4f], &'a ColorSpace)> for GradientShaderColors<'a> {
-    fn from(c: (&'a [Color4f], &'a ColorSpace)) -> Self {
+impl<'a> From<(&'a [Color4f], ColorSpace)> for GradientShaderColors<'a> {
+    fn from(c: (&'a [Color4f], ColorSpace)) -> Self {
         GradientShaderColors::<'a>::ColorsInSpace(c.0, c.1)
     }
 }

--- a/skia-safe/src/effects/image_source.rs
+++ b/skia-safe/src/effects/image_source.rs
@@ -3,12 +3,12 @@ use crate::{FilterQuality, Image, ImageFilter, Rect};
 use skia_bindings::{C_SkImageSource_Make, C_SkImageSource_Make2, SkImage, SkImageFilter};
 
 impl RCHandle<SkImageFilter> {
-    pub fn from_image(image: &Image) -> Option<Self> {
+    pub fn from_image(image: Image) -> Option<Self> {
         from_image(image)
     }
 
     pub fn from_image_rect(
-        image: &Image,
+        image: Image,
         src_rect: impl AsRef<Rect>,
         dst_rect: impl AsRef<Rect>,
         filter_quality: FilterQuality,
@@ -19,6 +19,10 @@ impl RCHandle<SkImageFilter> {
 
 impl RCHandle<SkImage> {
     pub fn as_filter(&self) -> Option<ImageFilter> {
+        self.clone().into_filter()
+    }
+
+    pub fn into_filter(self) -> Option<ImageFilter> {
         from_image(self)
     }
 
@@ -28,23 +32,33 @@ impl RCHandle<SkImage> {
         dst_rect: impl AsRef<Rect>,
         filter_quality: FilterQuality,
     ) -> Option<ImageFilter> {
+        self.clone()
+            .into_filter_rect(src_rect, dst_rect, filter_quality)
+    }
+
+    pub fn into_filter_rect(
+        self,
+        src_rect: impl AsRef<Rect>,
+        dst_rect: impl AsRef<Rect>,
+        filter_quality: FilterQuality,
+    ) -> Option<ImageFilter> {
         from_image_rect(self, src_rect, dst_rect, filter_quality)
     }
 }
 
-pub fn from_image(image: &Image) -> Option<ImageFilter> {
-    ImageFilter::from_ptr(unsafe { C_SkImageSource_Make(image.shared_native()) })
+pub fn from_image(image: Image) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe { C_SkImageSource_Make(image.into_ptr()) })
 }
 
 pub fn from_image_rect(
-    image: &Image,
+    image: Image,
     src_rect: impl AsRef<Rect>,
     dst_rect: impl AsRef<Rect>,
     filter_quality: FilterQuality,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
         C_SkImageSource_Make2(
-            image.shared_native(),
+            image.into_ptr(),
             src_rect.as_ref().native(),
             dst_rect.as_ref().native(),
             filter_quality.into_native(),

--- a/skia-safe/src/effects/lighting_image_filter.rs
+++ b/skia-safe/src/effects/lighting_image_filter.rs
@@ -9,7 +9,7 @@ use skia_bindings::{
 
 impl RCHandle<SkImageFilter> {
     pub fn distant_lit_diffuse_lighting<'a>(
-        &self,
+        self,
         crop_rect: impl Into<Option<&'a CropRect>>,
         direction: impl Into<Point3>,
         light_color: impl Into<Color>,
@@ -20,7 +20,7 @@ impl RCHandle<SkImageFilter> {
     }
 
     pub fn point_lit_diffuse_lighting<'a>(
-        &self,
+        self,
         crop_rect: impl Into<Option<&'a CropRect>>,
         location: impl Into<Point3>,
         light_color: impl Into<Color>,
@@ -32,7 +32,7 @@ impl RCHandle<SkImageFilter> {
 
     #[allow(clippy::too_many_arguments)]
     pub fn spot_lit_diffuse_lighting<'a>(
-        &self,
+        self,
         crop_rect: impl Into<Option<&'a CropRect>>,
         location: impl Into<Point3>,
         target: impl Into<Point3>,
@@ -56,7 +56,7 @@ impl RCHandle<SkImageFilter> {
     }
 
     pub fn distant_lit_specular_lighting<'a>(
-        &self,
+        self,
         crop_rect: impl Into<Option<&'a CropRect>>,
         direction: impl Into<Point3>,
         light_color: impl Into<Color>,
@@ -76,7 +76,7 @@ impl RCHandle<SkImageFilter> {
     }
 
     pub fn point_lit_specular_lighting<'a>(
-        &self,
+        self,
         crop_rect: impl Into<Option<&'a CropRect>>,
         location: impl Into<Point3>,
         light_color: impl Into<Color>,
@@ -97,7 +97,7 @@ impl RCHandle<SkImageFilter> {
 
     #[allow(clippy::too_many_arguments)]
     pub fn spot_lit_specular_lighting<'a>(
-        &self,
+        self,
         crop_rect: impl Into<Option<&'a CropRect>>,
         location: impl Into<Point3>,
         target: impl Into<Point3>,
@@ -128,7 +128,7 @@ pub fn distant_lit_diffuse<'a>(
     light_color: impl Into<Color>,
     surface_scale: scalar,
     kd: scalar,
-    input: &ImageFilter,
+    input: ImageFilter,
     crop_rect: impl Into<Option<&'a CropRect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
@@ -137,7 +137,7 @@ pub fn distant_lit_diffuse<'a>(
             light_color.into().into_native(),
             surface_scale,
             kd,
-            input.shared_native(),
+            input.into_ptr(),
             crop_rect.into().native_ptr_or_null(),
         )
     })
@@ -148,7 +148,7 @@ pub fn point_lit_diffuse<'a>(
     light_color: impl Into<Color>,
     surface_scale: scalar,
     kd: scalar,
-    input: &ImageFilter,
+    input: ImageFilter,
     crop_rect: impl Into<Option<&'a CropRect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
@@ -157,7 +157,7 @@ pub fn point_lit_diffuse<'a>(
             light_color.into().into_native(),
             surface_scale,
             kd,
-            input.shared_native(),
+            input.into_ptr(),
             crop_rect.into().native_ptr_or_null(),
         )
     })
@@ -172,7 +172,7 @@ pub fn spot_lit_diffuse<'a>(
     light_color: impl Into<Color>,
     surface_scale: scalar,
     kd: scalar,
-    input: &ImageFilter,
+    input: ImageFilter,
     crop_rect: impl Into<Option<&'a CropRect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
@@ -184,7 +184,7 @@ pub fn spot_lit_diffuse<'a>(
             light_color.into().into_native(),
             surface_scale,
             kd,
-            input.shared_native(),
+            input.into_ptr(),
             crop_rect.into().native_ptr_or_null(),
         )
     })
@@ -196,7 +196,7 @@ pub fn distant_lit_specular<'a>(
     surface_scale: scalar,
     ks: scalar,
     shininess: scalar,
-    input: &ImageFilter,
+    input: ImageFilter,
     crop_rect: impl Into<Option<&'a CropRect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
@@ -206,7 +206,7 @@ pub fn distant_lit_specular<'a>(
             surface_scale,
             ks,
             shininess,
-            input.shared_native(),
+            input.into_ptr(),
             crop_rect.into().native_ptr_or_null(),
         )
     })
@@ -218,7 +218,7 @@ pub fn point_lit_specular<'a>(
     surface_scale: scalar,
     ks: scalar,
     shininess: scalar,
-    input: &ImageFilter,
+    input: ImageFilter,
     crop_rect: impl Into<Option<&'a CropRect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
@@ -228,7 +228,7 @@ pub fn point_lit_specular<'a>(
             surface_scale,
             ks,
             shininess,
-            input.shared_native(),
+            input.into_ptr(),
             crop_rect.into().native_ptr_or_null(),
         )
     })
@@ -244,7 +244,7 @@ pub fn spot_lit_specular<'a>(
     surface_scale: scalar,
     ks: scalar,
     shininess: scalar,
-    input: &ImageFilter,
+    input: ImageFilter,
     crop_rect: impl Into<Option<&'a CropRect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
@@ -257,7 +257,7 @@ pub fn spot_lit_specular<'a>(
             surface_scale,
             ks,
             shininess,
-            input.shared_native(),
+            input.into_ptr(),
             crop_rect.into().native_ptr_or_null(),
         )
     })

--- a/skia-safe/src/effects/magnifier_image_filter.rs
+++ b/skia-safe/src/effects/magnifier_image_filter.rs
@@ -4,7 +4,7 @@ use skia_bindings::{C_SkMagnifierImageFilter_Make, SkImageFilter};
 
 impl RCHandle<SkImageFilter> {
     pub fn magnifier<'a>(
-        &self,
+        self,
         crop_rect: impl Into<Option<&'a CropRect>>,
         src_rect: impl AsRef<Rect>,
         inset: scalar,
@@ -16,14 +16,14 @@ impl RCHandle<SkImageFilter> {
 pub fn new<'a>(
     src_rect: impl AsRef<Rect>,
     inset: scalar,
-    input: &ImageFilter,
+    input: ImageFilter,
     crop_rect: impl Into<Option<&'a CropRect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
         C_SkMagnifierImageFilter_Make(
             src_rect.as_ref().native(),
             inset,
-            input.shared_native(),
+            input.into_ptr(),
             crop_rect.into().native_ptr_or_null(),
         )
     })

--- a/skia-safe/src/effects/matrix_convolution_image_filter.rs
+++ b/skia-safe/src/effects/matrix_convolution_image_filter.rs
@@ -7,7 +7,7 @@ use skia_bindings::{
 impl RCHandle<SkImageFilter> {
     #[allow(clippy::too_many_arguments)]
     pub fn matrix_convolution<'a>(
-        &self,
+        self,
         crop_rect: impl Into<Option<&'a CropRect>>,
         kernel_size: impl Into<ISize>,
         kernel: &[scalar],
@@ -54,7 +54,7 @@ pub fn new<'a>(
     kernel_offset: impl Into<IPoint>,
     tile_mode: TileMode,
     convolve_alpha: bool,
-    input: &ImageFilter,
+    input: ImageFilter,
     crop_rect: impl Into<Option<&'a CropRect>>,
 ) -> Option<ImageFilter> {
     let kernel_size = kernel_size.into();
@@ -71,7 +71,7 @@ pub fn new<'a>(
             kernel_offset.into().native(),
             tile_mode.into_native(),
             convolve_alpha,
-            input.shared_native(),
+            input.into_ptr(),
             crop_rect.into().native_ptr_or_null(),
         )
     })

--- a/skia-safe/src/effects/morphology_image_filter.rs
+++ b/skia-safe/src/effects/morphology_image_filter.rs
@@ -4,7 +4,7 @@ use skia_bindings::SkImageFilter;
 
 impl RCHandle<SkImageFilter> {
     pub fn dilate<'a>(
-        &self,
+        self,
         crop_rect: impl Into<Option<&'a CropRect>>,
         radii: (i32, i32),
     ) -> Option<Self> {
@@ -12,7 +12,7 @@ impl RCHandle<SkImageFilter> {
     }
 
     pub fn erode<'a>(
-        &self,
+        self,
         crop_rect: impl Into<Option<&'a CropRect>>,
         radii: (i32, i32),
     ) -> Option<Self> {
@@ -28,14 +28,14 @@ pub mod dilate_image_filter {
 
     pub fn new<'a>(
         (radius_x, radius_y): (i32, i32),
-        input: &ImageFilter,
+        input: ImageFilter,
         crop_rect: impl Into<Option<&'a CropRect>>,
     ) -> Option<ImageFilter> {
         ImageFilter::from_ptr(unsafe {
             C_SkDilateImageFilter_Make(
                 radius_x,
                 radius_y,
-                input.shared_native(),
+                input.into_ptr(),
                 crop_rect.into().native_ptr_or_null(),
             )
         })
@@ -44,20 +44,20 @@ pub mod dilate_image_filter {
 
 pub mod erode_image_filter {
     use crate::image_filter::CropRect;
-    use crate::prelude::NativePointerOrNull2;
+    use crate::prelude::{IntoPtr, NativePointerOrNull2};
     use crate::ImageFilter;
     use skia_bindings::C_SkErodeImageFilter_Make;
 
     pub fn new<'a>(
         (radius_x, radius_y): (i32, i32),
-        input: &ImageFilter,
+        input: ImageFilter,
         crop_rect: impl Into<Option<&'a CropRect>>,
     ) -> Option<ImageFilter> {
         ImageFilter::from_ptr(unsafe {
             C_SkErodeImageFilter_Make(
                 radius_x,
                 radius_y,
-                input.shared_native(),
+                input.into_ptr(),
                 crop_rect.into().native_ptr_or_null(),
             )
         })

--- a/skia-safe/src/effects/offset_image_filter.rs
+++ b/skia-safe/src/effects/offset_image_filter.rs
@@ -4,7 +4,7 @@ use skia_bindings::{C_SkOffsetImageFilter_Make, SkImageFilter};
 
 impl RCHandle<SkImageFilter> {
     pub fn offset<'a>(
-        &self,
+        self,
         crop_rect: impl Into<Option<&'a CropRect>>,
         delta: impl Into<Vector>,
     ) -> Option<Self> {
@@ -14,7 +14,7 @@ impl RCHandle<SkImageFilter> {
 
 pub fn new<'a>(
     delta: impl Into<Vector>,
-    input: &ImageFilter,
+    input: ImageFilter,
     crop_rect: impl Into<Option<&'a CropRect>>,
 ) -> Option<ImageFilter> {
     let delta = delta.into();
@@ -22,7 +22,7 @@ pub fn new<'a>(
         C_SkOffsetImageFilter_Make(
             delta.x,
             delta.y,
-            input.shared_native(),
+            input.into_ptr(),
             crop_rect.into().native_ptr_or_null(),
         )
     })

--- a/skia-safe/src/effects/picture_image_filter.rs
+++ b/skia-safe/src/effects/picture_image_filter.rs
@@ -4,7 +4,7 @@ use skia_bindings::{C_SkPictureImageFilter_Make, SkImageFilter, SkPicture};
 
 impl RCHandle<SkImageFilter> {
     pub fn from_picture<'a>(
-        picture: &Picture,
+        picture: Picture,
         crop_rect: impl Into<Option<&'a Rect>>,
     ) -> Option<Self> {
         from_picture(picture, crop_rect)
@@ -16,18 +16,22 @@ impl RCHandle<SkPicture> {
         &self,
         crop_rect: impl Into<Option<&'a Rect>>,
     ) -> Option<ImageFilter> {
+        self.clone().into_image_filter(crop_rect)
+    }
+
+    pub fn into_image_filter<'a>(
+        self,
+        crop_rect: impl Into<Option<&'a Rect>>,
+    ) -> Option<ImageFilter> {
         from_picture(self, crop_rect)
     }
 }
 
 pub fn from_picture<'a>(
-    picture: &Picture,
+    picture: Picture,
     crop_rect: impl Into<Option<&'a Rect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
-        C_SkPictureImageFilter_Make(
-            picture.shared_native(),
-            crop_rect.into().native_ptr_or_null(),
-        )
+        C_SkPictureImageFilter_Make(picture.into_ptr(), crop_rect.into().native_ptr_or_null())
     })
 }

--- a/skia-safe/src/effects/tile_image_filter.rs
+++ b/skia-safe/src/effects/tile_image_filter.rs
@@ -3,7 +3,7 @@ use crate::{ImageFilter, Rect};
 use skia_bindings::{C_SkTileImageFilter_Make, SkImageFilter};
 
 impl RCHandle<SkImageFilter> {
-    pub fn tile(&self, src: impl AsRef<Rect>, dst: impl AsRef<Rect>) -> Option<Self> {
+    pub fn tile(self, src: impl AsRef<Rect>, dst: impl AsRef<Rect>) -> Option<Self> {
         new(src, dst, self)
     }
 }
@@ -11,13 +11,13 @@ impl RCHandle<SkImageFilter> {
 pub fn new(
     src: impl AsRef<Rect>,
     dst: impl AsRef<Rect>,
-    input: &ImageFilter,
+    input: ImageFilter,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
         C_SkTileImageFilter_Make(
             src.as_ref().native(),
             dst.as_ref().native(),
-            input.shared_native(),
+            input.into_ptr(),
         )
     })
 }

--- a/skia-safe/src/effects/xfer_mode_image_filter.rs
+++ b/skia-safe/src/effects/xfer_mode_image_filter.rs
@@ -5,8 +5,8 @@ use skia_bindings::{C_SkXfermodeImageFilter_Make, SkImageFilter};
 impl RCHandle<SkImageFilter> {
     pub fn xfer_mode<'a>(
         blend_mode: BlendMode,
-        background: &ImageFilter,
-        foreground: impl Into<Option<&'a ImageFilter>>,
+        background: ImageFilter,
+        foreground: impl Into<Option<ImageFilter>>,
         crop_rect: impl Into<Option<&'a CropRect>>,
     ) -> Option<Self> {
         new(blend_mode, background, foreground, crop_rect)
@@ -15,15 +15,15 @@ impl RCHandle<SkImageFilter> {
 
 pub fn new<'a>(
     blend_mode: BlendMode,
-    background: &ImageFilter,
-    foreground: impl Into<Option<&'a ImageFilter>>,
+    background: ImageFilter,
+    foreground: impl Into<Option<ImageFilter>>,
     crop_rect: impl Into<Option<&'a CropRect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
         C_SkXfermodeImageFilter_Make(
             blend_mode.into_native(),
-            background.shared_native(),
-            foreground.into().shared_ptr(),
+            background.into_ptr(),
+            foreground.into().into_ptr_or_null(),
             crop_rect.into().native_ptr_or_null(),
         )
     })

--- a/skia-safe/src/gpu/backend_surface.rs
+++ b/skia-safe/src/gpu/backend_surface.rs
@@ -46,7 +46,7 @@ impl Handle<GrBackendFormat> {
             #[allow(clippy::map_clone)]
             self.native()
                 .getGLFormat()
-                .to_option()
+                .into_option()
                 .map(|format| *format)
         }
     }
@@ -56,7 +56,7 @@ impl Handle<GrBackendFormat> {
             #[allow(clippy::map_clone)]
             self.native()
                 .getGLTarget()
-                .to_option()
+                .into_option()
                 .map(|target| *target)
         }
     }
@@ -67,7 +67,7 @@ impl Handle<GrBackendFormat> {
             #[allow(clippy::map_clone)]
             self.native()
                 .getVkFormat()
-                .to_option()
+                .into_option()
                 .map(|format| *format)
         }
     }

--- a/skia-safe/src/gpu/context.rs
+++ b/skia-safe/src/gpu/context.rs
@@ -32,8 +32,8 @@ pub struct ResourceCacheUsage {
 
 impl RCHandle<GrContext> {
     // TODO: support variant with GrContextOptions
-    pub fn new_gl(interface: Option<&gl::Interface>) -> Option<Context> {
-        Context::from_ptr(unsafe { C_GrContext_MakeGL(interface.shared_ptr()) })
+    pub fn new_gl(interface: impl Into<Option<gl::Interface>>) -> Option<Context> {
+        Context::from_ptr(unsafe { C_GrContext_MakeGL(interface.into().into_ptr_or_null()) })
     }
 
     // TODO: support variant with GrContextOptions

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -109,7 +109,7 @@ impl RefHandle<SkShaper> {
     pub fn new_font_mgr_run_iterator(
         utf8: &str,
         font: &Font,
-        mut fallback: Option<&mut FontMgr>,
+        fallback: impl Into<Option<FontMgr>>,
     ) -> FontRunIterator {
         let bytes = utf8.as_bytes();
         FontRunIterator::from_ptr(unsafe {
@@ -117,7 +117,7 @@ impl RefHandle<SkShaper> {
                 bytes.as_ptr() as _,
                 bytes.len(),
                 font.native(),
-                fallback.shared_ptr_mut(),
+                fallback.into().into_ptr_or_null(),
             )
         })
         .unwrap()

--- a/skia-safe/src/prelude.rs
+++ b/skia-safe/src/prelude.rs
@@ -406,7 +406,7 @@ where
     }
 }
 
-/// A wrapper type that represents a native type through a pointer to
+/// A wrapper type that represents a native type with a pointer to
 /// the native object.
 #[repr(transparent)]
 pub struct RefHandle<N: NativeDrop>(*mut N);

--- a/skia-safe/src/utils/camera.rs
+++ b/skia-safe/src/utils/camera.rs
@@ -262,32 +262,26 @@ impl Camera3D {
 // Also note that the implementation uses interior pointers,
 // so we let Skia do the allocation.
 
-#[repr(transparent)]
-pub struct View3D(*mut Sk3DView);
+pub type View3D = RefHandle<Sk3DView>;
 unsafe impl Send for View3D {}
-
-impl NativeAccess<Sk3DView> for View3D {
-    fn native(&self) -> &Sk3DView {
-        unsafe { &*self.0 }
-    }
-    fn native_mut(&mut self) -> &mut Sk3DView {
-        unsafe { &mut *self.0 }
-    }
-}
 
 impl Default for View3D {
     fn default() -> Self {
-        View3D(unsafe { C_Sk3DView_new() })
+        Self::new()
     }
 }
 
-impl Drop for View3D {
+impl NativeDrop for Sk3DView {
     fn drop(&mut self) {
-        unsafe { C_Sk3DView_delete(self.native_mut()) }
+        unsafe { C_Sk3DView_delete(self) }
     }
 }
 
-impl View3D {
+impl RefHandle<Sk3DView> {
+    pub fn new() -> Self {
+        View3D::from_ptr(unsafe { C_Sk3DView_new() }).unwrap()
+    }
+
     pub fn save(&mut self) -> &mut Self {
         unsafe { self.native_mut().save() }
         self


### PR DESCRIPTION
The Skia API already suggested this by declaring a lot of functions such that they expect mutable pointers to reference counted types.

These functions were meant to consume the objects passed in without changing reference counters, and when looking at the examples, this change avoids a large number of borrows and makes the combination of filters feel more natural, for example.

For other types that are reused more frequently, like `Typeface` for example, I extended the function signatures so that they accept a reference or a value.



