### PR TITLE
m78: Support to pass None to image filter inputs

### DIFF
--- a/skia-safe/src/effects/arithmetic_image_filter.rs
+++ b/skia-safe/src/effects/arithmetic_image_filter.rs
@@ -7,8 +7,8 @@ impl RCHandle<SkImageFilter> {
     #[allow(clippy::too_many_arguments)]
     pub fn arithmetic<'a>(
         inputs: impl Into<ArithmeticFPInputs>,
-        background: Self,
-        foreground: Self,
+        background: impl Into<Option<Self>>,
+        foreground: impl Into<Option<Self>>,
         crop_rect: impl Into<Option<&'a IRect>>,
     ) -> Option<Self> {
         let inputs = inputs.into();

--- a/skia-safe/src/effects/displacement_map_effect.rs
+++ b/skia-safe/src/effects/displacement_map_effect.rs
@@ -34,7 +34,7 @@ fn test_channel_selector_type_layout() {
     ChannelSelector::test_layout();
 }
 
-#[deprecated(since = "0.19.0", note = "use color_filters::displacement_map")]
+#[deprecated(since = "0.19.0", note = "use image_filters::displacement_map")]
 #[allow(deprecated)]
 pub fn new<'a>(
     (x_channel_selector, y_channel_selector): (ChannelSelector, ChannelSelector),

--- a/skia-safe/src/effects/image_filters.rs
+++ b/skia-safe/src/effects/image_filters.rs
@@ -10,7 +10,7 @@ pub fn alpha_threshold<'a>(
     region: &Region,
     inner_min: scalar,
     outer_max: scalar,
-    input: ImageFilter,
+    input: impl Into<Option<ImageFilter>>,
     crop_rect: impl Into<Option<&'a IRect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
@@ -18,7 +18,7 @@ pub fn alpha_threshold<'a>(
             region.native(),
             inner_min,
             outer_max,
-            input.into_ptr(),
+            input.into().into_ptr_or_null(),
             crop_rect.into().native_ptr_or_null(),
         )
     })
@@ -31,8 +31,8 @@ pub fn arithmetic<'a>(
     k3: scalar,
     k4: scalar,
     enforce_pm_color: bool,
-    background: ImageFilter,
-    foreground: ImageFilter,
+    background: impl Into<Option<ImageFilter>>,
+    foreground: impl Into<Option<ImageFilter>>,
     crop_rect: impl Into<Option<&'a IRect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
@@ -42,8 +42,8 @@ pub fn arithmetic<'a>(
             k3,
             k4,
             enforce_pm_color,
-            background.into_ptr(),
-            foreground.into_ptr(),
+            background.into().into_ptr_or_null(),
+            foreground.into().into_ptr_or_null(),
             crop_rect.into().native_ptr_or_null(),
         )
     })
@@ -52,7 +52,7 @@ pub fn arithmetic<'a>(
 pub fn blur<'a>(
     (sigma_x, sigma_y): (scalar, scalar),
     tile_mode: impl Into<Option<TileMode>>,
-    input: ImageFilter,
+    input: impl Into<Option<ImageFilter>>,
     crop_rect: impl Into<Option<&'a IRect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
@@ -60,7 +60,7 @@ pub fn blur<'a>(
             sigma_x,
             sigma_y,
             tile_mode.into().unwrap_or(TileMode::Decal).into_native(),
-            input.into_ptr(),
+            input.into().into_ptr_or_null(),
             crop_rect.into().native_ptr_or_null(),
         )
     })
@@ -68,13 +68,13 @@ pub fn blur<'a>(
 
 pub fn color_filter<'a>(
     cf: ColorFilter,
-    input: ImageFilter,
+    input: impl Into<Option<ImageFilter>>,
     crop_rect: impl Into<Option<&'a IRect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
         sb::C_SkImageFilters_ColorFilter(
             cf.into_ptr(),
-            input.into_ptr(),
+            input.into().into_ptr_or_null(),
             crop_rect.into().native_ptr_or_null(),
         )
     })
@@ -89,7 +89,7 @@ pub fn compose(outer: ImageFilter, inner: ImageFilter) -> Option<ImageFilter> {
 pub fn displacement_map<'a>(
     (x_channel_selector, y_channel_selector): (ColorChannel, ColorChannel),
     scale: scalar,
-    displacement: ImageFilter,
+    displacement: impl Into<Option<ImageFilter>>,
     color: ImageFilter,
     crop_rect: impl Into<Option<&'a IRect>>,
 ) -> Option<ImageFilter> {
@@ -98,7 +98,7 @@ pub fn displacement_map<'a>(
             x_channel_selector.into_native(),
             y_channel_selector.into_native(),
             scale,
-            displacement.into_ptr(),
+            displacement.into().into_ptr_or_null(),
             color.into_ptr(),
             crop_rect.into().native_ptr_or_null(),
         )
@@ -109,7 +109,7 @@ pub fn drop_shadow<'a>(
     delta: impl Into<Vector>,
     (sigma_x, sigma_y): (scalar, scalar),
     color: impl Into<Color>,
-    input: ImageFilter,
+    input: impl Into<Option<ImageFilter>>,
     crop_rect: impl Into<Option<&'a IRect>>,
 ) -> Option<ImageFilter> {
     let delta = delta.into();
@@ -121,7 +121,7 @@ pub fn drop_shadow<'a>(
             sigma_x,
             sigma_y,
             color.into_native(),
-            input.into_ptr(),
+            input.into().into_ptr_or_null(),
             crop_rect.into().native_ptr_or_null(),
         )
     })
@@ -131,7 +131,7 @@ pub fn drop_shadow_only<'a>(
     delta: impl Into<Vector>,
     (sigma_x, sigma_y): (scalar, scalar),
     color: impl Into<Color>,
-    input: ImageFilter,
+    input: impl Into<Option<ImageFilter>>,
     crop_rect: impl Into<Option<&'a IRect>>,
 ) -> Option<ImageFilter> {
     let delta = delta.into();
@@ -143,7 +143,7 @@ pub fn drop_shadow_only<'a>(
             sigma_x,
             sigma_y,
             color.into_native(),
-            input.into_ptr(),
+            input.into().into_ptr_or_null(),
             crop_rect.into().native_ptr_or_null(),
         )
     })
@@ -173,14 +173,14 @@ pub fn image<'a>(
 pub fn magnifier<'a>(
     src_rect: impl AsRef<Rect>,
     inset: scalar,
-    input: ImageFilter,
+    input: impl Into<Option<ImageFilter>>,
     crop_rect: impl Into<Option<&'a IRect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
         sb::C_SkImageFilters_Magnifier(
             src_rect.as_ref().native(),
             inset,
-            input.into_ptr(),
+            input.into().into_ptr_or_null(),
             crop_rect.into().native_ptr_or_null(),
         )
     })
@@ -195,7 +195,7 @@ pub fn matrix_convolution<'a>(
     kernel_offset: impl Into<IPoint>,
     tile_mode: TileMode,
     convolve_alpha: bool,
-    input: ImageFilter,
+    input: impl Into<Option<ImageFilter>>,
     crop_rect: impl Into<Option<&'a IRect>>,
 ) -> Option<ImageFilter> {
     let kernel_size = kernel_size.into();
@@ -212,7 +212,7 @@ pub fn matrix_convolution<'a>(
             kernel_offset.into().native(),
             tile_mode.into_native(),
             convolve_alpha,
-            input.into_ptr(),
+            input.into().into_ptr_or_null(),
             crop_rect.into().native_ptr_or_null(),
         )
     })
@@ -221,23 +221,24 @@ pub fn matrix_convolution<'a>(
 pub fn matrix_transform(
     matrix: &Matrix,
     filter_quality: FilterQuality,
-    input: ImageFilter,
+    input: impl Into<Option<ImageFilter>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
         sb::C_SkImageFilters_MatrixTransform(
             matrix.native(),
             filter_quality.into_native(),
-            input.into_ptr(),
+            input.into().into_ptr_or_null(),
         )
     })
 }
 
 #[allow(clippy::new_ret_no_self)]
 pub fn merge<'a>(
-    filters: impl IntoIterator<Item = ImageFilter>,
+    filters: impl IntoIterator<Item = Option<ImageFilter>>,
     crop_rect: impl Into<Option<&'a IRect>>,
 ) -> Option<ImageFilter> {
-    let filter_ptrs: Vec<*mut SkImageFilter> = filters.into_iter().map(|f| f.into_ptr()).collect();
+    let filter_ptrs: Vec<*mut SkImageFilter> =
+        filters.into_iter().map(|f| f.into_ptr_or_null()).collect();
     ImageFilter::from_ptr(unsafe {
         sb::C_SkImageFilters_Merge(
             filter_ptrs.as_ptr(),
@@ -249,7 +250,7 @@ pub fn merge<'a>(
 
 pub fn offset<'a>(
     delta: impl Into<Vector>,
-    input: ImageFilter,
+    input: impl Into<Option<ImageFilter>>,
     crop_rect: impl Into<Option<&'a IRect>>,
 ) -> Option<ImageFilter> {
     let delta = delta.into();
@@ -257,7 +258,7 @@ pub fn offset<'a>(
         sb::C_SkImageFilters_Offset(
             delta.x,
             delta.y,
-            input.into_ptr(),
+            input.into().into_ptr_or_null(),
             crop_rect.into().native_ptr_or_null(),
         )
     })
@@ -284,27 +285,27 @@ pub fn picture<'a>(
 pub fn tile(
     src: impl AsRef<Rect>,
     dst: impl AsRef<Rect>,
-    input: ImageFilter,
+    input: impl Into<Option<ImageFilter>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
         sb::C_SkImageFilters_Tile(
             src.as_ref().native(),
             dst.as_ref().native(),
-            input.into_ptr(),
+            input.into().into_ptr_or_null(),
         )
     })
 }
 
 pub fn xfermode<'a>(
     blend_mode: BlendMode,
-    background: ImageFilter,
+    background: impl Into<Option<ImageFilter>>,
     foreground: impl Into<Option<ImageFilter>>,
     crop_rect: impl Into<Option<&'a IRect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
         sb::C_SkImageFilters_Xfermode(
             blend_mode.into_native(),
-            background.into_ptr(),
+            background.into().into_ptr_or_null(),
             foreground.into().into_ptr_or_null(),
             crop_rect.into().native_ptr_or_null(),
         )
@@ -313,14 +314,14 @@ pub fn xfermode<'a>(
 
 pub fn dilate<'a>(
     (radius_x, radius_y): (i32, i32),
-    input: ImageFilter,
+    input: impl Into<Option<ImageFilter>>,
     crop_rect: impl Into<Option<&'a IRect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
         sb::C_SkImageFilters_Dilate(
             radius_x,
             radius_y,
-            input.into_ptr(),
+            input.into().into_ptr_or_null(),
             crop_rect.into().native_ptr_or_null(),
         )
     })
@@ -328,14 +329,14 @@ pub fn dilate<'a>(
 
 pub fn erode<'a>(
     (radius_x, radius_y): (i32, i32),
-    input: ImageFilter,
+    input: impl Into<Option<ImageFilter>>,
     crop_rect: impl Into<Option<&'a IRect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
         sb::C_SkImageFilters_Erode(
             radius_x,
             radius_y,
-            input.into_ptr(),
+            input.into().into_ptr_or_null(),
             crop_rect.into().native_ptr_or_null(),
         )
     })
@@ -346,7 +347,7 @@ pub fn distant_lit_diffuse<'a>(
     light_color: impl Into<Color>,
     surface_scale: scalar,
     kd: scalar,
-    input: ImageFilter,
+    input: impl Into<Option<ImageFilter>>,
     crop_rect: impl Into<Option<&'a IRect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
@@ -355,7 +356,7 @@ pub fn distant_lit_diffuse<'a>(
             light_color.into().into_native(),
             surface_scale,
             kd,
-            input.into_ptr(),
+            input.into().into_ptr_or_null(),
             crop_rect.into().native_ptr_or_null(),
         )
     })
@@ -366,7 +367,7 @@ pub fn point_lit_diffuse<'a>(
     light_color: impl Into<Color>,
     surface_scale: scalar,
     kd: scalar,
-    input: ImageFilter,
+    input: impl Into<Option<ImageFilter>>,
     crop_rect: impl Into<Option<&'a IRect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
@@ -375,7 +376,7 @@ pub fn point_lit_diffuse<'a>(
             light_color.into().into_native(),
             surface_scale,
             kd,
-            input.into_ptr(),
+            input.into().into_ptr_or_null(),
             crop_rect.into().native_ptr_or_null(),
         )
     })
@@ -390,7 +391,7 @@ pub fn spot_lit_diffuse<'a>(
     light_color: impl Into<Color>,
     surface_scale: scalar,
     kd: scalar,
-    input: ImageFilter,
+    input: impl Into<Option<ImageFilter>>,
     crop_rect: impl Into<Option<&'a IRect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
@@ -402,7 +403,7 @@ pub fn spot_lit_diffuse<'a>(
             light_color.into().into_native(),
             surface_scale,
             kd,
-            input.into_ptr(),
+            input.into().into_ptr_or_null(),
             crop_rect.into().native_ptr_or_null(),
         )
     })
@@ -414,7 +415,7 @@ pub fn distant_lit_specular<'a>(
     surface_scale: scalar,
     ks: scalar,
     shininess: scalar,
-    input: ImageFilter,
+    input: impl Into<Option<ImageFilter>>,
     crop_rect: impl Into<Option<&'a IRect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
@@ -424,7 +425,7 @@ pub fn distant_lit_specular<'a>(
             surface_scale,
             ks,
             shininess,
-            input.into_ptr(),
+            input.into().into_ptr_or_null(),
             crop_rect.into().native_ptr_or_null(),
         )
     })
@@ -436,7 +437,7 @@ pub fn point_lit_specular<'a>(
     surface_scale: scalar,
     ks: scalar,
     shininess: scalar,
-    input: ImageFilter,
+    input: impl Into<Option<ImageFilter>>,
     crop_rect: impl Into<Option<&'a IRect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
@@ -446,7 +447,7 @@ pub fn point_lit_specular<'a>(
             surface_scale,
             ks,
             shininess,
-            input.into_ptr(),
+            input.into().into_ptr_or_null(),
             crop_rect.into().native_ptr_or_null(),
         )
     })
@@ -462,7 +463,7 @@ pub fn spot_lit_specular<'a>(
     surface_scale: scalar,
     ks: scalar,
     shininess: scalar,
-    input: ImageFilter,
+    input: impl Into<Option<ImageFilter>>,
     crop_rect: impl Into<Option<&'a IRect>>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
@@ -475,7 +476,7 @@ pub fn spot_lit_specular<'a>(
             surface_scale,
             ks,
             shininess,
-            input.into_ptr(),
+            input.into().into_ptr_or_null(),
             crop_rect.into().native_ptr_or_null(),
         )
     })

--- a/skia-safe/src/effects/image_source.rs
+++ b/skia-safe/src/effects/image_source.rs
@@ -47,12 +47,12 @@ impl RCHandle<SkImage> {
     }
 }
 
-#[deprecated(since = "0.19.0", note = "use color_filters::image")]
+#[deprecated(since = "0.19.0", note = "use image_filters::image")]
 pub fn from_image(image: Image) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe { sb::C_SkImageSource_Make(image.into_ptr()) })
 }
 
-#[deprecated(since = "0.19.0", note = "use color_filters::image")]
+#[deprecated(since = "0.19.0", note = "use image_filters::image")]
 pub fn from_image_rect(
     image: Image,
     src_rect: impl AsRef<Rect>,

--- a/skia-safe/src/effects/lighting_image_filter.rs
+++ b/skia-safe/src/effects/lighting_image_filter.rs
@@ -126,7 +126,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "0.19.0", note = "use color_filters::distant_lit_diffuse")]
+#[deprecated(since = "0.19.0", note = "use image_filters::distant_lit_diffuse")]
 pub fn distant_lit_diffuse<'a>(
     direction: impl Into<Point3>,
     light_color: impl Into<Color>,
@@ -147,7 +147,7 @@ pub fn distant_lit_diffuse<'a>(
     })
 }
 
-#[deprecated(since = "0.19.0", note = "use color_filters::point_lit_diffuse")]
+#[deprecated(since = "0.19.0", note = "use image_filters::point_lit_diffuse")]
 pub fn point_lit_diffuse<'a>(
     location: impl Into<Point3>,
     light_color: impl Into<Color>,
@@ -168,7 +168,7 @@ pub fn point_lit_diffuse<'a>(
     })
 }
 
-#[deprecated(since = "0.19.0", note = "use color_filters::spot_lit_diffuse")]
+#[deprecated(since = "0.19.0", note = "use image_filters::spot_lit_diffuse")]
 #[allow(clippy::too_many_arguments)]
 pub fn spot_lit_diffuse<'a>(
     location: impl Into<Point3>,
@@ -196,7 +196,7 @@ pub fn spot_lit_diffuse<'a>(
     })
 }
 
-#[deprecated(since = "0.19.0", note = "use color_filters::distant_lit_specular")]
+#[deprecated(since = "0.19.0", note = "use image_filters::distant_lit_specular")]
 pub fn distant_lit_specular<'a>(
     direction: impl Into<Point3>,
     light_color: impl Into<Color>,
@@ -219,7 +219,7 @@ pub fn distant_lit_specular<'a>(
     })
 }
 
-#[deprecated(since = "0.19.0", note = "use color_filters::point_lit_specular")]
+#[deprecated(since = "0.19.0", note = "use image_filters::point_lit_specular")]
 pub fn point_lit_specular<'a>(
     location: impl Into<Point3>,
     light_color: impl Into<Color>,
@@ -242,7 +242,7 @@ pub fn point_lit_specular<'a>(
     })
 }
 
-#[deprecated(since = "0.19.0", note = "use color_filters::spot_lit_specular")]
+#[deprecated(since = "0.19.0", note = "use image_filters::spot_lit_specular")]
 #[allow(clippy::too_many_arguments)]
 pub fn spot_lit_specular<'a>(
     location: impl Into<Point3>,

--- a/skia-safe/src/effects/magnifier_image_filter.rs
+++ b/skia-safe/src/effects/magnifier_image_filter.rs
@@ -14,7 +14,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "0.19.0", note = "use color_filters::magnifier")]
+#[deprecated(since = "0.19.0", note = "use image_filters::magnifier")]
 pub fn new<'a>(
     src_rect: impl AsRef<Rect>,
     inset: scalar,

--- a/skia-safe/src/effects/matrix_convolution_image_filter.rs
+++ b/skia-safe/src/effects/matrix_convolution_image_filter.rs
@@ -47,7 +47,7 @@ fn test_tile_mode_layout() {
     TileMode::test_layout();
 }
 
-#[deprecated(since = "0.19.0", note = "use color_filters::matrix_convolution")]
+#[deprecated(since = "0.19.0", note = "use image_filters::matrix_convolution")]
 #[allow(deprecated)]
 #[allow(clippy::too_many_arguments)]
 pub fn new<'a>(

--- a/skia-safe/src/effects/merge_image_filter.rs
+++ b/skia-safe/src/effects/merge_image_filter.rs
@@ -13,7 +13,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "0.19.0", note = "use color_filters::merge")]
+#[deprecated(since = "0.19.0", note = "use image_filters::merge")]
 #[allow(clippy::new_ret_no_self)]
 pub fn new<'a>(
     filters: impl IntoIterator<Item = ImageFilter>,

--- a/skia-safe/src/effects/merge_image_filter.rs
+++ b/skia-safe/src/effects/merge_image_filter.rs
@@ -6,7 +6,7 @@ use std::convert::TryInto;
 
 impl RCHandle<SkImageFilter> {
     pub fn merge<'a>(
-        filters: impl IntoIterator<Item = Self>,
+        filters: impl IntoIterator<Item = Option<Self>>,
         crop_rect: impl Into<Option<&'a IRect>>,
     ) -> Option<Self> {
         image_filters::merge(filters, crop_rect)

--- a/skia-safe/src/effects/morphology_image_filter.rs
+++ b/skia-safe/src/effects/morphology_image_filter.rs
@@ -26,7 +26,7 @@ pub mod dilate_image_filter {
     use crate::ImageFilter;
     use skia_bindings as sb;
 
-    #[deprecated(since = "0.19.0", note = "use color_filters::dilate")]
+    #[deprecated(since = "0.19.0", note = "use image_filters::dilate")]
     pub fn new<'a>(
         (radius_x, radius_y): (i32, i32),
         input: ImageFilter,
@@ -49,7 +49,7 @@ pub mod erode_image_filter {
     use crate::ImageFilter;
     use skia_bindings as sb;
 
-    #[deprecated(since = "0.19.0", note = "use color_filters::erode")]
+    #[deprecated(since = "0.19.0", note = "use image_filters::erode")]
     pub fn new<'a>(
         (radius_x, radius_y): (i32, i32),
         input: ImageFilter,

--- a/skia-safe/src/effects/offset_image_filter.rs
+++ b/skia-safe/src/effects/offset_image_filter.rs
@@ -13,7 +13,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "0.19.0", note = "use color_filters::offset")]
+#[deprecated(since = "0.19.0", note = "use image_filters::offset")]
 pub fn new<'a>(
     delta: impl Into<Vector>,
     input: ImageFilter,

--- a/skia-safe/src/effects/paint_image_filter.rs
+++ b/skia-safe/src/effects/paint_image_filter.rs
@@ -18,7 +18,7 @@ impl Handle<SkPaint> {
     }
 }
 
-#[deprecated(since = "0.19.0", note = "use color_filters::paint")]
+#[deprecated(since = "0.19.0", note = "use image_filters::paint")]
 pub fn from_paint<'a>(
     paint: &Paint,
     crop_rect: impl Into<Option<&'a CropRect>>,

--- a/skia-safe/src/effects/picture_image_filter.rs
+++ b/skia-safe/src/effects/picture_image_filter.rs
@@ -28,7 +28,7 @@ impl RCHandle<SkPicture> {
     }
 }
 
-#[deprecated(since = "0.19.0", note = "use color_filters::picture")]
+#[deprecated(since = "0.19.0", note = "use image_filters::picture")]
 pub fn from_picture<'a>(
     picture: Picture,
     target_rect: impl Into<Option<&'a Rect>>,

--- a/skia-safe/src/effects/tile_image_filter.rs
+++ b/skia-safe/src/effects/tile_image_filter.rs
@@ -9,7 +9,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "0.19.0", note = "use color_filters::tile")]
+#[deprecated(since = "0.19.0", note = "use image_filters::tile")]
 pub fn new(
     src: impl AsRef<Rect>,
     dst: impl AsRef<Rect>,

--- a/skia-safe/src/effects/xfer_mode_image_filter.rs
+++ b/skia-safe/src/effects/xfer_mode_image_filter.rs
@@ -14,7 +14,7 @@ impl RCHandle<SkImageFilter> {
     }
 }
 
-#[deprecated(since = "0.19.0", note = "use color_filters::xfermode()")]
+#[deprecated(since = "0.19.0", note = "use image_filters::xfermode()")]
 pub fn new<'a>(
     blend_mode: BlendMode,
     background: ImageFilter,

--- a/skia-safe/src/effects/xfer_mode_image_filter.rs
+++ b/skia-safe/src/effects/xfer_mode_image_filter.rs
@@ -6,7 +6,7 @@ use skia_bindings::SkImageFilter;
 impl RCHandle<SkImageFilter> {
     pub fn xfer_mode<'a>(
         blend_mode: BlendMode,
-        background: ImageFilter,
+        background: impl Into<Option<ImageFilter>>,
         foreground: impl Into<Option<ImageFilter>>,
         crop_rect: impl Into<Option<&'a IRect>>,
     ) -> Option<Self> {


### PR DESCRIPTION
As noted in #218, several functions that create image filters should support accepting `None` as image filter inputs.

Closes #218 
