### PR TITLE
Chrome Milestone 78

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,4 +5,6 @@ project (skia-bindings)
 
 include_directories(skia-bindings/skia)
 
+add_compile_definitions(SK_SHAPER_HARFBUZZ_AVAILABLE)
+
 add_library(skiabindings skia-bindings/src/bindings.cpp skia-bindings/src/shaper.cpp)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![Build Status](https://dev.azure.com/pragmatrix-github/rust-skia/_apis/build/status/rust-skia.rust-skia?branchName=master)](https://dev.azure.com/pragmatrix-github/rust-skia/_build/latest?branchName=master)
 
-Skia Submodule Status: chrome/m77 ([pending changes][skiapending]).
+Skia Submodule Status: chrome/m78 ([pending changes][skiapending]).
 
-[skiapending]: https://github.com/google/skia/compare/2417cee95d...chrome/m77
+[skiapending]: https://github.com/google/skia/compare/6d1c0d4196...chrome/m78
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Skia Submodule Status: chrome/m78 ([pending changes][skiapending]).
 
-[skiapending]: https://github.com/google/skia/compare/6d1c0d4196...chrome/m78
+[skiapending]: https://github.com/google/skia/compare/a40a8a5875...chrome/m78
 
 ## Goals
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -19,7 +19,7 @@ include = [ "Cargo.toml", "build.rs", "build_support.rs", "build_support/**/*.rs
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "2417cee95d"
+skia = "6d1c0d4196"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -19,7 +19,7 @@ include = [ "Cargo.toml", "build.rs", "build_support.rs", "build_support/**/*.rs
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "6d1c0d4196"
+skia = "a40a8a5875"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.18.0"
+version = "0.19.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -308,6 +308,12 @@ impl FinalBuildConfiguration {
                 args.push(("skia_use_expat", no()));
             }
 
+            if build.all_skia_libs {
+                // m78: modules/particles forgets to set SKIA_IMPLEMENTATION=1 and so
+                // expects system vulkan headers.
+                flags.push("-DSKIA_IMPLEMENTATION=1");
+            }
+
             if !flags.is_empty() {
                 let flags: String = {
                     let v: Vec<String> = flags.into_iter().map(quote).collect();

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -332,6 +332,14 @@ extern "C" SkImage* C_SkImage_MakeFromEncoded(SkData* encoded, const SkIRect* su
     return SkImage::MakeFromEncoded(sp(encoded), subset).release();
 }
 
+extern "C" SkImage* C_SkImage_DecodeToRaster(const void* encoded, size_t length, const SkIRect* subset) {
+    return SkImage::DecodeToRaster(encoded, length, subset).release();
+}
+
+extern "C" SkImage* C_SkImage_DecodeToTexture(GrContext* ctx, const void* encoded, size_t length, const SkIRect* subset) {
+    return SkImage::DecodeToTexture(ctx, encoded, length, subset).release();
+}
+
 extern "C" SkImage* C_SkImage_MakeFromCompressed(GrContext* context, SkData* encoded, int width, int height, SkImage::CompressionType type) {
     return SkImage::MakeFromCompressed(context, sp(encoded), width, height, type).release();
 }
@@ -345,7 +353,15 @@ extern "C" SkImage* C_SkImage_MakeFromTexture(
         SkColorSpace* colorSpace) {
     return SkImage::MakeFromTexture(context, *backendTexture, origin, colorType, alphaType, sp(colorSpace)).release();
 }
- 
+
+extern "C" SkImage* C_SkImage_MakeCrossContextFromPixmap(
+        GrContext* context,
+        const SkPixmap* pixmap,
+        bool buildMips,
+        bool limitToMaxTextureSize) {
+    return SkImage::MakeCrossContextFromPixmap(context, *pixmap, buildMips, limitToMaxTextureSize).release();
+}
+
 extern "C" SkImage* C_SkImage_MakeFromAdoptedTexture(
         GrContext* context,
         const GrBackendTexture* backendTexture,
@@ -483,6 +499,10 @@ extern "C" SkImage *C_SkImage_makeWithFilter(const SkImage *self, GrContext *con
 
 extern "C" SkImage* C_SkImage_makeColorSpace(const SkImage* self, SkColorSpace* target) {
     return self->makeColorSpace(sp(target)).release();
+}
+
+extern "C" SkImage* C_SkImage_reinterpretColorSpace(const SkImage* self, SkColorSpace* newColorSpace) {
+    return self->reinterpretColorSpace(sp(newColorSpace)).release();
 }
 
 //
@@ -1593,6 +1613,10 @@ extern "C" SkColorFilter* C_SkColorFilters_Matrix(const SkColorMatrix* colorMatr
 
 extern "C" SkColorFilter* C_SkColorFilters_MatrixRowMajor(const SkScalar array[20]) {
     return SkColorFilters::Matrix(array).release();
+}
+
+extern "C" SkColorFilter* C_SkColorFilters_HSLAMatrix(const float rowMajor[20]) {
+    return SkColorFilters::HSLAMatrix(rowMajor).release();
 }
 
 extern "C" SkColorFilter* C_SkColorFilters_LinearToSRGBGamma() {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -654,10 +654,6 @@ extern "C" void C_SkPath_Iter_destruct(SkPath::Iter* self) {
     self->~Iter();
 }
 
-extern "C" SkPath::Verb C_SkPath_Iter_next(SkPath::Iter* self, SkPoint pts[4], bool doConsumeDegenerates, bool exact) {
-    return self->next(pts, doConsumeDegenerates, exact);
-}
-
 extern "C" bool C_SkPath_Iter_isCloseLine(const SkPath::Iter* self) {
     return self->isCloseLine();
 }

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -2781,6 +2781,10 @@ extern "C" void C_GrContext_flush(GrContext* self) {
     self->flush();
 }
 
+extern "C" GrBackendFormat C_GrContext_defaultBackendFormat(const GrContext* self, SkColorType ct, GrRenderable renderable) {
+    return self->defaultBackendFormat(ct, renderable);
+}
+
 //
 // gpu/GrBackendDrawableInfo.h
 //
@@ -2904,19 +2908,6 @@ extern "C" void C_GrVkAlloc_Construct(GrVkAlloc* uninitialized, VkDeviceMemory m
 
 extern "C" bool C_GrVkAlloc_Equals(const GrVkAlloc* lhs, const GrVkAlloc* rhs) {
     return *lhs == *rhs;
-}
-
-extern "C" void C_GrVkYcbcrConversionInfo_Construct(
-        GrVkYcbcrConversionInfo* uninitialized,
-        VkSamplerYcbcrModelConversion ycbcrModel,
-        VkSamplerYcbcrRange ycbcrRange,
-        VkChromaLocation xChromaOffset,
-        VkChromaLocation yChromaOffset,
-        VkFilter chromaFilter,
-        VkBool32 forceExplicitReconstruction,
-        uint64_t externalFormat,
-        VkFormatFeatureFlags externalFormatFeatures) {
-    new (uninitialized) GrVkYcbcrConversionInfo(ycbcrModel, ycbcrRange, xChromaOffset, yChromaOffset, chromaFilter, forceExplicitReconstruction, externalFormat, externalFormatFeatures);
 }
 
 extern "C" bool C_GrVkYcbcrConversionInfo_Equals(const GrVkYcbcrConversionInfo* lhs, const GrVkYcbcrConversionInfo* rhs) {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -2781,8 +2781,8 @@ extern "C" void C_GrContext_flush(GrContext* self) {
     self->flush();
 }
 
-extern "C" GrBackendFormat C_GrContext_defaultBackendFormat(const GrContext* self, SkColorType ct, GrRenderable renderable) {
-    return self->defaultBackendFormat(ct, renderable);
+extern "C" void C_GrContext_defaultBackendFormat(const GrContext* self, SkColorType ct, GrRenderable renderable, GrBackendFormat* result) {
+    *result = self->defaultBackendFormat(ct, renderable);
 }
 
 //

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -68,6 +68,7 @@
 #include "include/effects/SkDropShadowImageFilter.h"
 #include "include/effects/SkGradientShader.h"
 #include "include/effects/SkHighContrastFilter.h"
+#include "include/effects/SkImageFilters.h"
 #include "include/effects/SkImageSource.h"
 #include "include/effects/SkLayerDrawLooper.h"
 #include "include/effects/SkLightingImageFilter.h"
@@ -2014,7 +2015,7 @@ extern "C" SkStreamAsset* C_SkDynamicMemoryWStream_detachAsStream(SkDynamicMemor
 }
 
 //
-// SkGradientShader
+// effects/SkGradientShader.h
 //
 
 extern "C" SkShader* C_SkGradientShader_MakeLinear(const SkPoint pts[2], const SkColor colors[], const SkScalar pos[], int count, SkTileMode mode, uint32_t flags, const SkMatrix* localMatrix) {
@@ -2050,7 +2051,7 @@ extern "C" SkShader* C_SkGradientShader_MakeSweep2(SkScalar cx, SkScalar cy, con
 }
 
 //
-// SkPerlinNoiseShader
+// effects/SkPerlinNoiseShader.h
 //
 
 extern "C" SkShader* C_SkPerlinNoiseShader_MakeFractalNoise(SkScalar baseFrequencyX, SkScalar baseFrequencyY, int numOctaves, SkScalar seed, const SkISize* tileSize) {
@@ -2066,7 +2067,7 @@ extern "C" SkShader* C_SkPerlinNoiseShader_MakeImprovedNoise(SkScalar baseFreque
 }
 
 //
-// effects/SkPath1DPathEffect
+// effects/SkPath1DPathEffect.h
 //
 
 extern "C" SkPathEffect* C_SkPath1DPathEffect_Make(const SkPath* path, SkScalar advance, SkScalar phase, SkPath1DPathEffect::Style style) {
@@ -2074,7 +2075,7 @@ extern "C" SkPathEffect* C_SkPath1DPathEffect_Make(const SkPath* path, SkScalar 
 }
 
 //
-// effects/SkLine2DPathEffect
+// effects/SkLine2DPathEffect.h
 //
 
 extern "C" SkPathEffect* C_SkLine2DPathEffect_Make(SkScalar width, const SkMatrix* matrix) {
@@ -2082,7 +2083,7 @@ extern "C" SkPathEffect* C_SkLine2DPathEffect_Make(SkScalar width, const SkMatri
 }
 
 //
-// effects/SkPath2DPathEffect
+// effects/SkPath2DPathEffect.h
 //
 
 extern "C" SkPathEffect* C_SkPath2DPathEffect_Make(const SkMatrix* matrix, const SkPath* path) {
@@ -2090,7 +2091,7 @@ extern "C" SkPathEffect* C_SkPath2DPathEffect_Make(const SkMatrix* matrix, const
 }
 
 //
-// effects/SkAlphaThresholdFilter
+// effects/SkAlphaThresholdFilter.h
 //
 
 extern "C" SkImageFilter *
@@ -2100,7 +2101,7 @@ C_SkAlphaThresholdFilter_Make(const SkRegion &region, SkScalar innerMin, SkScala
 }
 
 //
-// effects/SkArithmeticImageFilter
+// effects/SkArithmeticImageFilter.h
 //
 
 extern "C" SkImageFilter *C_SkArithmeticImageFilter_Make(float k1, float k2, float k3, float k4, bool enforcePMColor,
@@ -2112,7 +2113,7 @@ extern "C" SkImageFilter *C_SkArithmeticImageFilter_Make(float k1, float k2, flo
 }
 
 //
-// effects/SkBlurDrawLooper
+// effects/SkBlurDrawLooper.h
 //
 
 extern "C" SkDrawLooper* C_SkBlurDrawLooper_Make(SkColor color, SkScalar sigma, SkScalar dx, SkScalar dy) {
@@ -2125,7 +2126,7 @@ extern "C" SkDrawLooper* C_SkBlurDrawLooper_Make2(SkColor4f color, const SkColor
 }
 
 //
-// effects/SkBlurImageFilter
+// effects/SkBlurImageFilter.h
 //
 
 extern "C" SkImageFilter *C_SkBlurImageFilter_Make(SkScalar sigmaX, SkScalar sigmaY, SkImageFilter *input,
@@ -2135,7 +2136,7 @@ extern "C" SkImageFilter *C_SkBlurImageFilter_Make(SkScalar sigmaX, SkScalar sig
 }
 
 //
-// effects/SkColorFilterImageFilter
+// effects/SkColorFilterImageFilter.h
 //
 
 extern "C" SkImageFilter *C_SkColorFilterImageFilter_Make(SkColorFilter *cf, SkImageFilter *input,
@@ -2168,7 +2169,7 @@ extern "C" SkColorFilter *C_SkColorMatrixFilter_MakeLightingFilter(SkColor mul, 
 }
 
 //
-// effects/SkComposeImageFilter
+// effects/SkComposeImageFilter.h
 //
 
 extern "C" SkImageFilter *C_SkComposeImageFilter_Make(SkImageFilter *outer, SkImageFilter *inner) {
@@ -2176,7 +2177,7 @@ extern "C" SkImageFilter *C_SkComposeImageFilter_Make(SkImageFilter *outer, SkIm
 }
 
 //
-// effects/SkCornerPathEffect
+// effects/SkCornerPathEffect.h
 //
 
 extern "C" SkPathEffect* C_SkCornerPathEffect_Make(SkScalar radius) {
@@ -2184,7 +2185,7 @@ extern "C" SkPathEffect* C_SkCornerPathEffect_Make(SkScalar radius) {
 }
 
 //
-// effects/SkDashPathEffect
+// effects/SkDashPathEffect.h
 //
 
 extern "C" SkPathEffect* C_SkDashPathEffect_Make(const SkScalar intervals[], int count, SkScalar phase) {
@@ -2192,7 +2193,7 @@ extern "C" SkPathEffect* C_SkDashPathEffect_Make(const SkScalar intervals[], int
 }
 
 //
-// effects/SkDiscretePathEffect
+// effects/SkDiscretePathEffect.h
 //
 
 extern "C" SkPathEffect* C_SkDiscretePathEffect_Make(SkScalar segLength, SkScalar dev, uint32_t seedAssist) {
@@ -2200,7 +2201,7 @@ extern "C" SkPathEffect* C_SkDiscretePathEffect_Make(SkScalar segLength, SkScala
 }
 
 //
-// effects/SkDisplacementMapEffect
+// effects/SkDisplacementMapEffect.h
 //
 
 extern "C" SkImageFilter *C_SkDisplacementMapEffect_Make(SkDisplacementMapEffect::ChannelSelectorType xChannelSelector,
@@ -2214,7 +2215,7 @@ extern "C" SkImageFilter *C_SkDisplacementMapEffect_Make(SkDisplacementMapEffect
 }
 
 //
-// effects/SkDropShadowImageFilter
+// effects/SkDropShadowImageFilter.h
 //
 
 extern "C" SkImageFilter *C_SkDropShadowImageFilter_Make(SkScalar dx, SkScalar dy, SkScalar sigmaX, SkScalar sigmaY,
@@ -2234,7 +2235,7 @@ extern "C" SkColorFilter* C_SkHighContrastFilter_Make(const SkHighContrastConfig
 }
 
 //
-// effects/SkImageSource
+// effects/SkImageSource.h
 //
 
 extern "C" SkImageFilter *C_SkImageSource_Make(SkImage *image) {
@@ -2248,7 +2249,7 @@ C_SkImageSource_Make2(SkImage* image, const SkRect &srcRect, const SkRect &dstRe
 }
 
 //
-// effects/SkLayerDrawLooper
+// effects/SkLayerDrawLooper.h
 //
 
 extern "C" void C_SkLayerDrawLooper_Builder_destruct(SkLayerDrawLooper::Builder* self) {
@@ -2260,7 +2261,7 @@ extern "C" SkDrawLooper* C_SkLayerDrawLooper_Builder_detach(SkLayerDrawLooper::B
 }
 
 //
-// effects/SkLightingImageFilter
+// effects/SkLightingImageFilter.h
 //
 
 extern "C" SkImageFilter *
@@ -2326,7 +2327,7 @@ extern "C" SkColorFilter* C_SkLumaColorFilter_Make() {
 }
 
 //
-// effects/SkMagnifierImageFilter
+// effects/SkMagnifierImageFilter.h
 //
 
 extern "C" SkImageFilter *
@@ -2336,7 +2337,7 @@ C_SkMagnifierImageFilter_Make(const SkRect &srcRect, SkScalar inset, SkImageFilt
 }
 
 //
-// effects/SkMatrixConvolutionImageFilter
+// effects/SkMatrixConvolutionImageFilter.h
 //
 
 extern "C" SkImageFilter *
@@ -2354,7 +2355,7 @@ C_SkMatrixConvolutionImageFilter_Make(const SkISize &kernelSize,
 }
 
 //
-// effects/SkMergeImageFilter
+// effects/SkMergeImageFilter.h
 //
 
 extern "C" SkImageFilter *
@@ -2369,7 +2370,7 @@ C_SkMergeImageFilter_Make(SkImageFilter *const filters[], int count, const SkIma
 }
 
 //
-// effects/SkMorphologyImageFiter
+// effects/SkMorphologyImageFiter.h
 //
 
 extern "C" SkImageFilter *C_SkDilateImageFilter_Make(int radiusX, int radiusY, SkImageFilter *input,
@@ -2383,7 +2384,7 @@ extern "C" SkImageFilter *C_SkErodeImageFilter_Make(int radiusX, int radiusY, Sk
 }
 
 //
-// effects/SkOffsetImageFilter
+// effects/SkOffsetImageFilter.h
 //
 
 extern "C" SkImageFilter *C_SkOffsetImageFilter_Make(SkScalar dx, SkScalar dy, SkImageFilter *input,
@@ -2424,7 +2425,7 @@ extern "C" SkColorFilter* C_SkOverdrawColorFilter_Make(const SkPMColor colors[Sk
 }
 
 //
-// effects/SkPaintImageFilter
+// effects/SkPaintImageFilter.h
 //
 
 extern "C" SkImageFilter *C_SkPaintImageFilter_Make(const SkPaint &paint, const SkImageFilter::CropRect *cropRect) {
@@ -2432,7 +2433,7 @@ extern "C" SkImageFilter *C_SkPaintImageFilter_Make(const SkPaint &paint, const 
 }
 
 //
-// effects/SkPictureImageFilter
+// effects/SkPictureImageFilter.h
 //
 
 extern "C" SkImageFilter *C_SkPictureImageFilter_Make(SkPicture *picture, const SkRect *cropRect) {
@@ -2453,7 +2454,7 @@ extern "C" SkMaskFilter* C_SkShaderMaskFilter_Make(SkShader* shader) {
 }
 
 //
-// effects/SkTableColorFilter
+// effects/SkTableColorFilter.h
 //
 
 extern "C" SkColorFilter* C_SkTableColorFilter_Make(const uint8_t table[256]) {
@@ -2465,7 +2466,7 @@ extern "C" SkColorFilter* C_SkTableColorFilter_MakeARGB(const uint8_t tableA[256
 }
 
 //
-// effects/SkTileImageFilter
+// effects/SkTileImageFilter.h
 //
 
 extern "C" SkImageFilter *C_SkTileImageFilter_Make(const SkRect &src, const SkRect &dst, SkImageFilter *input) {
@@ -2481,7 +2482,7 @@ extern "C" SkPathEffect *C_SkTrimPathEffect_Make(SkScalar startT, SkScalar stopT
 }
 
 //
-// effects/SkXfermodeImageFilter
+// effects/SkXfermodeImageFilter.h
 //
 
 extern "C" SkImageFilter *
@@ -2491,7 +2492,190 @@ C_SkXfermodeImageFilter_Make(SkBlendMode mode, SkImageFilter *background, SkImag
 }
 
 //
-// docs/SkPDFDocument
+// effects/SkImageFilters.h
+// 
+
+extern "C" {
+
+SkImageFilter *
+C_SkImageFilters_AlphaThreshold(const SkRegion &region, SkScalar innerMin, SkScalar outerMax, SkImageFilter *input,
+                                const SkIRect *cropRect) {
+    return SkImageFilters::AlphaThreshold(region, innerMin, outerMax, sp(input), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_Arithmetic(float k1, float k2, float k3, float k4, bool enforcePMColor,
+                                           SkImageFilter *background,
+                                           SkImageFilter *foreground,
+                                           const SkIRect *cropRect) {
+    return SkImageFilters::Arithmetic(k1, k2, k3, k4, enforcePMColor, sp(background),
+                                      sp(foreground), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_Blur(SkScalar sigmaX, SkScalar sigmaY, SkTileMode tileMode,
+                                     SkImageFilter *input, const SkIRect *cropRect) {
+    return SkImageFilters::Blur(sigmaX, sigmaY, tileMode, sp(input), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_ColorFilter(SkColorFilter *cf, SkImageFilter *input, const SkIRect *cropRect) {
+    return SkImageFilters::ColorFilter(sp(cf), sp(input), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_Compose(SkImageFilter *outer, SkImageFilter *inner) {
+    return SkImageFilters::Compose(sp(outer), sp(inner)).release();
+}
+
+SkImageFilter *C_SkImageFilters_DisplacementMap(SkColorChannel xChannelSelector,
+                                                SkColorChannel yChannelSelector,
+                                                SkScalar scale, SkImageFilter *displacement,
+                                                SkImageFilter *color,
+                                                const SkIRect *cropRect) {
+    return SkImageFilters::DisplacementMap(xChannelSelector, yChannelSelector, scale, sp(displacement), sp(color),
+                                           cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_DropShadow(SkScalar dx, SkScalar dy,
+                                           SkScalar sigmaX, SkScalar sigmaY,
+                                           SkColor color, SkImageFilter *input,
+                                           const SkIRect *cropRect) {
+    return SkImageFilters::DropShadow(dx, dy, sigmaX, sigmaY, color, sp(input), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_DropShadowOnly(SkScalar dx, SkScalar dy,
+                                               SkScalar sigmaX, SkScalar sigmaY,
+                                               SkColor color, SkImageFilter *input,
+                                               const SkIRect *cropRect) {
+    return SkImageFilters::DropShadowOnly(dx, dy, sigmaX, sigmaY, color, sp(input), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_Image(SkImage *image, const SkRect *srcRect,
+                                      const SkRect *dstRect, SkFilterQuality filterQuality) {
+    return SkImageFilters::Image(sp(image), *srcRect, *dstRect, filterQuality).release();
+}
+
+SkImageFilter *C_SkImageFilters_Magnifier(const SkRect *srcRect, SkScalar inset,
+                                          SkImageFilter *input,
+                                          const SkIRect *cropRect) {
+    return SkImageFilters::Magnifier(*srcRect, inset, sp(input), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_MatrixConvolution(const SkISize *kernelSize,
+                                                  const SkScalar kernel[], SkScalar gain,
+                                                  SkScalar bias, const SkIPoint *kernelOffset,
+                                                  SkTileMode tileMode, bool convolveAlpha,
+                                                  SkImageFilter *input,
+                                                  const SkIRect *cropRect) {
+    return SkImageFilters::MatrixConvolution(*kernelSize, kernel, gain, bias, *kernelOffset, tileMode, convolveAlpha,
+                                             sp(input), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_MatrixTransform(const SkMatrix *matrix,
+                                                SkFilterQuality filterQuality,
+                                                SkImageFilter *input) {
+
+    return SkImageFilters::MatrixTransform(*matrix, filterQuality, sp(input)).release();
+}
+
+SkImageFilter *C_SkImageFilters_Merge(SkImageFilter *const filters[], int count,
+                                      const SkIRect *cropRect) {
+    auto array = new sk_sp<SkImageFilter>[count];
+    for (int i = 0; i < count; ++i) {
+        array[i] = sp(filters[i]);
+    }
+    auto imageFilter = SkImageFilters::Merge(array, count, cropRect).release();
+    delete[] array;
+    return imageFilter;
+}
+
+SkImageFilter *C_SkImageFilters_Offset(SkScalar dx, SkScalar dy, SkImageFilter *input,
+                                       const SkIRect *cropRect) {
+    return SkImageFilters::Offset(dx, dy, sp(input), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_Paint(const SkPaint *paint, const SkIRect *cropRect) {
+    return SkImageFilters::Paint(*paint, cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_Picture(SkPicture *pic, const SkRect *targetRect) {
+    return SkImageFilters::Picture(sp(pic), *targetRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_Tile(const SkRect *src, const SkRect *dst,
+                                     SkImageFilter *input) {
+    return SkImageFilters::Tile(*src, *dst, sp(input)).release();
+}
+
+SkImageFilter *C_SkImageFilters_Xfermode(SkBlendMode blendMode, SkImageFilter *background,
+                                         SkImageFilter *foreground,
+                                         const SkIRect *cropRect) {
+    return SkImageFilters::Xfermode(blendMode, sp(background), sp(foreground), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_Dilate(int radiusX, int radiusY, SkImageFilter *input,
+                                       const SkIRect *cropRect) {
+    return SkImageFilters::Dilate(radiusX, radiusY, sp(input), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_Erode(int radiusX, int radiusY, SkImageFilter *input,
+                                      const SkIRect *cropRect) {
+    return SkImageFilters::Erode(radiusX, radiusY, sp(input), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_DistantLitDiffuse(const SkPoint3 *direction, SkColor lightColor,
+                                                  SkScalar surfaceScale, SkScalar kd,
+                                                  SkImageFilter *input,
+                                                  const SkIRect *cropRect) {
+    return SkImageFilters::DistantLitDiffuse(*direction, lightColor, surfaceScale, kd, sp(input), cropRect).release();
+}
+
+SkImageFilter *C_SkImageFilters_PointLitDiffuse(const SkPoint3 *direction, SkColor lightColor,
+                                                SkScalar surfaceScale, SkScalar kd,
+                                                SkImageFilter *input,
+                                                const SkIRect *cropRect) {
+    return SkImageFilters::PointLitDiffuse(*direction, lightColor, surfaceScale, kd, sp(input), cropRect).release();
+}
+
+SkImageFilter *
+C_SkImageFilters_SpotLitDiffuse(const SkPoint3 *location,
+                                const SkPoint3 *target, SkScalar specularExponent, SkScalar cutoffAngle,
+                                SkColor lightColor, SkScalar surfaceScale, SkScalar kd,
+                                SkImageFilter *input, const SkIRect *cropRect) {
+    return SkImageFilters::SpotLitDiffuse(*location, *target, specularExponent, cutoffAngle, lightColor,
+                                          surfaceScale, kd, sp(input), cropRect).release();
+}
+
+SkImageFilter *
+C_ImageFilters_DistantLitSpecular(const SkPoint3 *direction,
+                                  SkColor lightColor, SkScalar surfaceScale, SkScalar ks,
+                                  SkScalar shininess, SkImageFilter *input,
+                                  const SkIRect *cropRect) {
+    return SkImageFilters::DistantLitSpecular(*direction, lightColor, surfaceScale, ks, shininess,
+                                              sp(input), cropRect).release();
+}
+
+SkImageFilter *
+C_SkImageFilters_PointLitSpecular(const SkPoint3 &location,
+                                  SkColor lightColor, SkScalar surfaceScale, SkScalar ks,
+                                  SkScalar shininess, SkImageFilter *input,
+                                  const SkIRect *cropRect) {
+    return SkImageFilters::PointLitSpecular(location, lightColor, surfaceScale, ks, shininess,
+                                            sp(input), cropRect).release();
+}
+
+SkImageFilter *
+C_SkImageFilters_SpotLitSpecular(const SkPoint3 &location,
+                                 const SkPoint3 &target, SkScalar specularExponent, SkScalar cutoffAngle,
+                                 SkColor lightColor, SkScalar surfaceScale, SkScalar ks,
+                                 SkScalar shininess, SkImageFilter *input,
+                                 const SkIRect *cropRect) {
+    return SkImageFilters::SpotLitSpecular(location, target, specularExponent, cutoffAngle, lightColor,
+                                           surfaceScale, ks, shininess, sp(input),
+                                           cropRect).release();
+}
+
+}
+
+//
+// docs/SkPDFDocument.h
 //
 
 extern "C" void C_SkPDF_Metadata_Construct(SkPDF::Metadata* uninitialized) {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -345,17 +345,7 @@ extern "C" SkImage* C_SkImage_MakeFromTexture(
         SkColorSpace* colorSpace) {
     return SkImage::MakeFromTexture(context, *backendTexture, origin, colorType, alphaType, sp(colorSpace)).release();
 }
-
-extern "C" SkImage* C_SkImage_MakeCrossContextFromEncoded(
-        GrContext* context,
-        SkData* data,
-        bool buildMips,
-        const SkColorSpace* dstColorSpace,
-        bool limitToMaxTextureSize
-        ) {
-    return SkImage::MakeCrossContextFromEncoded(context, sp(data), buildMips, const_cast<SkColorSpace*>(dstColorSpace), limitToMaxTextureSize).release();
-}
-
+ 
 extern "C" SkImage* C_SkImage_MakeFromAdoptedTexture(
         GrContext* context,
         const GrBackendTexture* backendTexture,
@@ -472,9 +462,8 @@ extern "C" SkImage* C_SkImage_makeSubset(const SkImage* self, const SkIRect* sub
 extern "C" SkImage* C_SkImage_makeTextureImage(
         const SkImage* self,
         GrContext* context,
-        const SkColorSpace* dstColorSpace,
         GrMipMapped mipMapped) {
-    return self->makeTextureImage(context, const_cast<SkColorSpace*>(dstColorSpace), mipMapped).release();
+    return self->makeTextureImage(context, mipMapped).release();
 }
 
 extern "C" SkImage* C_SkImage_makeNonTextureImage(const SkImage* self) {
@@ -1100,8 +1089,8 @@ extern "C" bool C_SkRegion_set(SkRegion* self, const SkRegion* region) {
     return self->set(*region);
 }
 
-extern "C" bool C_SkRegion_quickContains(const SkRegion* self, int32_t left, int32_t top, int32_t right, int32_t bottom) {
-    return self->quickContains(left, top, right, bottom);
+extern "C" bool C_SkRegion_quickContains(const SkRegion* self, const SkIRect* r) {
+    return self->quickContains(*r);
 }
 
 extern "C" void C_SkRegion_Iterator_Construct(SkRegion::Iterator* uninitialized) {
@@ -1738,7 +1727,7 @@ extern "C" int C_SkImageFilter_countInputs(const SkImageFilter* self) {
     return self->countInputs();
 }
 
-extern "C" SkImageFilter* C_SkImageFilter_getInput(const SkImageFilter* self, int i) {
+extern "C" const SkImageFilter* C_SkImageFilter_getInput(const SkImageFilter* self, int i) {
     return self->getInput(i);
 }
 

--- a/skia-bindings/src/shaper.cpp
+++ b/skia-bindings/src/shaper.cpp
@@ -5,16 +5,20 @@ extern "C" SkShaper* C_SkShaper_MakePrimitive() {
     return SkShaper::MakePrimitive().release();
 }
 
-extern "C" SkShaper* C_SkShaper_MakeShaperDrivenWrapper() {
-    return SkShaper::MakeShaperDrivenWrapper().release();
+extern "C" SkShaper* C_SkShaper_MakeShaperDrivenWrapper(SkFontMgr* fontMgr) {
+    return SkShaper::MakeShaperDrivenWrapper(sk_sp<SkFontMgr>(fontMgr)).release();
 }
 
-extern "C" SkShaper* C_SkShaper_MakeShapeThenWrap() {
-    return SkShaper::MakeShapeThenWrap().release();
+extern "C" SkShaper* C_SkShaper_MakeShapeThenWrap(SkFontMgr* fontMgr) {
+    return SkShaper::MakeShapeThenWrap(sk_sp<SkFontMgr>(fontMgr)).release();
 }
 
-extern "C" SkShaper* C_SkShaper_Make() {
-    return SkShaper::Make().release();
+extern "C" SkShaper* C_SkShaper_MakeShapeDontWrapOrReorder(SkFontMgr* fontMgr) {
+    return SkShaper::MakeShapeDontWrapOrReorder(sk_sp<SkFontMgr>(fontMgr)).release();
+}
+
+extern "C" SkShaper* C_SkShaper_Make(SkFontMgr* fontMgr) {
+    return SkShaper::Make(sk_sp<SkFontMgr>(fontMgr)).release();
 }
 
 extern "C" void C_SkShaper_delete(SkShaper* self) {

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -24,7 +24,7 @@ textlayout = ["skia-bindings/textlayout", "shaper"]
 
 [dependencies]
 bitflags = "1.0.4"
-skia-bindings = { version = "=0.18.0", path = "../skia-bindings" }
+skia-bindings = { version = "=0.19.0", path = "../skia-bindings" }
 lazy_static = "1.4"
 
 [dev-dependencies]

--- a/skia-safe/examples/skia-org/skshaper_example.rs
+++ b/skia-safe/examples/skia-org/skshaper_example.rs
@@ -20,7 +20,7 @@ fn draw_rtl_shaped(canvas: &mut Canvas) {
 
     let font = &Font::from_typeface(Typeface::default(), 64.0);
 
-    let shaper = Shaper::new();
+    let shaper = Shaper::new(None);
     if let Some((blob, _)) =
         shaper.shape_text_blob(RTL_TEXT, font, false, 10000.0, Point::default())
     {

--- a/skia-safe/src/core.rs
+++ b/skia-safe/src/core.rs
@@ -146,17 +146,11 @@ pub use image_encoder::*;
 pub mod image_filter;
 #[deprecated(since = "0.12.0", note = "use image_filter::crop_rect::CropEdge")]
 pub use image_filter::crop_rect::CropEdge as ImageFilterCropRectCropEdge;
-#[deprecated(since = "0.12.0", note = "use image_filter::Context")]
-pub use image_filter::Context as ImageFilterContext;
 #[deprecated(since = "0.12.0", note = "use image_filter::CropRect")]
 pub use image_filter::CropRect as ImageFilterCropRect;
 pub use image_filter::ImageFilter;
 #[deprecated(since = "0.12.0", note = "use image_filter::MapDirection")]
 pub use image_filter::MapDirection as ImageFilterMapDirection;
-#[deprecated(since = "0.12.0", note = "use image_filter::OutputProperties")]
-pub use image_filter::OutputProperties as ImageFilterOutputProperties;
-#[deprecated(since = "0.12.0", note = "use image_filter::TileUsage")]
-pub use image_filter::TileUsage as ImageFilterTileUsage;
 
 mod image_generator;
 pub use image_generator::*;
@@ -346,7 +340,7 @@ pub use vertices::VertexMode as VerticesVertexMode;
 pub use vertices::Vertices;
 
 pub mod yuva_index;
-pub use yuva_index::{ColorChannel, YUVAIndex};
+pub use yuva_index::YUVAIndex;
 
 mod yuva_size_info;
 pub use yuva_size_info::*;

--- a/skia-safe/src/core/color.rs
+++ b/skia-safe/src/core/color.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use crate::u8cpu;
 use skia_bindings as sb;
-use skia_bindings::{SkColor, SkColor4f, SkHSVToColor, SkPMColor, SkRGBToHSV};
+use skia_bindings::{SkColor, SkColor4f, SkColorChannel, SkHSVToColor, SkPMColor, SkRGBToHSV};
 use std::ops::{BitAnd, BitOr, Index, IndexMut, Mul};
 
 // TODO: What should we do with SkAlpha?
@@ -192,6 +192,21 @@ pub fn pre_multiply_argb(a: u8cpu, r: u8cpu, g: u8cpu, b: u8cpu) -> PMColor {
 
 pub fn pre_multiply_color(c: impl Into<Color>) -> PMColor {
     unsafe { sb::SkPreMultiplyColor(c.into().into_native()) }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[repr(i32)]
+pub enum ColorChannel {
+    R = SkColorChannel::kR as _,
+    G = SkColorChannel::kG as _,
+    B = SkColorChannel::kB as _,
+    A = SkColorChannel::kA as _,
+}
+
+impl NativeTransmutable<SkColorChannel> for ColorChannel {}
+#[test]
+fn color_channel_layout() {
+    ColorChannel::test_layout()
 }
 
 // decided not to directly support SkRGBA4f for now because of the

--- a/skia-safe/src/core/color_filter.rs
+++ b/skia-safe/src/core/color_filter.rs
@@ -107,6 +107,11 @@ pub mod color_filters {
             .unwrap()
     }
 
+    pub fn hsla_matrix(row_major: &[f32; 20]) -> ColorFilter {
+        ColorFilter::from_ptr(unsafe { sb::C_SkColorFilters_HSLAMatrix(row_major.as_ptr()) })
+            .unwrap()
+    }
+
     pub fn blend(c: impl Into<Color>, mode: BlendMode) -> Option<ColorFilter> {
         ColorFilter::from_ptr(unsafe {
             sb::C_SkColorFilters_Blend(c.into().into_native(), mode.into_native())

--- a/skia-safe/src/core/font.rs
+++ b/skia-safe/src/core/font.rs
@@ -119,6 +119,10 @@ impl Handle<SkFont> {
         self.has_flag(sb::SkFont_PrivFlags_kEmbolden_PrivFlag)
     }
 
+    pub fn is_baseline_snap(&self) -> bool {
+        self.has_flag(sb::SkFont_PrivFlags_kBaselineSnap_PrivFlag)
+    }
+
     fn has_flag(&self, flag: SkFont_PrivFlags) -> bool {
         (SkFont_PrivFlags::from(self.native().fFlags) & flag) != 0
     }
@@ -150,6 +154,11 @@ impl Handle<SkFont> {
 
     pub fn set_embolden(&mut self, embolden: bool) -> &mut Self {
         unsafe { self.native_mut().setEmbolden(embolden) }
+        self
+    }
+
+    pub fn set_baseline_snap(&mut self, baseline_snap: bool) -> &mut Self {
+        unsafe { self.native_mut().setBaselineSnap(baseline_snap) }
         self
     }
 

--- a/skia-safe/src/core/image.rs
+++ b/skia-safe/src/core/image.rs
@@ -486,7 +486,7 @@ impl RCHandle<SkImage> {
         Image::from_ptr(unsafe { sb::C_SkImage_makeSubset(self.native(), rect.as_ref().native()) })
     }
 
-    pub fn new_texture_image<'a>(
+    pub fn new_texture_image(
         &self,
         context: &mut gpu::Context,
         mip_mapped: gpu::MipMapped,

--- a/skia-safe/src/core/image_filter.rs
+++ b/skia-safe/src/core/image_filter.rs
@@ -196,7 +196,7 @@ impl RCHandle<SkImageFilter> {
         })
     }
 
-    #[deprecated(since = "m78", note = "use image_filters::matrix_transform()")]
+    #[deprecated(since = "0.0.0", note = "use image_filters::matrix_transform()")]
     pub fn with_matrix(self, matrix: &Matrix, quality: FilterQuality) -> ImageFilter {
         ImageFilter::from_ptr(unsafe {
             sb::C_SkImageFilter_MakeMatrixFilter(

--- a/skia-safe/src/core/image_filter.rs
+++ b/skia-safe/src/core/image_filter.rs
@@ -196,7 +196,7 @@ impl RCHandle<SkImageFilter> {
         })
     }
 
-    #[deprecated(since = "0.0.0", note = "use image_filters::matrix_transform()")]
+    #[deprecated(since = "0.19.0", note = "use image_filters::matrix_transform()")]
     pub fn with_matrix(self, matrix: &Matrix, quality: FilterQuality) -> ImageFilter {
         ImageFilter::from_ptr(unsafe {
             sb::C_SkImageFilter_MakeMatrixFilter(

--- a/skia-safe/src/core/milestone.rs
+++ b/skia-safe/src/core/milestone.rs
@@ -1,1 +1,1 @@
-pub const MILESTONE: usize = 77;
+pub const MILESTONE: usize = 78;

--- a/skia-safe/src/core/path.rs
+++ b/skia-safe/src/core/path.rs
@@ -178,20 +178,10 @@ impl<'a> Iter<'a> {
         r
     }
 
-    pub fn next(
-        &mut self,
-        do_consume_generates: impl Into<Option<bool>>,
-        exact: impl Into<Option<bool>>,
-    ) -> (Verb, Vec<Point>) {
+    pub fn next(&mut self) -> (Verb, Vec<Point>) {
         let mut points = [Point::default(); Verb::MAX_POINTS];
-        let verb = Verb::from_native(unsafe {
-            sb::C_SkPath_Iter_next(
-                self.native_mut(),
-                points.native_mut().as_mut_ptr(),
-                do_consume_generates.into().unwrap_or(true),
-                exact.into().unwrap_or(false),
-            )
-        });
+        let verb =
+            Verb::from_native(unsafe { self.native_mut().next(points.native_mut().as_mut_ptr()) });
         (verb, points[0..verb.points()].into())
     }
 
@@ -216,7 +206,7 @@ impl<'a> Iterator for Iter<'a> {
     type Item = (Verb, Vec<Point>);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (verb, points) = self.next(None, None);
+        let (verb, points) = self.next();
         if verb != Verb::Done {
             Some((verb, points))
         } else {

--- a/skia-safe/src/core/path.rs
+++ b/skia-safe/src/core/path.rs
@@ -178,13 +178,6 @@ impl<'a> Iter<'a> {
         r
     }
 
-    pub fn next(&mut self) -> (Verb, Vec<Point>) {
-        let mut points = [Point::default(); Verb::MAX_POINTS];
-        let verb =
-            Verb::from_native(unsafe { self.native_mut().next(points.native_mut().as_mut_ptr()) });
-        (verb, points[0..verb.points()].into())
-    }
-
     pub fn conic_weight(&self) -> Option<scalar> {
         #[allow(clippy::map_clone)]
         self.native()
@@ -206,9 +199,11 @@ impl<'a> Iterator for Iter<'a> {
     type Item = (Verb, Vec<Point>);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (verb, points) = self.next();
+        let mut points = [Point::default(); Verb::MAX_POINTS];
+        let verb =
+            Verb::from_native(unsafe { self.native_mut().next(points.native_mut().as_mut_ptr()) });
         if verb != Verb::Done {
-            Some((verb, points))
+            Some((verb, points[0..verb.points()].into()))
         } else {
             None
         }

--- a/skia-safe/src/core/rect.rs
+++ b/skia-safe/src/core/rect.rs
@@ -124,7 +124,7 @@ impl IRect {
         *self = Self::new_empty()
     }
 
-    #[deprecated(since = "m78", note = "use set_ltrb()")]
+    #[deprecated(since = "0.0.0", note = "use set_ltrb()")]
     pub fn set(&mut self, left: i32, top: i32, right: i32, bottom: i32) {
         self.set_ltrb(left, top, right, bottom)
     }
@@ -231,7 +231,7 @@ impl IRect {
         unsafe { r.native_mut().intersect(a.native(), b.native()) }.if_true_some(r)
     }
 
-    #[deprecated(since = "m78", note = "removed without alternative")]
+    #[deprecated(since = "0.0.0", note = "removed without alternative")]
     pub fn intersect_no_empty_check(a: &Self, b: &Self) -> Option<Self> {
         Self::intersect_no_empty_check_(a, b)
     }
@@ -240,7 +240,7 @@ impl IRect {
         Self::intersect(a, b).is_some()
     }
 
-    #[deprecated(since = "m78", note = "removed without alternative")]
+    #[deprecated(since = "0.0.0", note = "removed without alternative")]
     pub fn intersects_no_empty_check(a: &Self, b: &Self) -> bool {
         Self::intersect_no_empty_check_(a, b).is_some()
     }
@@ -488,7 +488,7 @@ impl Rect {
         *self = Self::from_irect(irect)
     }
 
-    #[deprecated(since = "m78", note = "use set_ltrb()")]
+    #[deprecated(since = "0.0.0", note = "use set_ltrb()")]
     pub fn set(&mut self, left: scalar, top: scalar, right: scalar, bottom: scalar) {
         self.set_ltrb(left, top, right, bottom)
     }
@@ -497,12 +497,12 @@ impl Rect {
         *self = Self::new(left, top, right, bottom)
     }
 
-    #[deprecated(since = "m78", note = "use from_irect()")]
+    #[deprecated(since = "0.0.0", note = "use from_irect()")]
     pub fn iset(&mut self, left: i32, top: i32, right: i32, bottom: i32) {
         *self = Self::from_irect(IRect::new(left, top, right, bottom))
     }
 
-    #[deprecated(since = "m78", note = "use from_isize()")]
+    #[deprecated(since = "0.0.0", note = "use from_isize()")]
     pub fn iset_wh(&mut self, width: i32, height: i32) {
         *self = Self::from_isize(ISize::new(width, height))
     }
@@ -612,7 +612,7 @@ impl Rect {
         unsafe { self.native_mut().intersect(r.as_ref().native()) }
     }
 
-    #[deprecated(since = "m78", note = "use intersect()")]
+    #[deprecated(since = "0.0.0", note = "use intersect()")]
     pub fn intersect_ltrb(
         &mut self,
         left: scalar,
@@ -631,7 +631,7 @@ impl Rect {
         }
     }
 
-    #[deprecated(since = "m78", note = "use intersects()")]
+    #[deprecated(since = "0.0.0", note = "use intersects()")]
     pub fn intersects_ltrb(
         &self,
         left: scalar,
@@ -687,7 +687,7 @@ impl Rect {
         l < r && t < b
     }
 
-    #[deprecated(since = "m78", note = "use join()")]
+    #[deprecated(since = "0.0.0", note = "use join()")]
     pub fn join_ltrb(&mut self, left: scalar, top: scalar, right: scalar, bottom: scalar) {
         self.join(Rect::new(left, top, right, bottom))
     }

--- a/skia-safe/src/core/rect.rs
+++ b/skia-safe/src/core/rect.rs
@@ -141,7 +141,7 @@ impl IRect {
         self.left = 0;
         self.top = 0;
         self.right = width;
-        self.bottom = width;
+        self.bottom = height;
     }
 
     #[must_use]

--- a/skia-safe/src/core/rect.rs
+++ b/skia-safe/src/core/rect.rs
@@ -124,7 +124,7 @@ impl IRect {
         *self = Self::new_empty()
     }
 
-    #[deprecated(since = "0.0.0", note = "use set_ltrb()")]
+    #[deprecated(since = "0.19.0", note = "use set_ltrb()")]
     pub fn set(&mut self, left: i32, top: i32, right: i32, bottom: i32) {
         self.set_ltrb(left, top, right, bottom)
     }
@@ -231,7 +231,7 @@ impl IRect {
         unsafe { r.native_mut().intersect(a.native(), b.native()) }.if_true_some(r)
     }
 
-    #[deprecated(since = "0.0.0", note = "removed without alternative")]
+    #[deprecated(since = "0.19.0", note = "removed without alternative")]
     pub fn intersect_no_empty_check(a: &Self, b: &Self) -> Option<Self> {
         Self::intersect_no_empty_check_(a, b)
     }
@@ -240,7 +240,7 @@ impl IRect {
         Self::intersect(a, b).is_some()
     }
 
-    #[deprecated(since = "0.0.0", note = "removed without alternative")]
+    #[deprecated(since = "0.19.0", note = "removed without alternative")]
     pub fn intersects_no_empty_check(a: &Self, b: &Self) -> bool {
         Self::intersect_no_empty_check_(a, b).is_some()
     }
@@ -488,7 +488,7 @@ impl Rect {
         *self = Self::from_irect(irect)
     }
 
-    #[deprecated(since = "0.0.0", note = "use set_ltrb()")]
+    #[deprecated(since = "0.19.0", note = "use set_ltrb()")]
     pub fn set(&mut self, left: scalar, top: scalar, right: scalar, bottom: scalar) {
         self.set_ltrb(left, top, right, bottom)
     }
@@ -497,12 +497,12 @@ impl Rect {
         *self = Self::new(left, top, right, bottom)
     }
 
-    #[deprecated(since = "0.0.0", note = "use from_irect()")]
+    #[deprecated(since = "0.19.0", note = "use from_irect()")]
     pub fn iset(&mut self, left: i32, top: i32, right: i32, bottom: i32) {
         *self = Self::from_irect(IRect::new(left, top, right, bottom))
     }
 
-    #[deprecated(since = "0.0.0", note = "use from_isize()")]
+    #[deprecated(since = "0.19.0", note = "use from_isize()")]
     pub fn iset_wh(&mut self, width: i32, height: i32) {
         *self = Self::from_isize(ISize::new(width, height))
     }
@@ -612,7 +612,7 @@ impl Rect {
         unsafe { self.native_mut().intersect(r.as_ref().native()) }
     }
 
-    #[deprecated(since = "0.0.0", note = "use intersect()")]
+    #[deprecated(since = "0.19.0", note = "use intersect()")]
     pub fn intersect_ltrb(
         &mut self,
         left: scalar,
@@ -631,7 +631,7 @@ impl Rect {
         }
     }
 
-    #[deprecated(since = "0.0.0", note = "use intersects()")]
+    #[deprecated(since = "0.19.0", note = "use intersects()")]
     pub fn intersects_ltrb(
         &self,
         left: scalar,
@@ -687,7 +687,7 @@ impl Rect {
         l < r && t < b
     }
 
-    #[deprecated(since = "0.0.0", note = "use join()")]
+    #[deprecated(since = "0.19.0", note = "use join()")]
     pub fn join_ltrb(&mut self, left: scalar, top: scalar, right: scalar, bottom: scalar) {
         self.join(Rect::new(left, top, right, bottom))
     }

--- a/skia-safe/src/core/region.rs
+++ b/skia-safe/src/core/region.rs
@@ -102,7 +102,7 @@ impl Handle<SkRegion> {
         unsafe { self.native_mut().setRect(rect.as_ref().native()) }
     }
 
-    #[deprecated(since = "m78", note = "use set_rect()")]
+    #[deprecated(since = "0.0.0", note = "use set_rect()")]
     pub fn set_rect_ltbr(&mut self, left: i32, top: i32, right: i32, bottom: i32) -> bool {
         self.set_rect(IRect::new(left, top, right, bottom))
     }
@@ -151,7 +151,7 @@ impl Handle<SkRegion> {
         unsafe { sb::C_SkRegion_quickContains(self.native(), r.native()) }
     }
 
-    #[deprecated(since = "m78", note = "use quick_contains()")]
+    #[deprecated(since = "0.0.0", note = "use quick_contains()")]
     pub fn quick_contains_ltrb(&self, left: i32, top: i32, right: i32, bottom: i32) -> bool {
         let rect = IRect::new(left, top, right, bottom);
         self.quick_contains(rect)

--- a/skia-safe/src/core/region.rs
+++ b/skia-safe/src/core/region.rs
@@ -102,6 +102,7 @@ impl Handle<SkRegion> {
         unsafe { self.native_mut().setRect(rect.as_ref().native()) }
     }
 
+    #[deprecated(since = "m78", note = "use set_rect()")]
     pub fn set_rect_ltbr(&mut self, left: i32, top: i32, right: i32, bottom: i32) -> bool {
         self.set_rect(IRect::new(left, top, right, bottom))
     }
@@ -147,11 +148,13 @@ impl Handle<SkRegion> {
 
     pub fn quick_contains(&self, r: impl AsRef<IRect>) -> bool {
         let r = r.as_ref();
-        self.quick_contains_ltrb(r.left, r.top, r.right, r.bottom)
+        unsafe { sb::C_SkRegion_quickContains(self.native(), r.native()) }
     }
 
+    #[deprecated(since = "m78", note = "use quick_contains()")]
     pub fn quick_contains_ltrb(&self, left: i32, top: i32, right: i32, bottom: i32) -> bool {
-        unsafe { sb::C_SkRegion_quickContains(self.native(), left, top, right, bottom) }
+        let rect = IRect::new(left, top, right, bottom);
+        self.quick_contains(rect)
     }
 
     // see also the quick_reject() trait below.

--- a/skia-safe/src/core/region.rs
+++ b/skia-safe/src/core/region.rs
@@ -102,7 +102,7 @@ impl Handle<SkRegion> {
         unsafe { self.native_mut().setRect(rect.as_ref().native()) }
     }
 
-    #[deprecated(since = "0.0.0", note = "use set_rect()")]
+    #[deprecated(since = "0.19.0", note = "use set_rect()")]
     pub fn set_rect_ltbr(&mut self, left: i32, top: i32, right: i32, bottom: i32) -> bool {
         self.set_rect(IRect::new(left, top, right, bottom))
     }
@@ -151,7 +151,7 @@ impl Handle<SkRegion> {
         unsafe { sb::C_SkRegion_quickContains(self.native(), r.native()) }
     }
 
-    #[deprecated(since = "0.0.0", note = "use quick_contains()")]
+    #[deprecated(since = "0.19.0", note = "use quick_contains()")]
     pub fn quick_contains_ltrb(&self, left: i32, top: i32, right: i32, bottom: i32) -> bool {
         let rect = IRect::new(left, top, right, bottom);
         self.quick_contains(rect)

--- a/skia-safe/src/core/size.rs
+++ b/skia-safe/src/core/size.rs
@@ -25,7 +25,7 @@ impl ISize {
         }
     }
 
-    pub fn new_empty() -> ISize {
+    pub const fn new_empty() -> ISize {
         Self::new(0, 0)
     }
 

--- a/skia-safe/src/core/yuva_index.rs
+++ b/skia-safe/src/core/yuva_index.rs
@@ -1,21 +1,7 @@
 use crate::prelude::*;
+use crate::ColorChannel;
 use skia_bindings as sb;
-use skia_bindings::{SkColorChannel, SkYUVAIndex, SkYUVAIndex_Index};
-
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-#[repr(i32)]
-pub enum ColorChannel {
-    R = SkColorChannel::kR as _,
-    G = SkColorChannel::kG as _,
-    B = SkColorChannel::kB as _,
-    A = SkColorChannel::kA as _,
-}
-
-impl NativeTransmutable<SkColorChannel> for ColorChannel {}
-#[test]
-fn test_color_channel_layout() {
-    ColorChannel::test_layout()
-}
+use skia_bindings::{SkYUVAIndex, SkYUVAIndex_Index};
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]

--- a/skia-safe/src/effects.rs
+++ b/skia-safe/src/effects.rs
@@ -21,6 +21,7 @@ pub mod drop_shadow_image_filter;
 pub mod gradient_shader;
 pub mod high_contrast_filter;
 pub use high_contrast_filter::{high_contrast_config, HighContrastConfig};
+pub mod image_filters;
 pub mod image_source;
 pub mod layer_draw_looper;
 pub mod lighting_image_filter;

--- a/skia-safe/src/effects/alpha_threshold_filter.rs
+++ b/skia-safe/src/effects/alpha_threshold_filter.rs
@@ -1,17 +1,17 @@
 use crate::prelude::*;
-use crate::{image_filter::CropRect, scalar, ImageFilter, Region};
+use crate::{image_filter::CropRect, image_filters, scalar, IRect, ImageFilter, Region};
 use skia_bindings as sb;
 use skia_bindings::SkImageFilter;
 
 impl RCHandle<SkImageFilter> {
     pub fn alpha_threshold<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         region: &Region,
         inner_min: scalar,
         outer_max: scalar,
     ) -> Option<Self> {
-        new(region, inner_min, outer_max, self, crop_rect)
+        image_filters::alpha_threshold(region, inner_min, outer_max, self, crop_rect)
     }
 }
 

--- a/skia-safe/src/effects/alpha_threshold_filter.rs
+++ b/skia-safe/src/effects/alpha_threshold_filter.rs
@@ -15,6 +15,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
+#[deprecated(since = "m78", note = "use image_filters::alpha_threshold()")]
 pub fn new<'a>(
     region: &Region,
     inner_min: scalar,

--- a/skia-safe/src/effects/alpha_threshold_filter.rs
+++ b/skia-safe/src/effects/alpha_threshold_filter.rs
@@ -15,7 +15,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "m78", note = "use image_filters::alpha_threshold()")]
+#[deprecated(since = "0.0.0", note = "use image_filters::alpha_threshold()")]
 pub fn new<'a>(
     region: &Region,
     inner_min: scalar,

--- a/skia-safe/src/effects/alpha_threshold_filter.rs
+++ b/skia-safe/src/effects/alpha_threshold_filter.rs
@@ -15,7 +15,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "0.0.0", note = "use image_filters::alpha_threshold()")]
+#[deprecated(since = "0.19.0", note = "use image_filters::alpha_threshold()")]
 pub fn new<'a>(
     region: &Region,
     inner_min: scalar,

--- a/skia-safe/src/effects/arithmetic_image_filter.rs
+++ b/skia-safe/src/effects/arithmetic_image_filter.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use crate::{image_filter, ImageFilter};
+use crate::{image_filter, image_filters, IRect, ImageFilter};
 use skia_bindings as sb;
 use skia_bindings::SkImageFilter;
 
@@ -9,9 +9,19 @@ impl RCHandle<SkImageFilter> {
         inputs: impl Into<ArithmeticFPInputs>,
         background: Self,
         foreground: Self,
-        crop_rect: impl Into<Option<&'a image_filter::CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
     ) -> Option<Self> {
-        new(inputs, background, foreground, crop_rect)
+        let inputs = inputs.into();
+        image_filters::arithmetic(
+            inputs.k[0],
+            inputs.k[1],
+            inputs.k[2],
+            inputs.k[3],
+            inputs.enforce_pm_color,
+            background,
+            foreground,
+            crop_rect,
+        )
     }
 }
 

--- a/skia-safe/src/effects/arithmetic_image_filter.rs
+++ b/skia-safe/src/effects/arithmetic_image_filter.rs
@@ -41,7 +41,7 @@ impl From<([f32; 4], bool)> for ArithmeticFPInputs {
 }
 
 #[allow(clippy::too_many_arguments)]
-#[deprecated(since = "m78", note = "use image_filters::arithmetic()")]
+#[deprecated(since = "0.0.0", note = "use image_filters::arithmetic()")]
 pub fn new<'a>(
     inputs: impl Into<ArithmeticFPInputs>,
     background: ImageFilter,

--- a/skia-safe/src/effects/arithmetic_image_filter.rs
+++ b/skia-safe/src/effects/arithmetic_image_filter.rs
@@ -31,6 +31,7 @@ impl From<([f32; 4], bool)> for ArithmeticFPInputs {
 }
 
 #[allow(clippy::too_many_arguments)]
+#[deprecated(since = "m78", note = "use image_filters::arithmetic()")]
 pub fn new<'a>(
     inputs: impl Into<ArithmeticFPInputs>,
     background: ImageFilter,

--- a/skia-safe/src/effects/arithmetic_image_filter.rs
+++ b/skia-safe/src/effects/arithmetic_image_filter.rs
@@ -41,7 +41,7 @@ impl From<([f32; 4], bool)> for ArithmeticFPInputs {
 }
 
 #[allow(clippy::too_many_arguments)]
-#[deprecated(since = "0.0.0", note = "use image_filters::arithmetic()")]
+#[deprecated(since = "0.19.0", note = "use image_filters::arithmetic()")]
 pub fn new<'a>(
     inputs: impl Into<ArithmeticFPInputs>,
     background: ImageFilter,

--- a/skia-safe/src/effects/blur_image_filter.rs
+++ b/skia-safe/src/effects/blur_image_filter.rs
@@ -16,6 +16,7 @@ impl RCHandle<SkImageFilter> {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
+#[deprecated(since = "m78", note = "use skia_safe::TileMode")]
 pub enum TileMode {
     Clamp = SkBlurImageFilter_TileMode::kClamp_TileMode as _,
     Repeat = SkBlurImageFilter_TileMode::kRepeat_TileMode as _,
@@ -28,6 +29,7 @@ fn test_tile_mode_layout() {
     TileMode::test_layout();
 }
 
+#[deprecated(since = "m78", note = "use image_filters::blur")]
 pub fn new<'a>(
     (sigma_x, sigma_y): (scalar, scalar),
     input: ImageFilter,

--- a/skia-safe/src/effects/blur_image_filter.rs
+++ b/skia-safe/src/effects/blur_image_filter.rs
@@ -14,7 +14,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "m78", note = "use skia_safe::TileMode")]
+#[deprecated(since = "0.0.0", note = "use skia_safe::TileMode")]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
 pub enum TileMode {
@@ -32,7 +32,7 @@ fn test_tile_mode_layout() {
 }
 
 #[allow(deprecated)]
-#[deprecated(since = "m78", note = "use image_filters::blur")]
+#[deprecated(since = "0.0.0", note = "use image_filters::blur")]
 pub fn new<'a>(
     (sigma_x, sigma_y): (scalar, scalar),
     input: ImageFilter,

--- a/skia-safe/src/effects/blur_image_filter.rs
+++ b/skia-safe/src/effects/blur_image_filter.rs
@@ -1,34 +1,37 @@
 use crate::prelude::*;
-use crate::{image_filter::CropRect, scalar, ImageFilter};
+use crate::{image_filter::CropRect, image_filters, scalar, IRect, ImageFilter};
 use skia_bindings as sb;
 use skia_bindings::{SkBlurImageFilter_TileMode, SkImageFilter};
 
 impl RCHandle<SkImageFilter> {
     pub fn blur<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         sigma: (scalar, scalar),
-        tile_mode: impl Into<Option<TileMode>>,
+        tile_mode: impl Into<Option<crate::TileMode>>,
     ) -> Option<Self> {
-        new(sigma, self, crop_rect, tile_mode)
+        image_filters::blur(sigma, tile_mode, self, crop_rect)
     }
 }
 
+#[deprecated(since = "m78", note = "use skia_safe::TileMode")]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
-#[deprecated(since = "m78", note = "use skia_safe::TileMode")]
 pub enum TileMode {
     Clamp = SkBlurImageFilter_TileMode::kClamp_TileMode as _,
     Repeat = SkBlurImageFilter_TileMode::kRepeat_TileMode as _,
     ClampToBlack = SkBlurImageFilter_TileMode::kClampToBlack_TileMode as _,
 }
 
+#[allow(deprecated)]
 impl NativeTransmutable<SkBlurImageFilter_TileMode> for TileMode {}
+#[allow(deprecated)]
 #[test]
 fn test_tile_mode_layout() {
     TileMode::test_layout();
 }
 
+#[allow(deprecated)]
 #[deprecated(since = "m78", note = "use image_filters::blur")]
 pub fn new<'a>(
     (sigma_x, sigma_y): (scalar, scalar),

--- a/skia-safe/src/effects/blur_image_filter.rs
+++ b/skia-safe/src/effects/blur_image_filter.rs
@@ -14,7 +14,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "0.0.0", note = "use skia_safe::TileMode")]
+#[deprecated(since = "0.19.0", note = "use skia_safe::TileMode")]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
 pub enum TileMode {
@@ -32,7 +32,7 @@ fn test_tile_mode_layout() {
 }
 
 #[allow(deprecated)]
-#[deprecated(since = "0.0.0", note = "use image_filters::blur")]
+#[deprecated(since = "0.19.0", note = "use image_filters::blur")]
 pub fn new<'a>(
     (sigma_x, sigma_y): (scalar, scalar),
     input: ImageFilter,

--- a/skia-safe/src/effects/color_filter_image_filter.rs
+++ b/skia-safe/src/effects/color_filter_image_filter.rs
@@ -1,15 +1,15 @@
 use crate::prelude::*;
-use crate::{image_filter::CropRect, ColorFilter, ImageFilter};
+use crate::{image_filter::CropRect, image_filters, ColorFilter, IRect, ImageFilter};
 use skia_bindings as sb;
 use skia_bindings::SkImageFilter;
 
 impl RCHandle<SkImageFilter> {
     pub fn color_filter<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         cf: ColorFilter,
     ) -> Option<Self> {
-        new(cf, self, crop_rect)
+        image_filters::color_filter(cf, self, crop_rect)
     }
 }
 

--- a/skia-safe/src/effects/color_filter_image_filter.rs
+++ b/skia-safe/src/effects/color_filter_image_filter.rs
@@ -13,6 +13,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
+#[deprecated(since = "m78", note = "use image_filters::color_filter")]
 pub fn new<'a>(
     cf: ColorFilter,
     input: ImageFilter,

--- a/skia-safe/src/effects/color_filter_image_filter.rs
+++ b/skia-safe/src/effects/color_filter_image_filter.rs
@@ -13,7 +13,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "m78", note = "use image_filters::color_filter")]
+#[deprecated(since = "0.0.0", note = "use image_filters::color_filter")]
 pub fn new<'a>(
     cf: ColorFilter,
     input: ImageFilter,

--- a/skia-safe/src/effects/color_filter_image_filter.rs
+++ b/skia-safe/src/effects/color_filter_image_filter.rs
@@ -13,7 +13,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "0.0.0", note = "use image_filters::color_filter")]
+#[deprecated(since = "0.19.0", note = "use image_filters::color_filter")]
 pub fn new<'a>(
     cf: ColorFilter,
     input: ImageFilter,

--- a/skia-safe/src/effects/compose_image_filter.rs
+++ b/skia-safe/src/effects/compose_image_filter.rs
@@ -9,6 +9,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
+#[deprecated(since = "m78", note = "use image_filters::compose")]
 pub fn new(outer: ImageFilter, inner: ImageFilter) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
         sb::C_SkComposeImageFilter_Make(outer.into_ptr(), inner.into_ptr())

--- a/skia-safe/src/effects/compose_image_filter.rs
+++ b/skia-safe/src/effects/compose_image_filter.rs
@@ -9,7 +9,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "m78", note = "use image_filters::compose")]
+#[deprecated(since = "0.0.0", note = "use image_filters::compose")]
 pub fn new(outer: ImageFilter, inner: ImageFilter) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
         sb::C_SkComposeImageFilter_Make(outer.into_ptr(), inner.into_ptr())

--- a/skia-safe/src/effects/compose_image_filter.rs
+++ b/skia-safe/src/effects/compose_image_filter.rs
@@ -1,11 +1,11 @@
 use crate::prelude::*;
-use crate::ImageFilter;
+use crate::{image_filters, ImageFilter};
 use skia_bindings as sb;
 use skia_bindings::SkImageFilter;
 
 impl RCHandle<SkImageFilter> {
     pub fn compose(outer: ImageFilter, inner: ImageFilter) -> Option<Self> {
-        new(outer, inner)
+        image_filters::compose(outer, inner)
     }
 }
 

--- a/skia-safe/src/effects/compose_image_filter.rs
+++ b/skia-safe/src/effects/compose_image_filter.rs
@@ -9,7 +9,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "0.0.0", note = "use image_filters::compose")]
+#[deprecated(since = "0.19.0", note = "use image_filters::compose")]
 pub fn new(outer: ImageFilter, inner: ImageFilter) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
         sb::C_SkComposeImageFilter_Make(outer.into_ptr(), inner.into_ptr())

--- a/skia-safe/src/effects/displacement_map_effect.rs
+++ b/skia-safe/src/effects/displacement_map_effect.rs
@@ -15,7 +15,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "m78", note = "use skia_safe::ColorChannel")]
+#[deprecated(since = "0.0.0", note = "use skia_safe::ColorChannel")]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
 pub enum ChannelSelector {
@@ -34,7 +34,7 @@ fn test_channel_selector_type_layout() {
     ChannelSelector::test_layout();
 }
 
-#[deprecated(since = "m78", note = "use color_filters::displacement_map")]
+#[deprecated(since = "0.0.0", note = "use color_filters::displacement_map")]
 #[allow(deprecated)]
 pub fn new<'a>(
     (x_channel_selector, y_channel_selector): (ChannelSelector, ChannelSelector),

--- a/skia-safe/src/effects/displacement_map_effect.rs
+++ b/skia-safe/src/effects/displacement_map_effect.rs
@@ -15,6 +15,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
+#[deprecated(since = "m78", note = "use skia_safe::ColorChannel")]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
 pub enum ChannelSelector {
@@ -31,6 +32,7 @@ fn test_channel_selector_type_layout() {
     ChannelSelector::test_layout();
 }
 
+#[deprecated(since = "m78", note = "use color_filters::displacement_map")]
 pub fn new<'a>(
     (x_channel_selector, y_channel_selector): (ChannelSelector, ChannelSelector),
     scale: scalar,

--- a/skia-safe/src/effects/displacement_map_effect.rs
+++ b/skia-safe/src/effects/displacement_map_effect.rs
@@ -1,17 +1,17 @@
 use crate::prelude::*;
-use crate::{image_filter::CropRect, scalar, ImageFilter};
+use crate::{image_filter::CropRect, image_filters, scalar, ColorChannel, IRect, ImageFilter};
 use skia_bindings as sb;
 use skia_bindings::{SkDisplacementMapEffect_ChannelSelectorType, SkImageFilter};
 
 impl RCHandle<SkImageFilter> {
     pub fn displacement_map_effect<'a>(
-        channel_selectors: (ChannelSelector, ChannelSelector),
+        channel_selectors: (ColorChannel, ColorChannel),
         scale: scalar,
         displacement: ImageFilter,
         color: ImageFilter,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
     ) -> Option<Self> {
-        new(channel_selectors, scale, displacement, color, crop_rect)
+        image_filters::displacement_map(channel_selectors, scale, displacement, color, crop_rect)
     }
 }
 
@@ -26,13 +26,16 @@ pub enum ChannelSelector {
     A = SkDisplacementMapEffect_ChannelSelectorType::kA_ChannelSelectorType as _,
 }
 
+#[allow(deprecated)]
 impl NativeTransmutable<SkDisplacementMapEffect_ChannelSelectorType> for ChannelSelector {}
 #[test]
+#[allow(deprecated)]
 fn test_channel_selector_type_layout() {
     ChannelSelector::test_layout();
 }
 
 #[deprecated(since = "m78", note = "use color_filters::displacement_map")]
+#[allow(deprecated)]
 pub fn new<'a>(
     (x_channel_selector, y_channel_selector): (ChannelSelector, ChannelSelector),
     scale: scalar,

--- a/skia-safe/src/effects/displacement_map_effect.rs
+++ b/skia-safe/src/effects/displacement_map_effect.rs
@@ -15,7 +15,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "0.0.0", note = "use skia_safe::ColorChannel")]
+#[deprecated(since = "0.19.0", note = "use skia_safe::ColorChannel")]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
 pub enum ChannelSelector {
@@ -34,7 +34,7 @@ fn test_channel_selector_type_layout() {
     ChannelSelector::test_layout();
 }
 
-#[deprecated(since = "0.0.0", note = "use color_filters::displacement_map")]
+#[deprecated(since = "0.19.0", note = "use color_filters::displacement_map")]
 #[allow(deprecated)]
 pub fn new<'a>(
     (x_channel_selector, y_channel_selector): (ChannelSelector, ChannelSelector),

--- a/skia-safe/src/effects/drop_shadow_image_filter.rs
+++ b/skia-safe/src/effects/drop_shadow_image_filter.rs
@@ -30,6 +30,10 @@ fn test_shadow_mode_layout() {
     ShadowMode::test_layout();
 }
 
+#[deprecated(
+    since = "m78",
+    note = "use color_filters::drop_shadow & color_filters::drop_shadow_only"
+)]
 pub fn new<'a>(
     delta: impl Into<Vector>,
     (sigma_x, sigma_y): (scalar, scalar),

--- a/skia-safe/src/effects/drop_shadow_image_filter.rs
+++ b/skia-safe/src/effects/drop_shadow_image_filter.rs
@@ -38,7 +38,7 @@ fn test_shadow_mode_layout() {
 }
 
 #[deprecated(
-    since = "m78",
+    since = "0.0.0",
     note = "use color_filters::drop_shadow & color_filters::drop_shadow_only"
 )]
 pub fn new<'a>(

--- a/skia-safe/src/effects/drop_shadow_image_filter.rs
+++ b/skia-safe/src/effects/drop_shadow_image_filter.rs
@@ -1,18 +1,25 @@
 use crate::prelude::*;
-use crate::{image_filter::CropRect, scalar, Color, ImageFilter, Vector};
+use crate::{image_filter::CropRect, image_filters, scalar, Color, IRect, ImageFilter, Vector};
 use skia_bindings as sb;
 use skia_bindings::{SkDropShadowImageFilter_ShadowMode, SkImageFilter};
 
 impl RCHandle<SkImageFilter> {
     pub fn drop_shadow<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         delta: impl Into<Vector>,
         sigma: (scalar, scalar),
         color: impl Into<Color>,
         shadow_mode: ShadowMode,
     ) -> Option<Self> {
-        new(delta, sigma, color, shadow_mode, self, crop_rect)
+        match shadow_mode {
+            ShadowMode::DrawShadowAndForeground => {
+                image_filters::drop_shadow(delta, sigma, color, self, crop_rect)
+            }
+            ShadowMode::DrawShadowOnly => {
+                image_filters::drop_shadow_only(delta, sigma, color, self, crop_rect)
+            }
+        }
     }
 }
 

--- a/skia-safe/src/effects/drop_shadow_image_filter.rs
+++ b/skia-safe/src/effects/drop_shadow_image_filter.rs
@@ -38,7 +38,7 @@ fn test_shadow_mode_layout() {
 }
 
 #[deprecated(
-    since = "0.0.0",
+    since = "0.19.0",
     note = "use color_filters::drop_shadow & color_filters::drop_shadow_only"
 )]
 pub fn new<'a>(

--- a/skia-safe/src/effects/image_filters.rs
+++ b/skia-safe/src/effects/image_filters.rs
@@ -1,0 +1,482 @@
+use crate::prelude::*;
+use crate::{
+    scalar, BlendMode, Color, ColorChannel, ColorFilter, FilterQuality, IPoint, IRect, ISize,
+    Image, ImageFilter, Matrix, Paint, Picture, Point3, Rect, Region, TileMode, Vector,
+};
+use skia_bindings as sb;
+use skia_bindings::SkImageFilter;
+
+pub fn alpha_threshold<'a>(
+    region: &Region,
+    inner_min: scalar,
+    outer_max: scalar,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_AlphaThreshold(
+            region.native(),
+            inner_min,
+            outer_max,
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn arithmetic<'a>(
+    k1: scalar,
+    k2: scalar,
+    k3: scalar,
+    k4: scalar,
+    enforce_pm_color: bool,
+    background: ImageFilter,
+    foreground: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Arithmetic(
+            k1,
+            k2,
+            k3,
+            k4,
+            enforce_pm_color,
+            background.into_ptr(),
+            foreground.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn blur<'a>(
+    (sigma_x, sigma_y): (scalar, scalar),
+    tile_mode: impl Into<Option<TileMode>>,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Blur(
+            sigma_x,
+            sigma_y,
+            tile_mode.into().unwrap_or(TileMode::Decal).into_native(),
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn color_filter<'a>(
+    cf: ColorFilter,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_ColorFilter(
+            cf.into_ptr(),
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn compose(outer: ImageFilter, inner: ImageFilter) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Compose(outer.into_ptr(), inner.into_ptr())
+    })
+}
+
+pub fn displacement_map<'a>(
+    (x_channel_selector, y_channel_selector): (ColorChannel, ColorChannel),
+    scale: scalar,
+    displacement: ImageFilter,
+    color: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_DisplacementMap(
+            x_channel_selector.into_native(),
+            y_channel_selector.into_native(),
+            scale,
+            displacement.into_ptr(),
+            color.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn drop_shadow<'a>(
+    delta: impl Into<Vector>,
+    (sigma_x, sigma_y): (scalar, scalar),
+    color: impl Into<Color>,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    let delta = delta.into();
+    let color = color.into();
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_DropShadow(
+            delta.x,
+            delta.y,
+            sigma_x,
+            sigma_y,
+            color.into_native(),
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn drop_shadow_only<'a>(
+    delta: impl Into<Vector>,
+    (sigma_x, sigma_y): (scalar, scalar),
+    color: impl Into<Color>,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    let delta = delta.into();
+    let color = color.into();
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_DropShadowOnly(
+            delta.x,
+            delta.y,
+            sigma_x,
+            sigma_y,
+            color.into_native(),
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn image<'a>(
+    image: Image,
+    src_rect: impl Into<Option<&'a Rect>>,
+    dst_rect: impl Into<Option<&'a Rect>>,
+    filter_quality: impl Into<Option<FilterQuality>>,
+) -> Option<ImageFilter> {
+    let image_rect = Rect::from_iwh(image.width(), image.height());
+    let src_rect = src_rect.into().unwrap_or(&image_rect);
+    let dst_rect = dst_rect.into().unwrap_or(&image_rect);
+    let filter_quality = filter_quality.into().unwrap_or(FilterQuality::High);
+
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Image(
+            image.into_ptr(),
+            src_rect.as_ref().native(),
+            dst_rect.as_ref().native(),
+            filter_quality.into_native(),
+        )
+    })
+}
+
+pub fn magnifier<'a>(
+    src_rect: impl AsRef<Rect>,
+    inset: scalar,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Magnifier(
+            src_rect.as_ref().native(),
+            inset,
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn matrix_convolution<'a>(
+    kernel_size: impl Into<ISize>,
+    kernel: &[scalar],
+    gain: scalar,
+    bias: scalar,
+    kernel_offset: impl Into<IPoint>,
+    tile_mode: TileMode,
+    convolve_alpha: bool,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    let kernel_size = kernel_size.into();
+    assert_eq!(
+        (kernel_size.width * kernel_size.height) as usize,
+        kernel.len()
+    );
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_MatrixConvolution(
+            kernel_size.native(),
+            kernel.as_ptr(),
+            gain,
+            bias,
+            kernel_offset.into().native(),
+            tile_mode.into_native(),
+            convolve_alpha,
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn matrix_transform(
+    matrix: &Matrix,
+    filter_quality: FilterQuality,
+    input: ImageFilter,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_MatrixTransform(
+            matrix.native(),
+            filter_quality.into_native(),
+            input.into_ptr(),
+        )
+    })
+}
+
+#[allow(clippy::new_ret_no_self)]
+pub fn merge<'a>(
+    filters: impl IntoIterator<Item = ImageFilter>,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    let filter_ptrs: Vec<*mut SkImageFilter> = filters.into_iter().map(|f| f.into_ptr()).collect();
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Merge(
+            filter_ptrs.as_ptr(),
+            filter_ptrs.len().try_into().unwrap(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn offset<'a>(
+    delta: impl Into<Vector>,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    let delta = delta.into();
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Offset(
+            delta.x,
+            delta.y,
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn paint<'a>(paint: &Paint, crop_rect: impl Into<Option<&'a IRect>>) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Paint(paint.native(), crop_rect.into().native_ptr_or_null())
+    })
+}
+
+pub fn picture<'a>(
+    picture: Picture,
+    target_rect: impl Into<Option<&'a Rect>>,
+) -> Option<ImageFilter> {
+    let picture_rect = picture.cull_rect();
+    let target_rect = target_rect.into().unwrap_or(&picture_rect);
+
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Picture(picture.into_ptr(), target_rect.native())
+    })
+}
+
+pub fn tile(
+    src: impl AsRef<Rect>,
+    dst: impl AsRef<Rect>,
+    input: ImageFilter,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Tile(
+            src.as_ref().native(),
+            dst.as_ref().native(),
+            input.into_ptr(),
+        )
+    })
+}
+
+pub fn xfermode<'a>(
+    blend_mode: BlendMode,
+    background: ImageFilter,
+    foreground: impl Into<Option<ImageFilter>>,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Xfermode(
+            blend_mode.into_native(),
+            background.into_ptr(),
+            foreground.into().into_ptr_or_null(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn dilate<'a>(
+    (radius_x, radius_y): (i32, i32),
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Dilate(
+            radius_x,
+            radius_y,
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn erode<'a>(
+    (radius_x, radius_y): (i32, i32),
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_Erode(
+            radius_x,
+            radius_y,
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn distant_lit_diffuse<'a>(
+    direction: impl Into<Point3>,
+    light_color: impl Into<Color>,
+    surface_scale: scalar,
+    kd: scalar,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_DistantLitDiffuse(
+            direction.into().native(),
+            light_color.into().into_native(),
+            surface_scale,
+            kd,
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn point_lit_diffuse<'a>(
+    location: impl Into<Point3>,
+    light_color: impl Into<Color>,
+    surface_scale: scalar,
+    kd: scalar,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_PointLitDiffuse(
+            location.into().native(),
+            light_color.into().into_native(),
+            surface_scale,
+            kd,
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn spot_lit_diffuse<'a>(
+    location: impl Into<Point3>,
+    target: impl Into<Point3>,
+    specular_exponent: scalar,
+    cutoff_angle: scalar,
+    light_color: impl Into<Color>,
+    surface_scale: scalar,
+    kd: scalar,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_SpotLitDiffuse(
+            location.into().native(),
+            target.into().native(),
+            specular_exponent,
+            cutoff_angle,
+            light_color.into().into_native(),
+            surface_scale,
+            kd,
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn distant_lit_specular<'a>(
+    direction: impl Into<Point3>,
+    light_color: impl Into<Color>,
+    surface_scale: scalar,
+    ks: scalar,
+    shininess: scalar,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_ImageFilters_DistantLitSpecular(
+            direction.into().native(),
+            light_color.into().into_native(),
+            surface_scale,
+            ks,
+            shininess,
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+pub fn point_lit_specular<'a>(
+    location: impl Into<Point3>,
+    light_color: impl Into<Color>,
+    surface_scale: scalar,
+    ks: scalar,
+    shininess: scalar,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_PointLitSpecular(
+            location.into().native(),
+            light_color.into().into_native(),
+            surface_scale,
+            ks,
+            shininess,
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn spot_lit_specular<'a>(
+    location: impl Into<Point3>,
+    target: impl Into<Point3>,
+    specular_exponent: scalar,
+    cutoff_angle: scalar,
+    light_color: impl Into<Color>,
+    surface_scale: scalar,
+    ks: scalar,
+    shininess: scalar,
+    input: ImageFilter,
+    crop_rect: impl Into<Option<&'a IRect>>,
+) -> Option<ImageFilter> {
+    ImageFilter::from_ptr(unsafe {
+        sb::C_SkImageFilters_SpotLitSpecular(
+            location.into().native(),
+            target.into().native(),
+            specular_exponent,
+            cutoff_angle,
+            light_color.into().into_native(),
+            surface_scale,
+            ks,
+            shininess,
+            input.into_ptr(),
+            crop_rect.into().native_ptr_or_null(),
+        )
+    })
+}

--- a/skia-safe/src/effects/image_source.rs
+++ b/skia-safe/src/effects/image_source.rs
@@ -47,12 +47,12 @@ impl RCHandle<SkImage> {
     }
 }
 
-#[deprecated(since = "m78", note = "use color_filters::image")]
+#[deprecated(since = "0.0.0", note = "use color_filters::image")]
 pub fn from_image(image: Image) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe { sb::C_SkImageSource_Make(image.into_ptr()) })
 }
 
-#[deprecated(since = "m78", note = "use color_filters::image")]
+#[deprecated(since = "0.0.0", note = "use color_filters::image")]
 pub fn from_image_rect(
     image: Image,
     src_rect: impl AsRef<Rect>,

--- a/skia-safe/src/effects/image_source.rs
+++ b/skia-safe/src/effects/image_source.rs
@@ -1,11 +1,11 @@
 use crate::prelude::*;
-use crate::{FilterQuality, Image, ImageFilter, Rect};
+use crate::{image_filters, FilterQuality, Image, ImageFilter, Rect};
 use skia_bindings as sb;
 use skia_bindings::{SkImage, SkImageFilter};
 
 impl RCHandle<SkImageFilter> {
     pub fn from_image(image: Image) -> Option<Self> {
-        from_image(image)
+        image_filters::image(image, None, None, None)
     }
 
     pub fn from_image_rect(
@@ -14,7 +14,7 @@ impl RCHandle<SkImageFilter> {
         dst_rect: impl AsRef<Rect>,
         filter_quality: FilterQuality,
     ) -> Option<Self> {
-        from_image_rect(image, src_rect, dst_rect, filter_quality)
+        image_filters::image(image, src_rect.as_ref(), dst_rect.as_ref(), filter_quality)
     }
 }
 
@@ -24,7 +24,7 @@ impl RCHandle<SkImage> {
     }
 
     pub fn into_filter(self) -> Option<ImageFilter> {
-        from_image(self)
+        image_filters::image(self, None, None, None)
     }
 
     pub fn as_filter_rect(
@@ -43,7 +43,7 @@ impl RCHandle<SkImage> {
         dst_rect: impl AsRef<Rect>,
         filter_quality: FilterQuality,
     ) -> Option<ImageFilter> {
-        from_image_rect(self, src_rect, dst_rect, filter_quality)
+        image_filters::image(self, src_rect.as_ref(), dst_rect.as_ref(), filter_quality)
     }
 }
 

--- a/skia-safe/src/effects/image_source.rs
+++ b/skia-safe/src/effects/image_source.rs
@@ -47,10 +47,12 @@ impl RCHandle<SkImage> {
     }
 }
 
+#[deprecated(since = "m78", note = "use color_filters::image")]
 pub fn from_image(image: Image) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe { sb::C_SkImageSource_Make(image.into_ptr()) })
 }
 
+#[deprecated(since = "m78", note = "use color_filters::image")]
 pub fn from_image_rect(
     image: Image,
     src_rect: impl AsRef<Rect>,

--- a/skia-safe/src/effects/image_source.rs
+++ b/skia-safe/src/effects/image_source.rs
@@ -47,12 +47,12 @@ impl RCHandle<SkImage> {
     }
 }
 
-#[deprecated(since = "0.0.0", note = "use color_filters::image")]
+#[deprecated(since = "0.19.0", note = "use color_filters::image")]
 pub fn from_image(image: Image) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe { sb::C_SkImageSource_Make(image.into_ptr()) })
 }
 
-#[deprecated(since = "0.0.0", note = "use color_filters::image")]
+#[deprecated(since = "0.19.0", note = "use color_filters::image")]
 pub fn from_image_rect(
     image: Image,
     src_rect: impl AsRef<Rect>,

--- a/skia-safe/src/effects/lighting_image_filter.rs
+++ b/skia-safe/src/effects/lighting_image_filter.rs
@@ -126,7 +126,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "m78", note = "use color_filters::distant_lit_diffuse")]
+#[deprecated(since = "0.0.0", note = "use color_filters::distant_lit_diffuse")]
 pub fn distant_lit_diffuse<'a>(
     direction: impl Into<Point3>,
     light_color: impl Into<Color>,
@@ -147,7 +147,7 @@ pub fn distant_lit_diffuse<'a>(
     })
 }
 
-#[deprecated(since = "m78", note = "use color_filters::point_lit_diffuse")]
+#[deprecated(since = "0.0.0", note = "use color_filters::point_lit_diffuse")]
 pub fn point_lit_diffuse<'a>(
     location: impl Into<Point3>,
     light_color: impl Into<Color>,
@@ -168,7 +168,7 @@ pub fn point_lit_diffuse<'a>(
     })
 }
 
-#[deprecated(since = "m78", note = "use color_filters::spot_lit_diffuse")]
+#[deprecated(since = "0.0.0", note = "use color_filters::spot_lit_diffuse")]
 #[allow(clippy::too_many_arguments)]
 pub fn spot_lit_diffuse<'a>(
     location: impl Into<Point3>,
@@ -196,7 +196,7 @@ pub fn spot_lit_diffuse<'a>(
     })
 }
 
-#[deprecated(since = "m78", note = "use color_filters::distant_lit_specular")]
+#[deprecated(since = "0.0.0", note = "use color_filters::distant_lit_specular")]
 pub fn distant_lit_specular<'a>(
     direction: impl Into<Point3>,
     light_color: impl Into<Color>,
@@ -219,7 +219,7 @@ pub fn distant_lit_specular<'a>(
     })
 }
 
-#[deprecated(since = "m78", note = "use color_filters::point_lit_specular")]
+#[deprecated(since = "0.0.0", note = "use color_filters::point_lit_specular")]
 pub fn point_lit_specular<'a>(
     location: impl Into<Point3>,
     light_color: impl Into<Color>,
@@ -242,7 +242,7 @@ pub fn point_lit_specular<'a>(
     })
 }
 
-#[deprecated(since = "m78", note = "use color_filters::spot_lit_specular")]
+#[deprecated(since = "0.0.0", note = "use color_filters::spot_lit_specular")]
 #[allow(clippy::too_many_arguments)]
 pub fn spot_lit_specular<'a>(
     location: impl Into<Point3>,

--- a/skia-safe/src/effects/lighting_image_filter.rs
+++ b/skia-safe/src/effects/lighting_image_filter.rs
@@ -119,6 +119,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
+#[deprecated(since = "m78", note = "use color_filters::distant_lit_diffuse")]
 pub fn distant_lit_diffuse<'a>(
     direction: impl Into<Point3>,
     light_color: impl Into<Color>,
@@ -139,6 +140,7 @@ pub fn distant_lit_diffuse<'a>(
     })
 }
 
+#[deprecated(since = "m78", note = "use color_filters::point_lit_diffuse")]
 pub fn point_lit_diffuse<'a>(
     location: impl Into<Point3>,
     light_color: impl Into<Color>,
@@ -159,6 +161,7 @@ pub fn point_lit_diffuse<'a>(
     })
 }
 
+#[deprecated(since = "m78", note = "use color_filters::spot_lit_diffuse")]
 #[allow(clippy::too_many_arguments)]
 pub fn spot_lit_diffuse<'a>(
     location: impl Into<Point3>,
@@ -186,6 +189,7 @@ pub fn spot_lit_diffuse<'a>(
     })
 }
 
+#[deprecated(since = "m78", note = "use color_filters::distant_lit_specular")]
 pub fn distant_lit_specular<'a>(
     direction: impl Into<Point3>,
     light_color: impl Into<Color>,
@@ -208,6 +212,7 @@ pub fn distant_lit_specular<'a>(
     })
 }
 
+#[deprecated(since = "m78", note = "use color_filters::point_lit_specular")]
 pub fn point_lit_specular<'a>(
     location: impl Into<Point3>,
     light_color: impl Into<Color>,
@@ -230,6 +235,7 @@ pub fn point_lit_specular<'a>(
     })
 }
 
+#[deprecated(since = "m78", note = "use color_filters::spot_lit_specular")]
 #[allow(clippy::too_many_arguments)]
 pub fn spot_lit_specular<'a>(
     location: impl Into<Point3>,

--- a/skia-safe/src/effects/lighting_image_filter.rs
+++ b/skia-safe/src/effects/lighting_image_filter.rs
@@ -1,35 +1,42 @@
 use crate::prelude::*;
-use crate::{image_filter::CropRect, scalar, Color, ImageFilter, Point3};
+use crate::{image_filter::CropRect, image_filters, scalar, Color, IRect, ImageFilter, Point3};
 use skia_bindings as sb;
 use skia_bindings::SkImageFilter;
 
 impl RCHandle<SkImageFilter> {
     pub fn distant_lit_diffuse_lighting<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         direction: impl Into<Point3>,
         light_color: impl Into<Color>,
         surface_scale: scalar,
         kd: scalar,
     ) -> Option<Self> {
-        distant_lit_diffuse(direction, light_color, surface_scale, kd, self, crop_rect)
+        image_filters::distant_lit_diffuse(
+            direction,
+            light_color,
+            surface_scale,
+            kd,
+            self,
+            crop_rect,
+        )
     }
 
     pub fn point_lit_diffuse_lighting<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         location: impl Into<Point3>,
         light_color: impl Into<Color>,
         surface_scale: scalar,
         kd: scalar,
     ) -> Option<Self> {
-        point_lit_diffuse(location, light_color, surface_scale, kd, self, crop_rect)
+        image_filters::point_lit_diffuse(location, light_color, surface_scale, kd, self, crop_rect)
     }
 
     #[allow(clippy::too_many_arguments)]
     pub fn spot_lit_diffuse_lighting<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         location: impl Into<Point3>,
         target: impl Into<Point3>,
         specular_exponent: scalar,
@@ -38,7 +45,7 @@ impl RCHandle<SkImageFilter> {
         surface_scale: scalar,
         kd: scalar,
     ) -> Option<Self> {
-        spot_lit_diffuse(
+        image_filters::spot_lit_diffuse(
             location,
             target,
             specular_exponent,
@@ -53,14 +60,14 @@ impl RCHandle<SkImageFilter> {
 
     pub fn distant_lit_specular_lighting<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         direction: impl Into<Point3>,
         light_color: impl Into<Color>,
         surface_scale: scalar,
         ks: scalar,
         shininess: scalar,
     ) -> Option<Self> {
-        distant_lit_specular(
+        image_filters::distant_lit_specular(
             direction,
             light_color,
             surface_scale,
@@ -73,14 +80,14 @@ impl RCHandle<SkImageFilter> {
 
     pub fn point_lit_specular_lighting<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         location: impl Into<Point3>,
         light_color: impl Into<Color>,
         surface_scale: scalar,
         ks: scalar,
         shininess: scalar,
     ) -> Option<Self> {
-        point_lit_specular(
+        image_filters::point_lit_specular(
             location,
             light_color,
             surface_scale,
@@ -94,7 +101,7 @@ impl RCHandle<SkImageFilter> {
     #[allow(clippy::too_many_arguments)]
     pub fn spot_lit_specular_lighting<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         location: impl Into<Point3>,
         target: impl Into<Point3>,
         specular_exponent: scalar,
@@ -104,7 +111,7 @@ impl RCHandle<SkImageFilter> {
         ks: scalar,
         shininess: scalar,
     ) -> Option<Self> {
-        spot_lit_specular(
+        image_filters::spot_lit_specular(
             location,
             target,
             specular_exponent,

--- a/skia-safe/src/effects/lighting_image_filter.rs
+++ b/skia-safe/src/effects/lighting_image_filter.rs
@@ -126,7 +126,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "0.0.0", note = "use color_filters::distant_lit_diffuse")]
+#[deprecated(since = "0.19.0", note = "use color_filters::distant_lit_diffuse")]
 pub fn distant_lit_diffuse<'a>(
     direction: impl Into<Point3>,
     light_color: impl Into<Color>,
@@ -147,7 +147,7 @@ pub fn distant_lit_diffuse<'a>(
     })
 }
 
-#[deprecated(since = "0.0.0", note = "use color_filters::point_lit_diffuse")]
+#[deprecated(since = "0.19.0", note = "use color_filters::point_lit_diffuse")]
 pub fn point_lit_diffuse<'a>(
     location: impl Into<Point3>,
     light_color: impl Into<Color>,
@@ -168,7 +168,7 @@ pub fn point_lit_diffuse<'a>(
     })
 }
 
-#[deprecated(since = "0.0.0", note = "use color_filters::spot_lit_diffuse")]
+#[deprecated(since = "0.19.0", note = "use color_filters::spot_lit_diffuse")]
 #[allow(clippy::too_many_arguments)]
 pub fn spot_lit_diffuse<'a>(
     location: impl Into<Point3>,
@@ -196,7 +196,7 @@ pub fn spot_lit_diffuse<'a>(
     })
 }
 
-#[deprecated(since = "0.0.0", note = "use color_filters::distant_lit_specular")]
+#[deprecated(since = "0.19.0", note = "use color_filters::distant_lit_specular")]
 pub fn distant_lit_specular<'a>(
     direction: impl Into<Point3>,
     light_color: impl Into<Color>,
@@ -219,7 +219,7 @@ pub fn distant_lit_specular<'a>(
     })
 }
 
-#[deprecated(since = "0.0.0", note = "use color_filters::point_lit_specular")]
+#[deprecated(since = "0.19.0", note = "use color_filters::point_lit_specular")]
 pub fn point_lit_specular<'a>(
     location: impl Into<Point3>,
     light_color: impl Into<Color>,
@@ -242,7 +242,7 @@ pub fn point_lit_specular<'a>(
     })
 }
 
-#[deprecated(since = "0.0.0", note = "use color_filters::spot_lit_specular")]
+#[deprecated(since = "0.19.0", note = "use color_filters::spot_lit_specular")]
 #[allow(clippy::too_many_arguments)]
 pub fn spot_lit_specular<'a>(
     location: impl Into<Point3>,

--- a/skia-safe/src/effects/magnifier_image_filter.rs
+++ b/skia-safe/src/effects/magnifier_image_filter.rs
@@ -14,7 +14,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "m78", note = "use color_filters::magnifier")]
+#[deprecated(since = "0.0.0", note = "use color_filters::magnifier")]
 pub fn new<'a>(
     src_rect: impl AsRef<Rect>,
     inset: scalar,

--- a/skia-safe/src/effects/magnifier_image_filter.rs
+++ b/skia-safe/src/effects/magnifier_image_filter.rs
@@ -14,6 +14,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
+#[deprecated(since = "m78", note = "use color_filters::magnifier")]
 pub fn new<'a>(
     src_rect: impl AsRef<Rect>,
     inset: scalar,

--- a/skia-safe/src/effects/magnifier_image_filter.rs
+++ b/skia-safe/src/effects/magnifier_image_filter.rs
@@ -1,16 +1,16 @@
 use crate::prelude::*;
-use crate::{image_filter::CropRect, scalar, ImageFilter, Rect};
+use crate::{image_filter::CropRect, image_filters, scalar, IRect, ImageFilter, Rect};
 use skia_bindings as sb;
 use skia_bindings::SkImageFilter;
 
 impl RCHandle<SkImageFilter> {
     pub fn magnifier<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         src_rect: impl AsRef<Rect>,
         inset: scalar,
     ) -> Option<Self> {
-        new(src_rect, inset, self, crop_rect)
+        image_filters::magnifier(src_rect, inset, self, crop_rect)
     }
 }
 

--- a/skia-safe/src/effects/magnifier_image_filter.rs
+++ b/skia-safe/src/effects/magnifier_image_filter.rs
@@ -14,7 +14,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "0.0.0", note = "use color_filters::magnifier")]
+#[deprecated(since = "0.19.0", note = "use color_filters::magnifier")]
 pub fn new<'a>(
     src_rect: impl AsRef<Rect>,
     inset: scalar,

--- a/skia-safe/src/effects/matrix_convolution_image_filter.rs
+++ b/skia-safe/src/effects/matrix_convolution_image_filter.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use crate::{image_filter::CropRect, scalar, IPoint, ISize, ImageFilter};
+use crate::{image_filter::CropRect, image_filters, scalar, IPoint, IRect, ISize, ImageFilter};
 use skia_bindings as sb;
 use skia_bindings::{SkImageFilter, SkMatrixConvolutionImageFilter_TileMode};
 
@@ -7,16 +7,16 @@ impl RCHandle<SkImageFilter> {
     #[allow(clippy::too_many_arguments)]
     pub fn matrix_convolution<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         kernel_size: impl Into<ISize>,
         kernel: &[scalar],
         gain: scalar,
         bias: scalar,
         kernel_offset: impl Into<IPoint>,
-        tile_mode: TileMode,
+        tile_mode: crate::TileMode,
         convolve_alpha: bool,
     ) -> Option<Self> {
-        new(
+        image_filters::matrix_convolution(
             kernel_size,
             kernel,
             gain,
@@ -39,6 +39,7 @@ pub enum TileMode {
     ClampToBlack = SkMatrixConvolutionImageFilter_TileMode::kClampToBlack_TileMode as _,
 }
 
+#[allow(deprecated)]
 impl NativeTransmutable<SkMatrixConvolutionImageFilter_TileMode> for TileMode {}
 #[test]
 fn test_tile_mode_layout() {
@@ -46,6 +47,7 @@ fn test_tile_mode_layout() {
 }
 
 #[deprecated(since = "m78", note = "use color_filters::matrix_convolution")]
+#[allow(deprecated)]
 #[allow(clippy::too_many_arguments)]
 pub fn new<'a>(
     kernel_size: impl Into<ISize>,

--- a/skia-safe/src/effects/matrix_convolution_image_filter.rs
+++ b/skia-safe/src/effects/matrix_convolution_image_filter.rs
@@ -42,6 +42,7 @@ pub enum TileMode {
 #[allow(deprecated)]
 impl NativeTransmutable<SkMatrixConvolutionImageFilter_TileMode> for TileMode {}
 #[test]
+#[allow(deprecated)]
 fn test_tile_mode_layout() {
     TileMode::test_layout();
 }

--- a/skia-safe/src/effects/matrix_convolution_image_filter.rs
+++ b/skia-safe/src/effects/matrix_convolution_image_filter.rs
@@ -30,6 +30,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
+#[deprecated(since = "m78", note = "use skia_safe::TileMode")]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
 pub enum TileMode {
@@ -44,6 +45,7 @@ fn test_tile_mode_layout() {
     TileMode::test_layout();
 }
 
+#[deprecated(since = "m78", note = "use color_filters::matrix_convolution")]
 #[allow(clippy::too_many_arguments)]
 pub fn new<'a>(
     kernel_size: impl Into<ISize>,

--- a/skia-safe/src/effects/matrix_convolution_image_filter.rs
+++ b/skia-safe/src/effects/matrix_convolution_image_filter.rs
@@ -30,7 +30,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "m78", note = "use skia_safe::TileMode")]
+#[deprecated(since = "0.0.0", note = "use skia_safe::TileMode")]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
 pub enum TileMode {
@@ -46,7 +46,7 @@ fn test_tile_mode_layout() {
     TileMode::test_layout();
 }
 
-#[deprecated(since = "m78", note = "use color_filters::matrix_convolution")]
+#[deprecated(since = "0.0.0", note = "use color_filters::matrix_convolution")]
 #[allow(deprecated)]
 #[allow(clippy::too_many_arguments)]
 pub fn new<'a>(

--- a/skia-safe/src/effects/matrix_convolution_image_filter.rs
+++ b/skia-safe/src/effects/matrix_convolution_image_filter.rs
@@ -30,7 +30,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "0.0.0", note = "use skia_safe::TileMode")]
+#[deprecated(since = "0.19.0", note = "use skia_safe::TileMode")]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
 pub enum TileMode {
@@ -47,7 +47,7 @@ fn test_tile_mode_layout() {
     TileMode::test_layout();
 }
 
-#[deprecated(since = "0.0.0", note = "use color_filters::matrix_convolution")]
+#[deprecated(since = "0.19.0", note = "use color_filters::matrix_convolution")]
 #[allow(deprecated)]
 #[allow(clippy::too_many_arguments)]
 pub fn new<'a>(

--- a/skia-safe/src/effects/merge_image_filter.rs
+++ b/skia-safe/src/effects/merge_image_filter.rs
@@ -13,6 +13,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
+#[deprecated(since = "m78", note = "use color_filters::merge")]
 #[allow(clippy::new_ret_no_self)]
 pub fn new<'a>(
     filters: impl IntoIterator<Item = ImageFilter>,

--- a/skia-safe/src/effects/merge_image_filter.rs
+++ b/skia-safe/src/effects/merge_image_filter.rs
@@ -13,7 +13,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "m78", note = "use color_filters::merge")]
+#[deprecated(since = "0.0.0", note = "use color_filters::merge")]
 #[allow(clippy::new_ret_no_self)]
 pub fn new<'a>(
     filters: impl IntoIterator<Item = ImageFilter>,

--- a/skia-safe/src/effects/merge_image_filter.rs
+++ b/skia-safe/src/effects/merge_image_filter.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use crate::{image_filter::CropRect, ImageFilter};
+use crate::{image_filter::CropRect, image_filters, IRect, ImageFilter};
 use skia_bindings as sb;
 use skia_bindings::SkImageFilter;
 use std::convert::TryInto;
@@ -7,9 +7,9 @@ use std::convert::TryInto;
 impl RCHandle<SkImageFilter> {
     pub fn merge<'a>(
         filters: impl IntoIterator<Item = Self>,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
     ) -> Option<Self> {
-        new(filters, crop_rect)
+        image_filters::merge(filters, crop_rect)
     }
 }
 

--- a/skia-safe/src/effects/merge_image_filter.rs
+++ b/skia-safe/src/effects/merge_image_filter.rs
@@ -13,7 +13,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "0.0.0", note = "use color_filters::merge")]
+#[deprecated(since = "0.19.0", note = "use color_filters::merge")]
 #[allow(clippy::new_ret_no_self)]
 pub fn new<'a>(
     filters: impl IntoIterator<Item = ImageFilter>,

--- a/skia-safe/src/effects/morphology_image_filter.rs
+++ b/skia-safe/src/effects/morphology_image_filter.rs
@@ -26,7 +26,7 @@ pub mod dilate_image_filter {
     use crate::ImageFilter;
     use skia_bindings as sb;
 
-    #[deprecated(since = "m78", note = "use color_filters::dilate")]
+    #[deprecated(since = "0.0.0", note = "use color_filters::dilate")]
     pub fn new<'a>(
         (radius_x, radius_y): (i32, i32),
         input: ImageFilter,
@@ -49,7 +49,7 @@ pub mod erode_image_filter {
     use crate::ImageFilter;
     use skia_bindings as sb;
 
-    #[deprecated(since = "m78", note = "use color_filters::erode")]
+    #[deprecated(since = "0.0.0", note = "use color_filters::erode")]
     pub fn new<'a>(
         (radius_x, radius_y): (i32, i32),
         input: ImageFilter,

--- a/skia-safe/src/effects/morphology_image_filter.rs
+++ b/skia-safe/src/effects/morphology_image_filter.rs
@@ -1,22 +1,22 @@
-use crate::image_filter::CropRect;
 use crate::prelude::*;
+use crate::{image_filters, IRect};
 use skia_bindings::SkImageFilter;
 
 impl RCHandle<SkImageFilter> {
     pub fn dilate<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         radii: (i32, i32),
     ) -> Option<Self> {
-        dilate_image_filter::new(radii, self, crop_rect)
+        image_filters::dilate(radii, self, crop_rect)
     }
 
     pub fn erode<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         radii: (i32, i32),
     ) -> Option<Self> {
-        erode_image_filter::new(radii, self, crop_rect)
+        image_filters::erode(radii, self, crop_rect)
     }
 }
 

--- a/skia-safe/src/effects/morphology_image_filter.rs
+++ b/skia-safe/src/effects/morphology_image_filter.rs
@@ -26,6 +26,7 @@ pub mod dilate_image_filter {
     use crate::ImageFilter;
     use skia_bindings as sb;
 
+    #[deprecated(since = "m78", note = "use color_filters::dilate")]
     pub fn new<'a>(
         (radius_x, radius_y): (i32, i32),
         input: ImageFilter,
@@ -48,6 +49,7 @@ pub mod erode_image_filter {
     use crate::ImageFilter;
     use skia_bindings as sb;
 
+    #[deprecated(since = "m78", note = "use color_filters::erode")]
     pub fn new<'a>(
         (radius_x, radius_y): (i32, i32),
         input: ImageFilter,

--- a/skia-safe/src/effects/morphology_image_filter.rs
+++ b/skia-safe/src/effects/morphology_image_filter.rs
@@ -26,7 +26,7 @@ pub mod dilate_image_filter {
     use crate::ImageFilter;
     use skia_bindings as sb;
 
-    #[deprecated(since = "0.0.0", note = "use color_filters::dilate")]
+    #[deprecated(since = "0.19.0", note = "use color_filters::dilate")]
     pub fn new<'a>(
         (radius_x, radius_y): (i32, i32),
         input: ImageFilter,
@@ -49,7 +49,7 @@ pub mod erode_image_filter {
     use crate::ImageFilter;
     use skia_bindings as sb;
 
-    #[deprecated(since = "0.0.0", note = "use color_filters::erode")]
+    #[deprecated(since = "0.19.0", note = "use color_filters::erode")]
     pub fn new<'a>(
         (radius_x, radius_y): (i32, i32),
         input: ImageFilter,

--- a/skia-safe/src/effects/offset_image_filter.rs
+++ b/skia-safe/src/effects/offset_image_filter.rs
@@ -1,15 +1,15 @@
 use crate::prelude::*;
-use crate::{image_filter::CropRect, ImageFilter, Vector};
+use crate::{image_filter::CropRect, image_filters, IRect, ImageFilter, Vector};
 use skia_bindings as sb;
 use skia_bindings::SkImageFilter;
 
 impl RCHandle<SkImageFilter> {
     pub fn offset<'a>(
         self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
         delta: impl Into<Vector>,
     ) -> Option<Self> {
-        new(delta, self, crop_rect)
+        image_filters::offset(delta, self, crop_rect)
     }
 }
 

--- a/skia-safe/src/effects/offset_image_filter.rs
+++ b/skia-safe/src/effects/offset_image_filter.rs
@@ -13,7 +13,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "m78", note = "use color_filters::offset")]
+#[deprecated(since = "0.0.0", note = "use color_filters::offset")]
 pub fn new<'a>(
     delta: impl Into<Vector>,
     input: ImageFilter,

--- a/skia-safe/src/effects/offset_image_filter.rs
+++ b/skia-safe/src/effects/offset_image_filter.rs
@@ -13,6 +13,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
+#[deprecated(since = "m78", note = "use color_filters::offset")]
 pub fn new<'a>(
     delta: impl Into<Vector>,
     input: ImageFilter,

--- a/skia-safe/src/effects/offset_image_filter.rs
+++ b/skia-safe/src/effects/offset_image_filter.rs
@@ -13,7 +13,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "0.0.0", note = "use color_filters::offset")]
+#[deprecated(since = "0.19.0", note = "use color_filters::offset")]
 pub fn new<'a>(
     delta: impl Into<Vector>,
     input: ImageFilter,

--- a/skia-safe/src/effects/paint_image_filter.rs
+++ b/skia-safe/src/effects/paint_image_filter.rs
@@ -18,7 +18,7 @@ impl Handle<SkPaint> {
     }
 }
 
-#[deprecated(since = "m78", note = "use color_filters::paint")]
+#[deprecated(since = "0.0.0", note = "use color_filters::paint")]
 pub fn from_paint<'a>(
     paint: &Paint,
     crop_rect: impl Into<Option<&'a CropRect>>,

--- a/skia-safe/src/effects/paint_image_filter.rs
+++ b/skia-safe/src/effects/paint_image_filter.rs
@@ -1,23 +1,20 @@
 use crate::prelude::*;
-use crate::{image_filter::CropRect, ImageFilter, Paint};
+use crate::{image_filter::CropRect, image_filters, IRect, ImageFilter, Paint};
 use skia_bindings as sb;
 use skia_bindings::{SkImageFilter, SkPaint};
 
 impl RCHandle<SkImageFilter> {
-    pub fn from_paint<'a>(
-        paint: &Paint,
-        crop_rect: impl Into<Option<&'a CropRect>>,
-    ) -> Option<Self> {
-        from_paint(paint, crop_rect)
+    pub fn from_paint<'a>(paint: &Paint, crop_rect: impl Into<Option<&'a IRect>>) -> Option<Self> {
+        image_filters::paint(paint, crop_rect)
     }
 }
 
 impl Handle<SkPaint> {
     pub fn as_image_filter<'a>(
         &self,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
     ) -> Option<ImageFilter> {
-        from_paint(self, crop_rect)
+        image_filters::paint(self, crop_rect)
     }
 }
 

--- a/skia-safe/src/effects/paint_image_filter.rs
+++ b/skia-safe/src/effects/paint_image_filter.rs
@@ -21,6 +21,7 @@ impl Handle<SkPaint> {
     }
 }
 
+#[deprecated(since = "m78", note = "use color_filters::paint")]
 pub fn from_paint<'a>(
     paint: &Paint,
     crop_rect: impl Into<Option<&'a CropRect>>,

--- a/skia-safe/src/effects/paint_image_filter.rs
+++ b/skia-safe/src/effects/paint_image_filter.rs
@@ -18,7 +18,7 @@ impl Handle<SkPaint> {
     }
 }
 
-#[deprecated(since = "0.0.0", note = "use color_filters::paint")]
+#[deprecated(since = "0.19.0", note = "use color_filters::paint")]
 pub fn from_paint<'a>(
     paint: &Paint,
     crop_rect: impl Into<Option<&'a CropRect>>,

--- a/skia-safe/src/effects/picture_image_filter.rs
+++ b/skia-safe/src/effects/picture_image_filter.rs
@@ -28,7 +28,7 @@ impl RCHandle<SkPicture> {
     }
 }
 
-#[deprecated(since = "m78", note = "use color_filters::picture")]
+#[deprecated(since = "0.0.0", note = "use color_filters::picture")]
 pub fn from_picture<'a>(
     picture: Picture,
     target_rect: impl Into<Option<&'a Rect>>,

--- a/skia-safe/src/effects/picture_image_filter.rs
+++ b/skia-safe/src/effects/picture_image_filter.rs
@@ -28,11 +28,12 @@ impl RCHandle<SkPicture> {
     }
 }
 
+#[deprecated(since = "m78", note = "use color_filters::picture")]
 pub fn from_picture<'a>(
     picture: Picture,
-    crop_rect: impl Into<Option<&'a Rect>>,
+    target_rect: impl Into<Option<&'a Rect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
-        sb::C_SkPictureImageFilter_Make(picture.into_ptr(), crop_rect.into().native_ptr_or_null())
+        sb::C_SkPictureImageFilter_Make(picture.into_ptr(), target_rect.into().native_ptr_or_null())
     })
 }

--- a/skia-safe/src/effects/picture_image_filter.rs
+++ b/skia-safe/src/effects/picture_image_filter.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use crate::{ImageFilter, Picture, Rect};
+use crate::{image_filters, ImageFilter, Picture, Rect};
 use skia_bindings as sb;
 use skia_bindings::{SkImageFilter, SkPicture};
 
@@ -8,7 +8,7 @@ impl RCHandle<SkImageFilter> {
         picture: Picture,
         crop_rect: impl Into<Option<&'a Rect>>,
     ) -> Option<Self> {
-        from_picture(picture, crop_rect)
+        image_filters::picture(picture, crop_rect)
     }
 }
 
@@ -24,7 +24,7 @@ impl RCHandle<SkPicture> {
         self,
         crop_rect: impl Into<Option<&'a Rect>>,
     ) -> Option<ImageFilter> {
-        from_picture(self, crop_rect)
+        image_filters::picture(self, crop_rect)
     }
 }
 

--- a/skia-safe/src/effects/picture_image_filter.rs
+++ b/skia-safe/src/effects/picture_image_filter.rs
@@ -28,7 +28,7 @@ impl RCHandle<SkPicture> {
     }
 }
 
-#[deprecated(since = "0.0.0", note = "use color_filters::picture")]
+#[deprecated(since = "0.19.0", note = "use color_filters::picture")]
 pub fn from_picture<'a>(
     picture: Picture,
     target_rect: impl Into<Option<&'a Rect>>,

--- a/skia-safe/src/effects/tile_image_filter.rs
+++ b/skia-safe/src/effects/tile_image_filter.rs
@@ -9,7 +9,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "m78", note = "use color_filters::tile")]
+#[deprecated(since = "0.0.0", note = "use color_filters::tile")]
 pub fn new(
     src: impl AsRef<Rect>,
     dst: impl AsRef<Rect>,

--- a/skia-safe/src/effects/tile_image_filter.rs
+++ b/skia-safe/src/effects/tile_image_filter.rs
@@ -9,6 +9,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
+#[deprecated(since = "m78", note = "use color_filters::tile")]
 pub fn new(
     src: impl AsRef<Rect>,
     dst: impl AsRef<Rect>,

--- a/skia-safe/src/effects/tile_image_filter.rs
+++ b/skia-safe/src/effects/tile_image_filter.rs
@@ -1,11 +1,11 @@
 use crate::prelude::*;
-use crate::{ImageFilter, Rect};
+use crate::{image_filters, ImageFilter, Rect};
 use skia_bindings as sb;
 use skia_bindings::SkImageFilter;
 
 impl RCHandle<SkImageFilter> {
     pub fn tile(self, src: impl AsRef<Rect>, dst: impl AsRef<Rect>) -> Option<Self> {
-        new(src, dst, self)
+        image_filters::tile(src, dst, self)
     }
 }
 

--- a/skia-safe/src/effects/tile_image_filter.rs
+++ b/skia-safe/src/effects/tile_image_filter.rs
@@ -9,7 +9,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "0.0.0", note = "use color_filters::tile")]
+#[deprecated(since = "0.19.0", note = "use color_filters::tile")]
 pub fn new(
     src: impl AsRef<Rect>,
     dst: impl AsRef<Rect>,

--- a/skia-safe/src/effects/xfer_mode_image_filter.rs
+++ b/skia-safe/src/effects/xfer_mode_image_filter.rs
@@ -14,6 +14,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
+#[deprecated(since = "m78", note = "use color_filters::xfermode")]
 pub fn new<'a>(
     blend_mode: BlendMode,
     background: ImageFilter,

--- a/skia-safe/src/effects/xfer_mode_image_filter.rs
+++ b/skia-safe/src/effects/xfer_mode_image_filter.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use crate::{image_filter::CropRect, BlendMode, ImageFilter};
+use crate::{image_filter::CropRect, image_filters, BlendMode, IRect, ImageFilter};
 use skia_bindings as sb;
 use skia_bindings::SkImageFilter;
 
@@ -8,13 +8,13 @@ impl RCHandle<SkImageFilter> {
         blend_mode: BlendMode,
         background: ImageFilter,
         foreground: impl Into<Option<ImageFilter>>,
-        crop_rect: impl Into<Option<&'a CropRect>>,
+        crop_rect: impl Into<Option<&'a IRect>>,
     ) -> Option<Self> {
-        new(blend_mode, background, foreground, crop_rect)
+        image_filters::xfermode(blend_mode, background, foreground, crop_rect)
     }
 }
 
-#[deprecated(since = "m78", note = "use color_filters::xfermode")]
+#[deprecated(since = "m78", note = "use color_filters::xfermode()")]
 pub fn new<'a>(
     blend_mode: BlendMode,
     background: ImageFilter,

--- a/skia-safe/src/effects/xfer_mode_image_filter.rs
+++ b/skia-safe/src/effects/xfer_mode_image_filter.rs
@@ -14,7 +14,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "m78", note = "use color_filters::xfermode()")]
+#[deprecated(since = "0.0.0", note = "use color_filters::xfermode()")]
 pub fn new<'a>(
     blend_mode: BlendMode,
     background: ImageFilter,

--- a/skia-safe/src/effects/xfer_mode_image_filter.rs
+++ b/skia-safe/src/effects/xfer_mode_image_filter.rs
@@ -14,7 +14,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "0.0.0", note = "use color_filters::xfermode()")]
+#[deprecated(since = "0.19.0", note = "use color_filters::xfermode()")]
 pub fn new<'a>(
     blend_mode: BlendMode,
     background: ImageFilter,

--- a/skia-safe/src/gpu/backend_surface.rs
+++ b/skia-safe/src/gpu/backend_surface.rs
@@ -47,6 +47,7 @@ impl Handle<GrBackendFormat> {
         })
     }
 
+    #[deprecated(since = "0.0.0", note = "use backend()")]
     pub fn backend_api(&self) -> BackendAPI {
         BackendAPI::from_native(self.native().fBackend)
     }

--- a/skia-safe/src/gpu/backend_surface.rs
+++ b/skia-safe/src/gpu/backend_surface.rs
@@ -49,38 +49,37 @@ impl Handle<GrBackendFormat> {
 
     #[deprecated(since = "0.0.0", note = "use backend()")]
     pub fn backend_api(&self) -> BackendAPI {
+        self.backend()
+    }
+
+    pub fn backend(&self) -> BackendAPI {
         BackendAPI::from_native(self.native().fBackend)
     }
 
+    // texture_type() would return a private type.
+
+    #[deprecated(since = "0.0.0", note = "use as_gl_format()")]
     pub fn gl_format(&self) -> Option<gl::Enum> {
-        unsafe {
-            #[allow(clippy::map_clone)]
-            self.native()
-                .getGLFormat()
-                .into_option()
-                .map(|format| *format)
-        }
+        Some(self.as_gl_format() as _)
     }
 
-    pub fn gl_target(&self) -> Option<gl::Enum> {
-        unsafe {
+    pub fn as_gl_format(&self) -> gl::Format {
+        gl::Format::from_native(unsafe {
             #[allow(clippy::map_clone)]
-            self.native()
-                .getGLTarget()
-                .into_option()
-                .map(|target| *target)
-        }
+            self.native().asGLFormat()
+        })
+    }
+
+    #[deprecated(since = "0.0.0", note = "use as_vk_format()")]
+    #[cfg(feature = "vulkan")]
+    pub fn vulkan_format(&self) -> Option<vk::Format> {
+        self.as_vk_format()
     }
 
     #[cfg(feature = "vulkan")]
-    pub fn vulkan_format(&self) -> Option<vk::Format> {
-        unsafe {
-            #[allow(clippy::map_clone)]
-            self.native()
-                .getVkFormat()
-                .into_option()
-                .map(|format| *format)
-        }
+    pub fn as_vk_format(&self) -> Option<vk::Format> {
+        let mut r = vk::Format::UNDEFINED;
+        unsafe { self.native().asVkFormat(&mut r) }.if_true_some(r)
     }
 
     pub fn to_texture_2d(&self) -> Option<Self> {

--- a/skia-safe/src/gpu/backend_surface.rs
+++ b/skia-safe/src/gpu/backend_surface.rs
@@ -47,7 +47,7 @@ impl Handle<GrBackendFormat> {
         })
     }
 
-    #[deprecated(since = "0.0.0", note = "use backend()")]
+    #[deprecated(since = "0.19.0", note = "use backend()")]
     pub fn backend_api(&self) -> BackendAPI {
         self.backend()
     }
@@ -58,7 +58,7 @@ impl Handle<GrBackendFormat> {
 
     // texture_type() would return a private type.
 
-    #[deprecated(since = "0.0.0", note = "use as_gl_format()")]
+    #[deprecated(since = "0.19.0", note = "use as_gl_format()")]
     pub fn gl_format(&self) -> Option<gl::Enum> {
         Some(self.as_gl_format() as _)
     }
@@ -70,7 +70,7 @@ impl Handle<GrBackendFormat> {
         })
     }
 
-    #[deprecated(since = "0.0.0", note = "use as_vk_format()")]
+    #[deprecated(since = "0.19.0", note = "use as_vk_format()")]
     #[cfg(feature = "vulkan")]
     pub fn vulkan_format(&self) -> Option<vk::Format> {
         self.as_vk_format()

--- a/skia-safe/src/gpu/context.rs
+++ b/skia-safe/src/gpu/context.rs
@@ -224,13 +224,16 @@ impl RCHandle<GrContext> {
     }
 
     pub fn default_backend_format(&self, ct: ColorType, renderable: Renderable) -> BackendFormat {
-        BackendFormat::from_native(unsafe {
+        let mut format = BackendFormat::default();
+        unsafe {
             sb::C_GrContext_defaultBackendFormat(
                 self.native(),
                 ct.into_native(),
                 renderable.into_native(),
+                format.native_mut(),
             )
-        })
+        };
+        format
     }
 
     // TODO: support createBackendTexture (several variants) and deleteBackendTexture(),

--- a/skia-safe/src/gpu/gl/types.rs
+++ b/skia-safe/src/gpu/gl/types.rs
@@ -1,6 +1,57 @@
 use crate::prelude::NativeTransmutable;
 use skia_bindings as sb;
-use skia_bindings::{GrGLFramebufferInfo, GrGLTextureInfo, GrGLenum, GrGLuint};
+use skia_bindings::{
+    GrGLFormat, GrGLFramebufferInfo, GrGLStandard, GrGLTextureInfo, GrGLenum, GrGLuint,
+};
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[repr(i32)]
+pub enum Standard {
+    None = GrGLStandard::kNone_GrGLStandard as _,
+    GL = GrGLStandard::kGL_GrGLStandard as _,
+    GLES = GrGLStandard::kGLES_GrGLStandard as _,
+    WebGL = GrGLStandard::kWebGL_GrGLStandard as _,
+}
+
+impl NativeTransmutable<GrGLStandard> for Standard {}
+#[test]
+fn test_standard_layout() {
+    Standard::test_layout()
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[repr(i32)]
+#[allow(non_camel_case_types)]
+pub enum Format {
+    Unknown = GrGLFormat::kUnknown as _,
+    RGBA8 = GrGLFormat::kRGBA8 as _,
+    R8 = GrGLFormat::kR8 as _,
+    ALPHA8 = GrGLFormat::kALPHA8 as _,
+    LUMINANCE8 = GrGLFormat::kLUMINANCE8 as _,
+    BGRA8 = GrGLFormat::kBGRA8 as _,
+    RGB565 = GrGLFormat::kRGB565 as _,
+    RGBA16F = GrGLFormat::kRGBA16F as _,
+    R16F = GrGLFormat::kR16F as _,
+    RGB8 = GrGLFormat::kRGB8 as _,
+    RG8 = GrGLFormat::kRG8 as _,
+    RGB10_A2 = GrGLFormat::kRGB10_A2 as _,
+    RGBA4 = GrGLFormat::kRGBA4 as _,
+    RGBA32F = GrGLFormat::kRGBA32F as _,
+    SRGB8_ALPHA8 = GrGLFormat::kSRGB8_ALPHA8 as _,
+    COMPRESSED_RGB8_ETC2 = GrGLFormat::kCOMPRESSED_RGB8_ETC2 as _,
+    COMPRESSED_ETC1_RGB8 = GrGLFormat::kCOMPRESSED_ETC1_RGB8 as _,
+    R16 = GrGLFormat::kR16 as _,
+    RG16 = GrGLFormat::kRG16 as _,
+    RGBA16 = GrGLFormat::kRGBA16 as _,
+    RG16F = GrGLFormat::kRG16F as _,
+    LUMINANCE16F = GrGLFormat::kLUMINANCE16F as _,
+}
+
+impl NativeTransmutable<GrGLFormat> for Format {}
+#[test]
+fn test_format_layout() {
+    Format::test_layout()
+}
 
 pub type Enum = GrGLenum;
 pub type UInt = GrGLuint;

--- a/skia-safe/src/gpu/vk/types.rs
+++ b/skia-safe/src/gpu/vk/types.rs
@@ -110,6 +110,7 @@ impl Default for YcbcrConversionInfo {
 }
 
 impl YcbcrConversionInfo {
+    #[allow(clippy::too_many_arguments)]
     pub fn new_with_format(
         format: vk::Format,
         external_format: u64,

--- a/skia-safe/src/gpu/vk/types.rs
+++ b/skia-safe/src/gpu/vk/types.rs
@@ -239,7 +239,7 @@ impl ImageInfo {
         }
     }
 
-    #[deprecated(since = "0.0.0", note = "use new()")]
+    #[deprecated(since = "0.19.0", note = "use new()")]
     #[allow(clippy::too_many_arguments)]
     pub unsafe fn from_image(
         image: vk::Image,

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -21,7 +21,7 @@ impl NativeDrop for SkShaper {
 
 impl Default for RefHandle<SkShaper> {
     fn default() -> Self {
-        Self::new()
+        Self::new(None)
     }
 }
 
@@ -30,16 +30,26 @@ impl RefHandle<SkShaper> {
         Self::from_ptr(unsafe { sb::C_SkShaper_MakePrimitive() }).unwrap()
     }
 
-    pub fn new_shaper_driven_wrapper() -> Option<Self> {
-        Self::from_ptr(unsafe { sb::C_SkShaper_MakeShaperDrivenWrapper() })
+    pub fn new_shaper_driven_wrapper(font_mgr: impl Into<Option<FontMgr>>) -> Option<Self> {
+        Self::from_ptr(unsafe {
+            sb::C_SkShaper_MakeShaperDrivenWrapper(font_mgr.into().into_ptr_or_null())
+        })
     }
 
-    pub fn new_shape_then_wrap() -> Option<Self> {
-        Self::from_ptr(unsafe { sb::C_SkShaper_MakeShapeThenWrap() })
+    pub fn new_shape_then_wrap(font_mgr: impl Into<Option<FontMgr>>) -> Option<Self> {
+        Self::from_ptr(unsafe {
+            sb::C_SkShaper_MakeShapeThenWrap(font_mgr.into().into_ptr_or_null())
+        })
     }
 
-    pub fn new() -> Self {
-        Self::from_ptr(unsafe { sb::C_SkShaper_Make() }).unwrap()
+    pub fn new_shape_dont_wrap_or_reorder(font_mgr: impl Into<Option<FontMgr>>) -> Option<Self> {
+        Self::from_ptr(unsafe {
+            sb::C_SkShaper_MakeShapeDontWrapOrReorder(font_mgr.into().into_ptr_or_null())
+        })
+    }
+
+    pub fn new(font_mgr: impl Into<Option<FontMgr>>) -> Self {
+        Self::from_ptr(unsafe { sb::C_SkShaper_Make(font_mgr.into().into_ptr_or_null()) }).unwrap()
     }
 }
 
@@ -547,7 +557,7 @@ mod tests {
     fn test_rtl_text_shaping() {
         skia_bindings::icu::init();
 
-        let shaper = Shaper::new();
+        let shaper = Shaper::new(None);
         shaper.shape(
             "العربية",
             &Font::default(),

--- a/skia-safe/src/svg/canvas.rs
+++ b/skia-safe/src/svg/canvas.rs
@@ -38,6 +38,7 @@ bitflags! {
     #[derive(Default)]
     pub struct Flags : u32 {
         const CONVERT_TEXT_TO_PATHS = sb::SkSVGCanvas_kConvertTextToPaths_Flag as _;
+        const NO_PRETTY_XML = sb::SkSVGCanvas_kNoPrettyXML_Flag as _;
     }
 }
 
@@ -81,8 +82,7 @@ fn test_svg() {
     let data = canvas.end();
     let contents = String::from_utf8_lossy(data.as_bytes());
     dbg!(&contents);
-    assert!(contents
-        .contains(r#"<ellipse fill="rgb(0,0,0)" stroke="none" cx="10" cy="10" rx="10" ry="10"/>"#));
+    assert!(contents.contains(r#"<ellipse cx="10" cy="10" rx="10" ry="10"/>"#));
     assert!(contents.contains(r#"</svg>"#));
 }
 


### PR DESCRIPTION
This PR updates rust-skia to support Skia's `chrome/m78` branch.

- [x] Update `README.md` ([rendered](https://github.com/pragmatrix/rust-skia/blob/m78/README.md))  
  > Most important here is to change the Skia branch name and the current commit hash at the top of the `README.md` file.
- [x] Skia can be built ([release notes](https://github.com/google/skia/blob/chrome/m78/RELEASE_NOTES.txt)).
- [x] skia-bindings.
- [ ] skia-safe: Update & add new wrappers by diffing include files.  
  > Add TODOs for everything that can not be updated right now, and attempt to stay compatible with previous versions of skia-safe without trying too hard before version 1.0. Use `deprecated` attributes if needed.
  - [x] `codec/`
  - [x] `core/`
  - [x] `docs/`
  - [x] `effects/`
  - [x] `gpu/`
    - [x] `gl/`
    - [x] `vk/`
  - [x] `modules/`
    - [x] `skshaper/`
    - [ ] `skparagraph/` pragmatrix#2
    - [ ] `skplaintexteditor/`
  - [x] `pathops/`
  - [x] `svg/`
  - [x] `utils/`
- [x] ~One week before Chrome 78 stable will be released? ([Schedule](https://www.chromestatus.com/features/schedule))
- [x] Any pending changes in the Skia `chrome/m78` branch that aren't synchronized yet?
- [x] Do the hashes in `skia-bindings/Cargo.toml` under `[package.metadata]` match the submodules `depot_tools` and `skia`?
- [x] Rebase on or merge with master.
- [x] Update versions of `skia-bindings/Cargo.toml` and `skia-safe/Cargo.toml` and also add the version to the new `deprecated` attributes.
