### PR TITLE
Don't download the current binaries if the crt-static target feature is set.

### DIFF
--- a/skia-bindings/build_support/binaries.rs
+++ b/skia-bindings/build_support/binaries.rs
@@ -98,6 +98,10 @@ pub fn key(repository_short_hash: &str, features: &[impl AsRef<str>]) -> String 
         components.push(group(features));
     };
 
+    if cargo::target_crt_static() {
+        components.push("static".into());
+    }
+
     components.join("-")
 }
 

--- a/skia-bindings/build_support/cargo.rs
+++ b/skia-bindings/build_support/cargo.rs
@@ -74,6 +74,10 @@ pub fn target() -> Target {
     parse_target(target_str)
 }
 
+pub fn target_crt_static() -> bool {
+    cfg!(target_feature = "crt-static")
+}
+
 pub fn host() -> Target {
     let host_str = env::var("HOST").unwrap();
     println!("HOST: {}", host_str);

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -280,10 +280,10 @@ impl FinalBuildConfiguration {
                     // When static feature is enabled (target-feature=+crt-static) the C runtime should be statically linked
                     // and the compiler has to place the library name LIBCMT.lib into the .obj
                     // See https://docs.microsoft.com/en-us/cpp/build/reference/md-mt-ld-use-run-time-library?view=vs-2019
-                    if cfg!(target_feature = "crt-static") {
+                    if cargo::target_crt_static() {
                         flags.push("/MT");
                     }
-                    // otherwith the C runtime should be linked dynamically
+                    // otherwise the C runtime should be linked dynamically
                     else {
                         flags.push("/MD");
                     }


### PR DESCRIPTION
Related to #230 

The current prebuilt Windows binaries are not compatible with static runtimes and will generate linker errors when downloaded. This PR fixes that problem by appending a `-static` to the binaries key if the `crt-static` target feature is set. This also opens up the possibility to generate static prebuilt Windows binaries in the future.

/cc @syrel 
