### PR TITLE
Compile Skia with /MT on Windows in case of a static build

### DIFF
--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -280,8 +280,7 @@ impl FinalBuildConfiguration {
                     // When static feature is enabled (target-feature=+crt-static) the C runtime should be statically linked
                     // and the compiler has to place the library name LIBCMT.lib into the .obj
                     // See https://docs.microsoft.com/en-us/cpp/build/reference/md-mt-ld-use-run-time-library?view=vs-2019
-                    if cfg!(target_feature = "crt-static")
-                    {
+                    if cfg!(target_feature = "crt-static") {
                         flags.push("/MT");
                     }
                     // otherwith the C runtime should be linked dynamically


### PR DESCRIPTION
Compilation of `rust-bindings` fails on Windows when static feature is enabled (`target-feature=+crt-static`). It is caused by the hardcoded `/MD` flag in `skia.rs`:
https://github.com/rust-skia/rust-skia/blob/16e5d76f3ce25586a11c5366c0fd9cb9558a6e97/skia-bindings/build_support/skia.rs#L280

The following output is produced by the linker:
```
...
libskia_bindings-3a6fe11b7ffa2c88.rlib(skia.SkShadowUtils.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MD_DynamicRelease' doesn't match value 'MT_StaticRelease' in libskia_bindings-3a6fe11b7ffa2c88.rlib(bindings.o)
libskia_bindings-3a6fe11b7ffa2c88.rlib(skia.SkTextBlob.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MD_DynamicRelease' doesn't match value 'MT_StaticRelease' in libskia_bindings-3a6fe11b7ffa2c88.rlib(bindings.o)
libskia_bindings-3a6fe11b7ffa2c88.rlib(gpu.GrBackendSurface.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MD_DynamicRelease' doesn't match value 'MT_StaticRelease' in libskia_bindings-3a6fe11b7ffa2c88.rlib(bindings.o)
libskia_bindings-3a6fe11b7ffa2c88.rlib(skia.SkPath.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MD_DynamicRelease' doesn't match value 'MT_StaticRelease' in libskia_bindings-3a6fe11b7ffa2c88.rlib(bindings.o)
libskia_bindings-3a6fe11b7ffa2c88.rlib(skia.SkRect.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MD_DynamicRelease' doesn't match value 'MT_StaticRelease' in libskia_bindings-3a6fe11b7ffa2c88.rlib(bindings.o)
libskia_bindings-3a6fe11b7ffa2c88.rlib(skia.SkImage.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MD_DynamicRelease' doesn't match value 'MT_StaticRelease' in libskia_bindings-3a6fe11b7ffa2c88.rlib(bindings.o)
...
```

This pull request changes `skia.rs` build script to support static and dynamic C runtimes according to [rust-lang.org/static-and-dynamic-c-runtimes](https://doc.rust-lang.org/reference/linkage.html#static-and-dynamic-c-runtimes) in which we use conditional compilation relying on`(target_feature = "crt-static")` to choose the correct compiler flag (`/MD` vs `/MT`)