### PR TITLE
include! bindings.rs

### DIFF
--- a/skia-bindings/.gitignore
+++ b/skia-bindings/.gitignore
@@ -1,2 +1,0 @@
-/src/bindings.rs
-/src/bindings.rs.bk

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -21,10 +21,8 @@ include = [
 	"build_support/**/*.rs", 
 	"src/**/*.h", 
 	"src/**/*.cpp", 
-	"src/defaults.rs", 
-	"src/icu.rs", 
-	"src/impls.rs",
-	"src/lib.rs" ]
+	"src/*.rs" 
+]
 
 [lib]
 doctest = false

--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -1,8 +1,8 @@
 mod build_support;
 use build_support::{binaries, cargo, git, skia, utils};
+use std::io;
 use std::io::Cursor;
 use std::path::Path;
-use std::{fs, io};
 
 /// Environment variables used by this build script.
 mod env {

--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -202,8 +202,6 @@ fn download_and_install(url: impl AsRef<str>, output_directory: &Path) -> io::Re
     );
     binaries::unpack(Cursor::new(archive), output_directory)?;
     // TODO: verify key?
-    println!("INSTALLING BINDINGS");
-    fs::copy(output_directory.join("bindings.rs"), SRC_BINDINGS_RS)?;
 
     Ok(())
 }

--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -59,7 +59,6 @@ mod env {
     }
 }
 
-const SRC_BINDINGS_RS: &str = "src/bindings.rs";
 const SKIA_LICENSE: &str = "skia/LICENSE";
 
 fn main() {
@@ -162,10 +161,7 @@ fn main() {
         );
 
         println!("EXPORTING BINARIES");
-        let source_files = &[
-            (SRC_BINDINGS_RS, "bindings.rs"),
-            (SKIA_LICENSE, "LICENSE_SKIA"),
-        ];
+        let source_files = &[(SKIA_LICENSE, "LICENSE_SKIA")];
         binaries::export(&binaries_config, source_files, &staging_directory)
             .expect("EXPORTING BINARIES FAILED")
     }

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -704,9 +704,6 @@ fn generate_bindings(build: &FinalBuildConfiguration, output_directory: &Path) {
         })
         .size_t_is_usize(true)
         .parse_callbacks(Box::new(ParseCallbacks))
-        .raw_line("#![allow(clippy::all)]")
-        // GrVkBackendContext contains u128 fields on macOS
-        .raw_line("#![allow(improper_ctypes)]")
         .allowlist_function("C_.*")
         .constified_enum(".*Mask")
         .constified_enum(".*Flags")
@@ -887,9 +884,8 @@ fn generate_bindings(build: &FinalBuildConfiguration, output_directory: &Path) {
     println!("GENERATING BINDINGS");
     let bindings = builder.generate().expect("Unable to generate bindings");
 
-    let out_path = PathBuf::from("src");
     bindings
-        .write_to_file(out_path.join("bindings.rs"))
+        .write_to_file(output_directory.join("bindings.rs"))
         .expect("Couldn't write bindings!");
 }
 

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -481,7 +481,7 @@ impl BinariesConfiguration {
         let target = cargo::target();
 
         let mut built_libraries = Vec::new();
-        let mut additional_files = Vec::new();
+        let mut additional_files: Vec<PathBuf> = vec!["bindings.rs".into()];
         let feature_ids = features.ids();
 
         if features.text_layout {

--- a/skia-bindings/src/lib.rs
+++ b/skia-bindings/src/lib.rs
@@ -1,9 +1,14 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+#![allow(clippy::all)]
+// GrVkBackendContext contains u128 fields on macOS
+#![allow(improper_ctypes)]
+// mem::uninitialized()
+#![allow(invalid_value)]
+#![allow(deprecated)]
 
-mod bindings;
-pub use bindings::*;
+include!(concat!(env!("OUT_DIR"), "/skia/bindings.rs"));
 
 mod defaults;
 pub use defaults::*;


### PR DESCRIPTION
Now that IntelliJ Rust has landed support for `include!(concat!(env!("OUT_DIR"), ..))` it's time to prepare a PR that generates the `bindings.rs` file in the output directory and includes it from `skia-bindings/src/lib.rs`.

To enable code insight in IntelliJ based IDEs, the experimental feature `org.rust.cargo.fetch.out.dir` has to be enabled. More information [is available from the IntelliJ Rust team](https://blog.jetbrains.com/clion/2019/12/recent-updates-in-rust/).

I'll keep this PR open and unmerged until both IntelliJ Rust and Rust Analyzer are officially resolving `OUT_DIR` [through the build script output](https://github.com/rust-lang/cargo/pull/7622) as a faster alternative compared to `cargo --build-plan` that is currently in use.

Closes #10 