### PR TITLE
Experiment: Build with --target wasm32-unknown-emscripten

### DIFF
--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -127,6 +127,14 @@ jobs:
         echo "##vso[task.setvariable variable=PATH;]${PATH}:${HOME}/android-ndk-$(androidNDK)/toolchains/llvm/prebuilt/$(androidHost)/bin"
       displayName: 'Install Android NDK $(androidNDK)'
 
+  - ${{ if eq(parameters.platform, 'macOS') }}:
+      # macOS
+      - bash: |
+          set -e
+          brew unlink node@6
+          brew install emscripten --force
+        displayName: Install Emscripten
+
   # Note: support to ignore specific rust files and directories is unstable yet: https://github.com/rust-lang/rustfmt/pull/2522
   - bash: |
       set -e
@@ -144,6 +152,11 @@ jobs:
       releaseBinaries: ${{ parameters.deployRelease }}
 
   - ${{ if eq(parameters.platform, 'macOS') }}:
+    - template: 'azure-pipelines-build-target.yml'
+      parameters:
+        target: 'wasm32-unknown-emscripten'
+        releaseBinaries: true
+
     - template: 'azure-pipelines-build-target.yml'
       parameters:
         target: 'aarch64-linux-android'

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -227,7 +227,7 @@ impl FinalBuildConfiguration {
                     args.push(("target_os", quote("ios")));
                     args.push(("target_cpu", quote(clang::target_arch(arch))));
                 }
-                ("wasm32", "unknown", _, _) => {
+                ("wasm32", "unknown", "emscripten", _) => {
                     args.push(("target_cpu", quote("wasm")));
                     compiler_executables = ("emcc", "em++");
                 }
@@ -649,7 +649,12 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
             }
         }
         ("wasm32", "unknown", "emscripten", _) => {
-            builder = builder.clang_arg("--target=wasm32");
+            builder = builder.clang_arg("--target=wasm32-unknown-emscripten");
+            // Add C++ includes (otherwise build will fail with <cmath> not found)
+            builder = builder.clang_arg("-I/usr/share/emscripten/system/include/libcxx");
+            // visibility=default, otherwise some types may be missing:
+            // https://github.com/rust-lang/rust-bindgen/issues/751#issuecomment-555735577
+            builder = builder.clang_arg("-fvisibility=default");
         }
         _ => {}
     }


### PR DESCRIPTION
This PR is an humble experiment to build Skia, skia-bindings, and skia-safe with `--target wasm32-unknown-emscripten`.

In addition to the regular build prerequisites noted in the README, this PR requires [emscripten](https://emscripten.org/docs/getting_started/downloads.html) to be installed.

So far I've only managed to build Skia, skia-bindings, and skia-safe on Ubuntu 19 but anything beyond that, for example linking an example application fails.

Any help is appreciated.

Status:

- [ ] Ubuntu 18 / 19
  - [x] skia-bindings
    - [x] Skia
    - [x] skia-bindings lib
    - [x] bindings.rs
  - [x] skia-safe
  - [ ] example: skia-org
- [ ] macOS
  - [ ] skia-bindings
    - [ ] Skia
    - [ ] skia-bindings lib
    - [ ] bindings.rs
  - [ ] skia-safe
  - [ ] example: skia-org
- [ ] Windows
  - [ ] skia-bindings
    - [ ] Skia
    - [ ] skia-bindings lib
    - [ ] bindings.rs
  - [ ] skia-safe
  - [ ] example: skia-org

I'll try to keep this PR up to date so that anyone who likes to help can step in anytime (PR against my branch).

Closes #39 