### PR TITLE
Chrome Milestone 79

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Skia Submodule Status: chrome/m79 ([pending changes][skiapending]).
 
-[skiapending]: https://github.com/google/skia/compare/0df7697235...chrome/m79
+[skiapending]: https://github.com/google/skia/compare/2542bdfcd6...chrome/m79
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![Build Status](https://dev.azure.com/pragmatrix-github/rust-skia/_apis/build/status/rust-skia.rust-skia?branchName=master)](https://dev.azure.com/pragmatrix-github/rust-skia/_build/latest?branchName=master)
 
-Skia Submodule Status: chrome/m78 ([pending changes][skiapending]).
+Skia Submodule Status: chrome/m79 ([pending changes][skiapending]).
 
-[skiapending]: https://github.com/google/skia/compare/a40a8a5875...chrome/m78
+[skiapending]: https://github.com/google/skia/compare/0df7697235...chrome/m79
 
 ## Goals
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -19,7 +19,7 @@ include = [ "Cargo.toml", "build.rs", "build_support.rs", "build_support/**/*.rs
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "a40a8a5875"
+skia = "0df7697235"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.20.0"
+version = "0.21.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -19,7 +19,7 @@ include = [ "Cargo.toml", "build.rs", "build_support.rs", "build_support/**/*.rs
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "0df7697235"
+skia = "2542bdfcd6"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-bindings/Makefile
+++ b/skia-bindings/Makefile
@@ -1,0 +1,2 @@
+skparagraph.patch: skia/BUILD.gn skia/modules/skparagraph/BUILD.gn
+	(cd skia && git diff) >$@

--- a/skia-bindings/Makefile
+++ b/skia-bindings/Makefile
@@ -1,2 +1,6 @@
 skparagraph.patch: skia/BUILD.gn skia/modules/skparagraph/BUILD.gn
 	(cd skia && git diff) >$@
+
+.PHONY: skia-short-hash
+skia-short-hash:
+	cd skia && git rev-parse --short HEAD

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -686,6 +686,13 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
         // modules/skshaper/
         .whitelist_type("SkShaper")
         .whitelist_type("RustRunHandler")
+        // modules/skparagraph
+        //   pulls in a std::map<>, which we treat as opaque, but bindgen creates wrong bindings for
+        //   std::_Tree* types
+        .blacklist_type("std::_Tree.*")
+        .blacklist_type("std::map.*")
+        //   not used at all:
+        .blacklist_type("std::vector.*")
         // Vulkan reexports that got swallowed by making them opaque.
         .whitelist_type("VkPhysicalDeviceFeatures")
         .whitelist_type("VkPhysicalDeviceFeatures2")
@@ -828,7 +835,7 @@ const OPAQUE_TYPES: &[&str] = &[
     // skparagraph (m78), (layout fails on macOS and Linux, not sure why, looks like an obscure alignment problem)
     "skia::textlayout::FontCollection",
     // skparagraph (m79), std::map is used in LineMetrics
-    "skia::textlayout::LineMetrics",
+    "std::map",
     // Vulkan reexports with the wrong field naming conventions.
     "VkPhysicalDeviceFeatures",
     "VkPhysicalDeviceFeatures2",

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -686,9 +686,6 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
         // modules/skshaper/
         .whitelist_type("SkShaper")
         .whitelist_type("RustRunHandler")
-        // modules/skparagraph/
-        .whitelist_type("skia::textlayout::Block")
-        .whitelist_type("skia::textlayout::Placeholder")
         // Vulkan reexports that got swallowed by making them opaque.
         .whitelist_type("VkPhysicalDeviceFeatures")
         .whitelist_type("VkPhysicalDeviceFeatures2")
@@ -830,6 +827,8 @@ const OPAQUE_TYPES: &[&str] = &[
     "std::u16string",
     // skparagraph (m78), (layout fails on macOS and Linux, not sure why, looks like an obscure alignment problem)
     "skia::textlayout::FontCollection",
+    // skparagraph (m79), std::map is used in LineMetrics
+    "skia::textlayout::LineMetrics",
     // Vulkan reexports with the wrong field naming conventions.
     "VkPhysicalDeviceFeatures",
     "VkPhysicalDeviceFeatures2",

--- a/skia-bindings/skparagraph.patch
+++ b/skia-bindings/skparagraph.patch
@@ -1,19 +1,21 @@
 diff --git a/BUILD.gn b/BUILD.gn
-index 6a85dd96b..809d4724d 100644
+index b5929c6744..efdd6bd168 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -1076,6 +1076,9 @@ group("modules") {
-     "modules/particles",
+@@ -1087,9 +1087,9 @@ group("modules") {
      "modules/skottie",
      "modules/skshaper",
-+    # Patched in by skia-bindings
-+    # **SKIA-BINDINGS-PATCH-MARKER-SKPARAGRAPH**
-+    "modules/skparagraph",
    ]
+-  if (target_cpu == "wasm") {
++  # Patched in by skia-bindings
++  # **SKIA-BINDINGS-PATCH-MARKER-SKPARAGRAPH**
+     deps += [ "modules/skparagraph" ]
+-  }
  }
  
+ # Targets guarded by skia_enable_tools may use //third_party freely.
 diff --git a/modules/skparagraph/BUILD.gn b/modules/skparagraph/BUILD.gn
-index 5a85d37c4..a3ab9b884 100644
+index 5a85d37c4e..a3ab9b8846 100644
 --- a/modules/skparagraph/BUILD.gn
 +++ b/modules/skparagraph/BUILD.gn
 @@ -18,6 +18,7 @@ if (skia_enable_skparagraph) {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1311,10 +1311,6 @@ extern "C" bool C_SkYUVASizeInfo_equals(const SkYUVASizeInfo* l, const SkYUVASiz
     return *l == *r;
 }
 
-extern "C" size_t C_SkYUVASizeInfo_computeTotalBytes(const SkYUVASizeInfo* self) {
-    return self->computeTotalBytes();
-}
-
 //
 // core/SkFlattenable.h
 //

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -786,8 +786,32 @@ extern "C" void C_SkAutoCanvasRestore_restore(SkAutoCanvasRestore* self) {
 }
 
 //
-// SkImageInfo
+// core/SkImageInfo.h
 //
+
+extern "C" void C_SkColorInfo_Construct(SkColorInfo* uninitialized) {
+    new (uninitialized) SkColorInfo();
+}
+
+extern "C" void C_SkColorInfo_Construct2(SkColorInfo* uninitialized, SkColorType ct, SkAlphaType at, SkColorSpace* cs) {
+    new (uninitialized) SkColorInfo(ct, at, sp(cs));
+}
+
+extern "C" void C_SkColorInfo_destruct(SkColorInfo* self) {
+    self->~SkColorInfo();
+}
+
+extern "C" void C_SkColorInfo_Copy(const SkColorInfo* from, SkColorInfo* to) {
+    *to = *from;
+}
+
+extern "C" bool C_SkColorInfo_Equals(const SkColorInfo* lhs, const SkColorInfo* rhs) {
+    return *lhs == *rhs;
+}
+
+extern "C" bool C_SkColorInfo_gammaCloseToSRGB(const SkColorInfo* self) {
+    return self->gammaCloseToSRGB();
+}
 
 extern "C" void C_SkImageInfo_Construct(SkImageInfo* uninitialized) {
     new (uninitialized) SkImageInfo();
@@ -811,17 +835,6 @@ extern "C" void C_SkImageInfo_Make(SkImageInfo* self, int width, int height, SkC
 
 extern "C" void C_SkImageInfo_MakeS32(SkImageInfo* self, int width, int height, SkAlphaType at) {
     *self = SkImageInfo::MakeS32(width, height, at);
-}
-
-extern "C" SkColorSpace* C_SkImageInfo_colorSpace(const SkImageInfo* self) {
-    // note: colorSpace returns just a pointer without increasing the reference counter.
-    SkColorSpace* cs = self->colorSpace();
-    if (cs) cs->ref();
-    return cs;
-}
-
-extern "C" bool C_SkImageInfo_gammaCloseToSRGB(const SkImageInfo* self) {
-    return self->gammaCloseToSRGB();
 }
 
 extern "C" void C_SkImageInfo_reset(SkImageInfo* self) {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -310,6 +310,10 @@ extern "C" bool C_SkSurfaceCharacterization_equals(const SkSurfaceCharacterizati
     return *self == *rhs;
 }
 
+extern "C" void C_SkSurfaceCharacterization_createColorSpace(const SkSurfaceCharacterization* self, SkColorSpace* cs, SkSurfaceCharacterization* out) {
+    *out = self->createColorSpace(sp(cs));
+}
+
 extern "C" const SkImageInfo* C_SkSurfaceCharacterization_imageInfo(const SkSurfaceCharacterization* self) {
     return &self->imageInfo();
 }

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1223,6 +1223,9 @@ extern "C" SkTextBlob *C_SkTextBlob_MakeFromRSXform(const void *text, size_t byt
     return SkTextBlob::MakeFromRSXform(text, byteLength, xform, *font, encoding).release();
 }
 
+extern "C" void C_SkTextBlob_Iter_destruct(SkTextBlob::Iter* self) {
+    self->~Iter();
+}
 
 extern "C" void C_SkTextBlobBuilder_destruct(SkTextBlobBuilder* self) {
     self->~SkTextBlobBuilder();

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -2804,6 +2804,10 @@ extern "C" void C_GrContext_flush(GrContext* self) {
     self->flush();
 }
 
+extern "C" size_t C_GrContext_ComputeImageSize(SkImage* image, GrMipMapped mm, bool useNextPow2) {
+    return GrContext::ComputeImageSize(sp(image), mm, useNextPow2);
+}
+
 extern "C" void C_GrContext_defaultBackendFormat(const GrContext* self, SkColorType ct, GrRenderable renderable, GrBackendFormat* result) {
     *result = self->defaultBackendFormat(ct, renderable);
 }

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -29,6 +29,7 @@
 #include "include/core/SkPaint.h"
 #include "include/core/SkPath.h"
 #include "include/core/SkPathMeasure.h"
+#include "include/core/SkPathTypes.h"
 #include "include/core/SkPicture.h"
 #include "include/core/SkPictureRecorder.h"
 #include "include/core/SkPixelRef.h"
@@ -709,6 +710,12 @@ extern "C" uint32_t C_SkPath_getSegmentMasks(const SkPath* self) {
 extern "C" void C_SkPathMeasure_destruct(const SkPathMeasure* self) {
     self->~SkPathMeasure();
 }
+
+//
+// core/SkPathTypes.h
+//
+
+extern "C" void C_SkPathTypes(SkPathFillType, SkPathConvexityType, SkPathDirection, SkPathSegmentMask, SkPathVerb) {}
 
 //
 // SkCanvas

--- a/skia-bindings/src/paragraph.cpp
+++ b/skia-bindings/src/paragraph.cpp
@@ -269,8 +269,8 @@ extern "C" {
         *style = self->peekStyle();
     }
 
-    void C_ParagraphBuilder_addText(ParagraphBuilder* self, const char* text) {
-        self->addText(text);
+    void C_ParagraphBuilder_addText(ParagraphBuilder* self, const char* text, size_t len) {
+        self->addText(text, len);
     }
 
     void C_ParagraphBuilder_addPlaceholder(ParagraphBuilder* self, const PlaceholderStyle* placeholderStyle) {

--- a/skia-bindings/src/paragraph.cpp
+++ b/skia-bindings/src/paragraph.cpp
@@ -4,6 +4,7 @@
 
 #include "modules/skparagraph/include/DartTypes.h"
 #include "modules/skparagraph/include/FontCollection.h"
+#include "modules/skparagraph/include/Metrics.h"
 #include "modules/skparagraph/include/ParagraphCache.h"
 #include "modules/skparagraph/include/Paragraph.h"
 #include "modules/skparagraph/include/ParagraphBuilder.h"
@@ -44,7 +45,7 @@ extern "C" {
     }
 
     SkFontMgr* C_FontCollection_getFallbackManager(const FontCollection* self) {
-        return self->geFallbackManager().release();
+        return self->getFallbackManager().release();
     }
 
     SkTypeface* C_FontCollection_matchTypeface(FontCollection* self, const char* familyName, SkFontStyle fontStyle, const SkString* locale) {
@@ -135,6 +136,14 @@ extern "C" {
 }
 
 //
+// Metrics.h
+//
+
+extern "C" {
+    void C_Metrics_Types(const StyleMetrics*, const LineMetrics*) {}
+}
+
+//
 // Paragraph.h
 //
 
@@ -176,8 +185,8 @@ extern "C" {
         new(uninitialized) TextBoxes{std::move(v)};
     }
 
-    void C_Paragraph_GetRectsForPlaceholders(Paragraph* self, TextBoxes* uninitialized) {
-        auto v = self->GetRectsForPlaceholders();
+    void C_Paragraph_getRectsForPlaceholders(Paragraph* self, TextBoxes* uninitialized) {
+        auto v = self->getRectsForPlaceholders();
         new(uninitialized) TextBoxes{std::move(v)};
     }
 
@@ -247,6 +256,8 @@ extern "C" {
 //
 
 extern "C" {
+    void C_TextStyle_Types(const Block*, const Placeholder*) {}
+    
     void C_TextStyle_CopyConstruct(TextStyle* uninitialized, const TextStyle* other) {
         new(uninitialized) TextStyle(*other);
     }

--- a/skia-bindings/src/shaper.cpp
+++ b/skia-bindings/src/shaper.cpp
@@ -57,6 +57,10 @@ extern "C" uint8_t C_SkShaper_BiDiRunIterator_currentLevel(const SkShaper::BiDiR
     return self->currentLevel();
 }
 
+extern "C" SkShaper::BiDiRunIterator* C_SkShaper_MakeBidiRunIterator(const char* utf8, size_t utf8Bytes, uint8_t bidiLevel) {
+    return SkShaper::MakeBiDiRunIterator(utf8, utf8Bytes, bidiLevel).release();
+}
+
 extern "C" SkShaper::BiDiRunIterator* C_SkShaper_MakeIcuBidiRunIterator(const char* utf8, size_t utf8Bytes, uint8_t bidiLevel) {
     return SkShaper::MakeIcuBiDiRunIterator(utf8, utf8Bytes, bidiLevel).release();
 }
@@ -67,6 +71,10 @@ extern "C" SkShaper::BiDiRunIterator* C_SkShaper_TrivialBidiRunIterator_new(uint
 
 extern "C" SkFourByteTag C_SkShaper_ScriptRunIterator_currentScript(const SkShaper::ScriptRunIterator* self) {
     return self->currentScript();
+}
+
+extern "C" SkShaper::ScriptRunIterator* C_SkShaper_MakeScriptRunIterator(const char* utf8, size_t utf8Bytes, SkFourByteTag script) {
+    return SkShaper::MakeScriptRunIterator(utf8, utf8Bytes, script).release();
 }
 
 extern "C" SkShaper::ScriptRunIterator* C_SkShaper_MakeHbIcuScriptRunIterator(const char* utf8, size_t utf8Bytes) {

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -27,7 +27,7 @@ textlayout = ["skia-bindings/textlayout", "shaper"]
 
 [dependencies]
 bitflags = "1.0.4"
-skia-bindings = { version = "=0.20.0", path = "../skia-bindings" }
+skia-bindings = { version = "=0.21.0", path = "../skia-bindings" }
 lazy_static = "1.4"
 
 [dev-dependencies]

--- a/skia-safe/src/core.rs
+++ b/skia-safe/src/core.rs
@@ -193,15 +193,7 @@ pub mod path;
 pub use path::AddPathMode;
 #[deprecated(since = "0.12.0", note = "use path::ArcSize")]
 pub use path::ArcSize as PathArcSize;
-#[deprecated(since = "0.12.0", note = "use path::Convexity")]
-pub use path::Convexity as PathConvexity;
-#[deprecated(since = "0.12.0", note = "use matrix::AffineMember")]
-pub use path::Direction as PathDirection;
-#[deprecated(since = "0.12.0", note = "use path::FillType")]
-pub use path::FillType as PathFillType;
 pub use path::Path;
-#[deprecated(since = "0.12.0", note = "use path::SegmentMask")]
-pub use path::SegmentMask as PathSegmentMask;
 
 pub mod path_effect;
 #[deprecated(since = "0.12.0", note = "use path_effect::point_data::PointFlags")]
@@ -214,6 +206,9 @@ pub use path_effect::PointData as PathEffectPointData;
 
 pub mod path_measure;
 pub use path_measure::PathMeasure;
+
+pub mod path_types;
+pub use path_types::*;
 
 mod picture;
 pub use picture::*;

--- a/skia-safe/src/core/color_filter.rs
+++ b/skia-safe/src/core/color_filter.rs
@@ -63,10 +63,18 @@ impl RCHandle<SkColorFilter> {
         Color::from_native(unsafe { self.native().filterColor(color.into().into_native()) })
     }
 
-    pub fn filter_color4f(&self, color: impl AsRef<Color4f>, color_space: &ColorSpace) -> Color4f {
+    pub fn filter_color4f(
+        &self,
+        color: impl AsRef<Color4f>,
+        src_color_space: &ColorSpace,
+        dst_color_space: Option<&ColorSpace>,
+    ) -> Color4f {
         Color4f::from_native(unsafe {
-            self.native()
-                .filterColor4f(color.as_ref().native(), color_space.native_mut_force())
+            self.native().filterColor4f(
+                color.as_ref().native(),
+                src_color_space.native_mut_force(),
+                dst_color_space.native_ptr_or_null_mut_force(),
+            )
         })
     }
 

--- a/skia-safe/src/core/color_space.rs
+++ b/skia-safe/src/core/color_space.rs
@@ -76,6 +76,27 @@ pub mod named_transfer_fn {
         e: 0.0,
         f: 0.0,
     };
+
+    pub const PQ: ColorSpaceTransferFn = ColorSpaceTransferFn {
+        g: -2.0,
+        a: -107.0 / 128.0,
+        b: 1.0,
+        c: 32.0 / 2523.0,
+        d: 2413.0 / 128.0,
+        e: -2392.0 / 128.0,
+        f: 8192.0 / 1305.0,
+    };
+
+    #[allow(clippy::excessive_precision)]
+    pub const HLG: ColorSpaceTransferFn = ColorSpaceTransferFn {
+        g: -3.0,
+        a: 2.0,
+        b: 2.0,
+        c: 1.0 / 0.178_832_77,
+        d: 0.284_668_92,
+        e: 0.559_910_73,
+        f: 0.0,
+    };
 }
 
 pub type ColorSpace = RCHandle<SkColorSpace>;

--- a/skia-safe/src/core/image_info.rs
+++ b/skia-safe/src/core/image_info.rs
@@ -183,7 +183,7 @@ impl Handle<SkColorInfo> {
         Self::new(new_color_type, self.alpha_type(), self.color_space())
     }
 
-    pub fn with_color_space(&self, cs: ColorSpace) -> Self {
+    pub fn with_color_space(&self, cs: impl Into<Option<ColorSpace>>) -> Self {
         Self::new(self.color_type(), self.alpha_type(), cs)
     }
 

--- a/skia-safe/src/core/milestone.rs
+++ b/skia-safe/src/core/milestone.rs
@@ -1,1 +1,1 @@
-pub const MILESTONE: usize = 78;
+pub const MILESTONE: usize = 79;

--- a/skia-safe/src/core/path_types.rs
+++ b/skia-safe/src/core/path_types.rs
@@ -1,0 +1,106 @@
+use crate::prelude::*;
+use skia_bindings as sb;
+use skia_bindings::{
+    SkPathConvexityType, SkPathDirection, SkPathFillType, SkPathVerb, SkPath_Convexity,
+    SkPath_Direction, SkPath_FillType, SkPath_Verb,
+};
+use std::mem;
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[repr(i32)]
+pub enum PathFillType {
+    Winding = SkPathFillType::kWinding as _,
+    EvenOdd = SkPathFillType::kEvenOdd as _,
+    InverseWinding = SkPathFillType::kInverseWinding as _,
+    InverseEvenOdd = SkPathFillType::kInverseEvenOdd as _,
+}
+
+impl NativeTransmutable<SkPathFillType> for PathFillType {}
+impl NativeTransmutable<SkPath_FillType> for SkPathFillType {}
+#[test]
+pub fn test_fill_type_layout() {
+    PathFillType::test_layout();
+    SkPathFillType::test_layout();
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[repr(i32)]
+pub enum PathConvexityType {
+    Unknown = SkPathConvexityType::kUnknown as _,
+    Convex = SkPathConvexityType::kConvex as _,
+    Concave = SkPathConvexityType::kConcave as _,
+}
+
+impl NativeTransmutable<SkPathConvexityType> for PathConvexityType {}
+#[test]
+fn test_convexity_layout() {
+    PathConvexityType::test_layout();
+}
+
+// The sizes of SkPath_Convexity and SkPathConvexityType differ in C++, so
+// we provide custom conversions.
+impl PathConvexityType {
+    pub(crate) fn native_from_path(convexity: SkPath_Convexity) -> SkPathConvexityType {
+        unsafe { mem::transmute(convexity as i32) }
+    }
+
+    pub(crate) fn native_to_path(convexity: SkPathConvexityType) -> SkPath_Convexity {
+        unsafe { mem::transmute(convexity as u8) }
+    }
+}
+
+#[test]
+fn test_path_convexity_layout() {
+    assert_eq!(mem::size_of::<SkPath_Convexity>(), mem::size_of::<u8>());
+    assert_eq!(mem::size_of::<SkPathConvexityType>(), mem::size_of::<i32>());
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[repr(i32)]
+pub enum PathDirection {
+    CW = SkPathDirection::kCW as _,
+    CCW = SkPathDirection::kCCW as _,
+}
+
+impl NativeTransmutable<SkPathDirection> for PathDirection {}
+impl NativeTransmutable<SkPath_Direction> for SkPathDirection {}
+#[test]
+fn test_direction_layout() {
+    PathDirection::test_layout();
+    SkPathDirection::test_layout();
+}
+
+impl Default for PathDirection {
+    fn default() -> Self {
+        PathDirection::CW
+    }
+}
+
+bitflags! {
+    pub struct PathSegmentMask: u32 {
+        const LINE = sb::SkPathSegmentMask_kLine_SkPathSegmentMask as _;
+        const QUAD = sb::SkPathSegmentMask_kQuad_SkPathSegmentMask as _;
+        const CONIC = sb::SkPathSegmentMask_kConic_SkPathSegmentMask as _;
+        const CUBIC = sb::SkPathSegmentMask_kCubic_SkPathSegmentMask as _;
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[repr(i32)]
+pub enum PathVerb {
+    Move = SkPathVerb::kMove as _,
+    Line = SkPathVerb::kLine as _,
+    Quad = SkPathVerb::kQuad as _,
+    Conic = SkPathVerb::kConic as _,
+    Qubic = SkPathVerb::kCubic as _,
+    Close = SkPathVerb::kClose as _,
+    Done = SkPathVerb::kDone as _,
+}
+
+impl NativeTransmutable<SkPathVerb> for PathVerb {}
+impl NativeTransmutable<SkPath_Verb> for SkPathVerb {}
+#[test]
+fn test_verb_layout() {
+    PathVerb::test_layout();
+    SkPathVerb::test_layout();
+}

--- a/skia-safe/src/core/surface.rs
+++ b/skia-safe/src/core/surface.rs
@@ -418,8 +418,9 @@ impl RCHandle<SkSurface> {
         unsafe { self.native_mut().readPixels2(bitmap.native(), src.x, src.y) }
     }
 
-    // TODO: wrap asyncRescaleAndReadPixels (m76)
-    // TODO: wrap asyncRescaleAndReadPixelsYUV420 (m77)
+    // TODO: wrap AsyncReadResult (m79)
+    // TODO: wrap asyncRescaleAndReadPixels (m76/m79)
+    // TODO: wrap asyncRescaleAndReadPixelsYUV420 (m77/m79)
 
     pub fn write_pixels_from_pixmap(&mut self, src: &Pixmap, dst: impl Into<IPoint>) {
         let dst = dst.into();

--- a/skia-safe/src/core/surface_characterization.rs
+++ b/skia-safe/src/core/surface_characterization.rs
@@ -39,9 +39,21 @@ impl Default for Handle<SkSurfaceCharacterization> {
 // TODO: there is an alterative for when SK_SUPPORT_GPU is not set, of which the
 //       layout differs, should we support that?
 impl Handle<SkSurfaceCharacterization> {
-    pub fn resized(&self, size: impl Into<ISize>) -> SurfaceCharacterization {
+    pub fn resized(&self, size: impl Into<ISize>) -> Self {
         let size = size.into();
         Self::from_native(unsafe { self.native().createResized(size.width, size.height) })
+    }
+
+    pub fn with_color_space(&self, color_space: impl Into<Option<ColorSpace>>) -> Self {
+        let mut characterization = Self::default();
+        unsafe {
+            sb::C_SkSurfaceCharacterization_createColorSpace(
+                self.native(),
+                color_space.into().into_ptr_or_null(),
+                characterization.native_mut(),
+            )
+        };
+        characterization
     }
 
     // TODO: contextInfo() / refContextInfo()

--- a/skia-safe/src/core/text_blob.rs
+++ b/skia-safe/src/core/text_blob.rs
@@ -36,13 +36,8 @@ impl RCHandle<SkTextBlob> {
         self.native().fUniqueID
     }
 
-    #[deprecated(note = "use get_intercepts()")]
-    pub fn interceps(&self, bounds: [scalar; 2], paint: Option<&Paint>) -> Vec<scalar> {
-        self.get_interceps(bounds, paint)
-    }
-
     // TODO: consider to provide an inplace variant.
-    pub fn get_interceps(&self, bounds: [scalar; 2], paint: Option<&Paint>) -> Vec<scalar> {
+    pub fn get_intercepts(&self, bounds: [scalar; 2], paint: Option<&Paint>) -> Vec<scalar> {
         unsafe {
             let count = self.native().getIntercepts(
                 bounds.as_ptr(),

--- a/skia-safe/src/core/yuva_size_info.rs
+++ b/skia-safe/src/core/yuva_size_info.rs
@@ -23,7 +23,7 @@ impl YUVASizeInfo {
     pub const MAX_COUNT: usize = 4;
 
     pub fn compute_total_bytes(&self) -> usize {
-        unsafe { sb::C_SkYUVASizeInfo_computeTotalBytes(self.native()) }
+        unsafe { self.native().computeTotalBytes() }
     }
 
     // TODO: try to expose a safe(r) Rust function.

--- a/skia-safe/src/gpu/gl/types.rs
+++ b/skia-safe/src/gpu/gl/types.rs
@@ -36,7 +36,6 @@ pub enum Format {
     RG8 = GrGLFormat::kRG8 as _,
     RGB10_A2 = GrGLFormat::kRGB10_A2 as _,
     RGBA4 = GrGLFormat::kRGBA4 as _,
-    RGBA32F = GrGLFormat::kRGBA32F as _,
     SRGB8_ALPHA8 = GrGLFormat::kSRGB8_ALPHA8 as _,
     COMPRESSED_RGB8_ETC2 = GrGLFormat::kCOMPRESSED_RGB8_ETC2 as _,
     COMPRESSED_ETC1_RGB8 = GrGLFormat::kCOMPRESSED_ETC1_RGB8 as _,

--- a/skia-safe/src/modules/paragraph.rs
+++ b/skia-safe/src/modules/paragraph.rs
@@ -7,6 +7,9 @@ pub use dart_types::*;
 mod font_collection;
 pub use font_collection::*;
 
+mod metrics;
+pub use metrics::*;
+
 #[allow(clippy::module_inception)]
 mod paragraph;
 pub use paragraph::*;

--- a/skia-safe/src/modules/paragraph/metrics.rs
+++ b/skia-safe/src/modules/paragraph/metrics.rs
@@ -1,0 +1,100 @@
+use crate::paragraph::TextStyle;
+use crate::prelude::*;
+use crate::FontMetrics;
+use skia_bindings as sb;
+use skia_bindings::{skia_textlayout_LineMetrics, skia_textlayout_StyleMetrics};
+use std::ops::Range;
+use std::{marker, mem, ptr};
+
+#[repr(C)]
+pub struct StyleMetrics<'a> {
+    pub text_style: &'a TextStyle,
+    pub font_metrics: FontMetrics,
+}
+
+impl NativeTransmutable<skia_textlayout_StyleMetrics> for StyleMetrics<'_> {}
+
+#[test]
+fn test_style_metrics_layout() {
+    StyleMetrics::test_layout();
+}
+
+impl<'a> StyleMetrics<'a> {
+    pub fn new(style: &'a TextStyle, metrics: impl Into<Option<FontMetrics>>) -> Self {
+        Self {
+            text_style: style,
+            font_metrics: metrics.into().unwrap_or_default(),
+        }
+    }
+}
+
+#[repr(C)]
+pub struct LineMetrics<'a> {
+    pub start_index: usize,
+    pub end_index: usize,
+    pub end_excluding_whitespaces: usize,
+    pub end_including_newline: usize,
+    pub hard_break: bool,
+    pub ascent: f64,
+    pub descent: f64,
+    pub unscaled_ascent: f64,
+    pub height: f64,
+    pub width: f64,
+    pub left: f64,
+    pub baseline: f64,
+    pub line_number: usize,
+    line_metrics:
+        [u8; mem::size_of::<skia_textlayout_LineMetrics>() - mem::size_of::<LMInternal>()],
+    pd: marker::PhantomData<&'a StyleMetrics<'a>>,
+}
+
+// Internal Line Metrics mirror to compute what the map takes up space.
+// In case this computation is incorrect, the NativeTransmutable test below will fail.
+#[repr(C)]
+struct LMInternal {
+    start_end: [usize; 4],
+    hard_break: bool,
+    seven_metrics: [f64; 7],
+    line_number: usize,
+}
+
+impl NativeTransmutable<skia_textlayout_LineMetrics> for LineMetrics<'_> {}
+
+#[test]
+fn test_line_metrics_layout() {
+    LineMetrics::test_layout();
+}
+
+impl<'a> LineMetrics<'a> {
+    // TODO: may support constructors (but what about the lifetime bounds?).
+
+    /// Returns the number of style metrics in the given index range.
+    pub fn get_style_metrics_count(&self, range: Range<usize>) -> usize {
+        unsafe { sb::C_LineMetrics_fLineMetrics_count(self.native(), range.start, range.end) }
+    }
+
+    /// Returns indices and references to style metrics in the given range.
+    pub fn get_style_metrics(&self, range: Range<usize>) -> Vec<StyleMetricsRecord<'a>> {
+        let count = self.get_style_metrics_count(range.clone());
+        let mut v: Vec<(usize, *mut StyleMetrics<'a>)> = vec![(0, ptr::null_mut()); count];
+        unsafe {
+            sb::C_LineMetrics_fLineMetrics_getRange(
+                self.native(),
+                range.start,
+                range.end,
+                v.as_mut_ptr() as *mut sb::StyleMetricsRecord,
+            );
+            mem::transmute(v)
+        }
+    }
+}
+
+type StyleMetricsRecord<'a> = (usize, &'a StyleMetrics<'a>);
+
+#[test]
+fn test_style_metrics_record_layout() {
+    assert_eq!(
+        mem::size_of::<(usize, *mut StyleMetrics)>(),
+        mem::size_of::<sb::StyleMetricsRecord>()
+    )
+}

--- a/skia-safe/src/modules/paragraph/metrics.rs
+++ b/skia-safe/src/modules/paragraph/metrics.rs
@@ -84,7 +84,11 @@ impl<'a> LineMetrics<'a> {
                 range.end,
                 v.as_mut_ptr() as *mut sb::StyleMetricsRecord,
             );
-            mem::transmute(v)
+            // TODO: can the second allocation of that vec be avoided? Transmuting the vec is
+            //       UB beginning with Rust 1.40.
+            v.into_iter()
+                .map(|v| mem::transmute::<(usize, *mut StyleMetrics<'a>), StyleMetricsRecord>(v))
+                .collect()
         }
     }
 }

--- a/skia-safe/src/modules/paragraph/paragraph.rs
+++ b/skia-safe/src/modules/paragraph/paragraph.rs
@@ -70,7 +70,7 @@ impl RefHandle<sb::skia_textlayout_Paragraph> {
 
     pub fn get_rects_for_placeholders(&mut self) -> TextBoxes {
         TextBoxes::construct(|tb| unsafe {
-            sb::C_Paragraph_GetRectsForPlaceholders(self.native_mut(), tb)
+            sb::C_Paragraph_getRectsForPlaceholders(self.native_mut(), tb)
         })
     }
 

--- a/skia-safe/src/modules/paragraph/paragraph_builder.rs
+++ b/skia-safe/src/modules/paragraph/paragraph_builder.rs
@@ -1,7 +1,7 @@
 use super::{FontCollection, Paragraph, ParagraphStyle, PlaceholderStyle, TextStyle};
 use crate::prelude::*;
 use skia_bindings as sb;
-use std::ffi;
+use std::os::raw;
 
 pub type ParagraphBuilder = RefHandle<sb::skia_textlayout_ParagraphBuilder>;
 
@@ -29,8 +29,14 @@ impl RefHandle<sb::skia_textlayout_ParagraphBuilder> {
     }
 
     pub fn add_text(&mut self, str: impl AsRef<str>) -> &mut Self {
-        let cstr = ffi::CString::new(str.as_ref()).unwrap();
-        unsafe { sb::C_ParagraphBuilder_addText(self.native_mut(), cstr.as_ptr()) }
+        let str = str.as_ref();
+        unsafe {
+            sb::C_ParagraphBuilder_addText(
+                self.native_mut(),
+                str.as_ptr() as *const raw::c_char,
+                str.len(),
+            )
+        }
         self
     }
 

--- a/skia-safe/src/modules/paragraph/text_style.rs
+++ b/skia-safe/src/modules/paragraph/text_style.rs
@@ -1,8 +1,10 @@
 use super::{FontFamilies, TextBaseline, TextShadow};
 use crate::interop::{AsStr, FromStrs, SetStr};
 use crate::prelude::*;
+use crate::textlayout::{RangeExtensions, EMPTY_INDEX, EMPTY_RANGE};
 use crate::{interop, scalar, Color, FontMetrics, FontStyle, Paint, Typeface};
 use skia_bindings as sb;
+use std::ops::Range;
 use std::slice;
 
 bitflags! {
@@ -56,9 +58,7 @@ fn decoration_layout() {
     Decoration::test_layout();
 }
 
-use crate::textlayout::{RangeExtensions, EMPTY_INDEX, EMPTY_RANGE};
 pub use sb::skia_textlayout_PlaceholderAlignment as PlaceholderAlignment;
-use std::ops::Range;
 
 #[test]
 fn placeholder_alignment_member_naming() {
@@ -364,10 +364,11 @@ pub type BlockRange = Range<usize>;
 pub const EMPTY_BLOCK: usize = EMPTY_INDEX;
 pub const EMPTY_BLOCKS: Range<usize> = EMPTY_RANGE;
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq)]
 pub struct Placeholder {
     pub range: TextRange,
     pub style: PlaceholderStyle,
+    pub text_style: TextStyle,
     pub blocks_before: BlockRange,
     pub text_before: TextRange,
 }
@@ -384,6 +385,7 @@ impl Default for Placeholder {
         Self {
             range: EMPTY_RANGE,
             style: Default::default(),
+            text_style: Default::default(),
             blocks_before: 0..0,
             text_before: 0..0,
         }
@@ -391,12 +393,19 @@ impl Default for Placeholder {
 }
 
 impl Placeholder {
-    pub fn new(range: Range<usize>, style: PlaceholderStyle, blocks_before: BlockRange) -> Self {
+    pub fn new(
+        range: Range<usize>,
+        style: PlaceholderStyle,
+        text_style: TextStyle,
+        blocks_before: BlockRange,
+        text_before: TextRange,
+    ) -> Self {
         Self {
             range,
             style,
+            text_style,
             blocks_before,
-            text_before: 0..0,
+            text_before,
         }
     }
 }

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -59,20 +59,21 @@ pub trait RunIterator {
     fn at_end(&self) -> bool;
 }
 
-impl<T> RunIterator for T
+impl<T> RunIterator for RefHandle<T>
 where
+    T: NativeDrop,
     T: NativeBase<SkShaper_RunIterator>,
 {
     fn consume(&mut self) {
-        unsafe { sb::C_SkShaper_RunIterator_consume(self.base_mut()) }
+        unsafe { sb::C_SkShaper_RunIterator_consume(self.native_mut().base_mut()) }
     }
 
     fn end_of_current_run(&self) -> usize {
-        unsafe { sb::C_SkShaper_RunIterator_endOfCurrentRun(self.base()) }
+        unsafe { sb::C_SkShaper_RunIterator_endOfCurrentRun(self.native().base()) }
     }
 
     fn at_end(&self) -> bool {
-        unsafe { sb::C_SkShaper_RunIterator_atEnd(self.base()) }
+        unsafe { sb::C_SkShaper_RunIterator_atEnd(self.native().base()) }
     }
 }
 

--- a/skia-safe/src/prelude.rs
+++ b/skia-safe/src/prelude.rs
@@ -481,6 +481,35 @@ impl<N: NativeRefCounted> RCHandle<N> {
             Self(ptr)
         })
     }
+
+    /// Create a reference to the Rust wrapper from a reference to a pointer that points
+    /// to the native type.
+    pub(crate) fn from_unshared_ptr_ref(n: &*mut N) -> &Option<Self> {
+        unsafe { transmute_ref(n) }
+    }
+}
+
+#[cfg(tests)]
+mod rc_handle_tests {
+    use crate::prelude::RCHandle;
+    use crate::Typeface;
+    use skia_bindings::SkTypeface;
+    use std::ptr;
+
+    #[test]
+    fn rc_native_ref_null() {
+        let f: *mut SkTypeface = ptr::null_mut();
+        let r = Typeface::from_native_ref(&f);
+        assert!(r.is_none())
+    }
+
+    #[test]
+    fn rc_native_ref_non_null() {
+        let tf = Typeface::default();
+        let f: *mut SkTypeface = tf.0;
+        let r = Typeface::from_native_ref(&f);
+        assert!(r.is_some())
+    }
 }
 
 impl<N: NativeRefCounted> NativeAccess<N> for RCHandle<N> {

--- a/skia-safe/src/prelude.rs
+++ b/skia-safe/src/prelude.rs
@@ -777,7 +777,7 @@ impl<E> AsPointerOrNullMut<E> for Option<Vec<E>> {
 
 // Wraps a handle so that the Rust's borrow checker assumes it represents
 // something that borrows something else.
-#[repr(C)]
+#[repr(transparent)]
 pub struct Borrows<'a, H>(H, PhantomData<&'a ()>);
 
 impl<'a, H> Deref for Borrows<'a, H> {


### PR DESCRIPTION
This PR updates rust-skia to support Skia's `chrome/m79` branch.

- [x] Update `README.md` ([rendered](https://github.com/pragmatrix/rust-skia/blob/m79/README.md))  
  > Most important here is to change the Skia branch name and the current commit hash at the top of the `README.md` file.
- [x] Skia can be built ([release notes](https://github.com/google/skia/blob/chrome/m79/RELEASE_NOTES.txt)).
- [x] skia-bindings.
- [x] skia-safe: Update & add new wrappers by diffing include files.  
  > Add TODOs for everything that can not be updated right now, and attempt to stay compatible with previous versions of skia-safe without trying too hard before version 1.0. Use `deprecated` attributes if needed.
  - [x] `codec/`
  - [x] `core/`
  - [x] `docs/`
  - [x] `effects/`
  - [x] `gpu/`
    - [x] `gl/`
    - [x] `vk/`
  - [x] `modules/`
    - [x] `skshaper/`
    - [x] `skparagraph/`
  - [x] `pathops/`
  - [x] `svg/`
  - [x] `utils/`
- [x] ~One week before Chrome 79 stable will be released? ([Schedule](https://www.chromestatus.com/features/schedule))
- [x] Any pending changes in the Skia `chrome/m79` branch that aren't synchronized yet?
- [x] Do the hashes in `skia-bindings/Cargo.toml` under `[package.metadata]` match the submodules `depot_tools` and `skia`?
- [x] Rebase on or merge with master.
- [x] Update versions of `skia-bindings/Cargo.toml` and `skia-safe/Cargo.toml` and also add the version to the new `deprecated` attributes.
