### PR TITLE
Use lazy-static 1.4 as the minimum supported version for building skia-safe

### DIFF
--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -24,8 +24,7 @@ shaper = ["skia-bindings/shaper"]
 [dependencies]
 bitflags = "1.0.4"
 skia-bindings = { version = "=0.15.0", path = "../skia-bindings" }
-# TODO: 1.3 breaks offscreen_gl_context
-lazy_static = "=1.2"
+lazy_static = "1.4"
 
 [dev-dependencies]
 # for skia-org


### PR DESCRIPTION
Following up on dependabot's suggestion to upgrade lazy-static in #193, and also because I am not able to reproduce the original problem anymore, I think it's best now to set 1.4 as the minimum version.
