### PR TITLE
Speed up CI by building only two feature configurations only

### DIFF
--- a/azure-pipelines-build-target.yml
+++ b/azure-pipelines-build-target.yml
@@ -3,9 +3,8 @@ parameters:
   runBinaries: false
   runClippy: false
   # produce and release binaries to GitHub
-  releaseBinaries: false
+  releaseBinaries: 'False'
   exampleArgs: ''
-  toolchain: stable
 
 steps:
   - bash: |
@@ -52,7 +51,7 @@ steps:
           pathtoPublish: '$(Build.ArtifactStagingDirectory)/skia-org'
           artifactName: 'skia-org-examples-$(platform)-$(toolchain)'
 
-  - ${{ if eq(parameters.releaseBinaries, True) }}:
+  - ${{ if eq(parameters.releaseBinaries, 'True') }}:
     - task: ArchiveFiles@2
       displayName: 'Archive binaries (${{ parameters.target }})'
       inputs:

--- a/azure-pipelines-build-target.yml
+++ b/azure-pipelines-build-target.yml
@@ -2,8 +2,10 @@ parameters:
   # defaults:
   runBinaries: false
   runClippy: false
+  # produce and release binaries to GitHub
   releaseBinaries: false
   exampleArgs: ''
+  toolchain: stable
 
 steps:
   - bash: |
@@ -52,7 +54,6 @@ steps:
 
   - ${{ if eq(parameters.releaseBinaries, True) }}:
     - task: ArchiveFiles@2
-      condition: and(succeeded(), eq(variables['toolchain'], 'stable'), eq(variables['Build.SourceBranchName'], variables['release_branch']))
       displayName: 'Archive binaries (${{ parameters.target }})'
       inputs:
         rootFolderOrFile: '$(Build.ArtifactStagingDirectory)/skia-binaries'
@@ -61,7 +62,6 @@ steps:
         archiveFile: '$(Build.ArtifactStagingDirectory)/skia-binaries-$(SKIA_BINARIES_KEY).tar.gz'
 
     - task: GithubRelease@0
-      condition: and(succeeded(), eq(variables['toolchain'], 'stable'), eq(variables['Build.SourceBranchName'], variables['release_branch']))
       displayName: 'Release to GitHub rust-skia/skia-binaries (${{ parameters.target }})'
       inputs:
         action: 'edit'

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -8,25 +8,24 @@ jobs:
   strategy:
     matrix:
       stable:
-        toolchain: stable
         features: ''
         exampleArgs: '--driver cpu --driver pdf'
-      beta:
-        toolchain: beta
-        features: ''
-        exampleArgs: ''
-      stable-vulkan:
-        toolchain: stable
-        features: 'vulkan'
-        exampleArgs: ''
-      stable-svg:
-        toolchain: stable
-        features: 'svg'
-        exampleArgs: '--driver svg'
-      stable-shaper:
-        toolchain: stable
-        features: 'shaper'
-        exampleArgs: ''
+
+      ${{ if parameters.deployRelease }}:
+        stable-vulkan:
+          features: 'vulkan'
+        stable-svg:
+          features: 'svg'
+        stable-shaper:
+          features: 'shaper'
+
+      ${{ if not(parameters.deployRelease) }}:
+        stable-all-features:
+          features: 'vulkan,svg,shaper'
+          exampleArgs: '--driver cpu --driver pdf --driver svg'
+        beta-all-features:
+          toolchain: beta
+          features: 'vulkan,svg,shaper'
 
   variables:
     platform: ${{ parameters.platform }}
@@ -112,7 +111,7 @@ jobs:
       ${{ if ne(parameters.platform, 'Windows') }}:
         runClippy: true
       runBinaries: true
-      releaseBinaries: true
+      releaseBinaries: ${{ parameters.deployRelease }}
 
   - ${{ if eq(parameters.platform, 'macOS') }}:
     - template: 'azure-pipelines-build-target.yml'
@@ -126,12 +125,12 @@ jobs:
     - template: 'azure-pipelines-build-target.yml'
       parameters:
         target: 'aarch64-apple-ios'
-        releaseBinaries: true
+        releaseBinaries: ${{ parameters.deployRelease }}
 
     - template: 'azure-pipelines-build-target.yml'
       parameters:
         target: 'x86_64-apple-ios'
-        releaseBinaries: true
+        releaseBinaries: ${{ parameters.deployRelease }}
 
   - ${{ if eq(parameters.platform, 'Linux') }}:
     - template: 'azure-pipelines-build-target.yml'

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -8,24 +8,33 @@ jobs:
   strategy:
     matrix:
       stable:
+        toolchain: stable
         features: ''
         exampleArgs: '--driver cpu --driver pdf'
 
-      ${{ if parameters.deployRelease }}:
+      ${{ if eq(parameters.deployRelease, 'True') }}:
         stable-vulkan:
+          toolchain: stable
           features: 'vulkan'
+          exampleArgs: ''
         stable-svg:
+          toolchain: stable
           features: 'svg'
+          exampleArgs: ''
         stable-shaper:
+          toolchain: stable
           features: 'shaper'
+          exampleArgs: ''
 
-      ${{ if not(parameters.deployRelease) }}:
+      ${{ if eq(parameters.deployRelease, 'False') }}:
         stable-all-features:
+          toolchain: stable
           features: 'vulkan,svg,shaper'
           exampleArgs: '--driver cpu --driver pdf --driver svg'
         beta-all-features:
           toolchain: beta
           features: 'vulkan,svg,shaper'
+          exampleArgs: ''
 
   variables:
     platform: ${{ parameters.platform }}
@@ -33,7 +42,6 @@ jobs:
     image: ${{ parameters.image }}
     androidNDK: ${{ parameters.androidNDK }}
     rust_backtrace: 1
-    release_branch: 'release'
 
   pool:
     vmImage: $(image)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,15 @@
+# This script can run in two configurations:
+#
+# deployRelease = true
+#   A reasonable number of feature combinations are built and binaries are deployed.
+#
+# deployRelease = false
+#   Only two feature sets are built: One with no features and one with all features.
+#   And no binaries or packages are released.
+
+variables:
+  deployRelease: $[ eq(variables['build.SourceBranchName'], 'release') ]
+
 stages:
 
 - stage: 'Build'
@@ -8,6 +20,7 @@ stages:
       platformTarget: 'x86_64-unknown-linux-gnu'
       androidNDK: 'r18b-linux-x86_64'
       image: 'ubuntu-16.04'
+      deployRelease: $(deployRelease)
 
   - template: 'azure-pipelines-template.yml'
     parameters:
@@ -15,15 +28,17 @@ stages:
       platformTarget: 'x86_64-apple-darwin'
       androidNDK: 'r18b-darwin-x86_64'
       image: 'macOS-10.14'
+      deployRelease: $(deployRelease)
 
   - template: 'azure-pipelines-template.yml'
     parameters:
       platform: 'Windows'
       platformTarget: 'x86_64-pc-windows-msvc'
       image: 'windows-2019'
+      deployRelease: $(deployRelease)
 
 - stage: 'Package'
-  condition: and(succeeded(), eq(variables['build.SourceBranchName'], 'release'))
+  condition: and(succeeded(), variables.deployRelease)
   jobs:
   - job:
     pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@
 #   And no binaries or packages are released.
 
 variables:
-  deployRelease: $[ eq(variables['build.SourceBranchName'], 'release') ]
+  deployRelease: ${{ eq(variables['build.SourceBranchName'], 'release') }}
 
 stages:
 
@@ -20,7 +20,7 @@ stages:
       platformTarget: 'x86_64-unknown-linux-gnu'
       androidNDK: 'r18b-linux-x86_64'
       image: 'ubuntu-16.04'
-      deployRelease: $(deployRelease)
+      deployRelease: ${{ eq(variables['build.SourceBranchName'], 'release') }}
 
   - template: 'azure-pipelines-template.yml'
     parameters:
@@ -28,17 +28,17 @@ stages:
       platformTarget: 'x86_64-apple-darwin'
       androidNDK: 'r18b-darwin-x86_64'
       image: 'macOS-10.14'
-      deployRelease: $(deployRelease)
+      deployRelease: ${{ eq(variables['build.SourceBranchName'], 'release') }}
 
   - template: 'azure-pipelines-template.yml'
     parameters:
       platform: 'Windows'
       platformTarget: 'x86_64-pc-windows-msvc'
       image: 'windows-2019'
-      deployRelease: $(deployRelease)
+      deployRelease: ${{ eq(variables['build.SourceBranchName'], 'release') }}
 
 - stage: 'Package'
-  condition: and(succeeded(), variables.deployRelease)
+  condition: and(succeeded(), eq(variables.deployRelease, 'True'))
   jobs:
   - job:
     pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,15 +47,13 @@ stages:
       rust_backtrace: 1
 
     steps:
-    - script: |
-        curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
-        echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
-      displayName: 'Install Rust'
-
-    - script: |
+    - bash: |
+        set -e
+        rustup default stable
+        rustup update stable
         rustc -Vv
         cargo -V
-      displayName: 'Print versions'
+      displayName: 'Update Rust and Print Versions'
 
     # skia-bindings gets packaged without verification, because the build process modifies the src directory.
     # TODO: reenable package verification as soon CLion and rust-analyzer supports !include macros.


### PR DESCRIPTION
This PR updates the azure pipelines script to clearly separate two build configurations: 

One that is used for testing only, in which all platforms are built in three different combinations: 
- stable toolchain and no features
- stable toolchain and all features
- and beta toolchain and all features.

These three combinations should be sufficient to test incoming PRs.

The other build configuration is the one that releases binaries and the final crates. It can be allowed to run much longer and therefore build more feature combinations. For now, we keep the current combinations, but may add _reasonable_ ones on request.
