### PR TITLE
Disable the Packaging stage for the release branch, it won't work any…

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,58 +48,60 @@ stages:
       image: 'windows-2019'
       deployRelease: ${{ eq(variables['build.SourceBranchName'], 'release') }}
 
-- stage: 'Package'
-  condition: and(succeeded(), eq(variables.deployRelease, 'True'))
-  jobs:
-  - job:
-    pool:
-      vmImage: ubuntu-16.04
-    variables:
-      rust_backtrace: 1
-
-    steps:
-    - bash: |
-        set -e
-        rustup default stable
-        rustup update stable
-        rustc -Vv
-        cargo -V
-      displayName: 'Update Rust and Print Versions'
-
-    # skia-bindings gets packaged without verification, because the build process modifies the src directory.
-    # TODO: reenable package verification as soon CLion and rust-analyzer supports !include macros.
-    - bash: |
-        set -e
-        (cd skia-bindings && cargo package -vv --no-verify --target-dir /tmp/)
-        mkdir -p "$(Build.ArtifactStagingDirectory)/package/"
-        cp /tmp/package/skia-bindings-*.crate "$(Build.ArtifactStagingDirectory)/package/"
-        # pseudo-verification:
-        (cd /tmp/package && tar xzf skia-bindings-*.crate && rm skia-bindings-*.crate)
-        (cd /tmp/package/skia-bindings-* && cargo build -vv --release)
-      displayName: 'Package and Verify skia-bindings'
-
-    # TODO: why does this fail with
-    # error: 1 files in the working directory contain changes that were not yet committed into git:
-    #   src/prelude.rs
-    # to proceed despite this, pass the `--allow-dirty` flag
-    # TODO: find a better way to extract the GITHUB_RELEASE_TAG
-    - bash: |
-        set -e
-        cd skia-safe && cargo package -vv --offline --no-verify --allow-dirty --target-dir "$(Build.ArtifactStagingDirectory)"
-        export GITHUB_RELEASE_TAG=$(cd "$(Build.ArtifactStagingDirectory)/package" && find skia-safe-*.crate | cut -d'-' -f3 | cut -d'.' -f1-3)
-        echo "##vso[task.setvariable variable=GITHUB_RELEASE_TAG;]${GITHUB_RELEASE_TAG}"
-      displayName: 'Package skia-safe'
-
-    - task: GithubRelease@0
-      displayName: 'Release to GitHub rust-skia/rust-skia'
-      inputs:
-        action: 'edit'
-        gitHubConnection: 'rust-skia-github-connection'
-        repositoryName: 'rust-skia/rust-skia'
-        tagSource: 'manual'
-        target: 'release'
-        tag: '$(GITHUB_RELEASE_TAG)'
-        assets: '$(Build.ArtifactStagingDirectory)/package/*.crate'
-        assetUploadMode: 'replace'
-        isPreRelease: true
-        addChangeLog: false
+# Because deployment can not be done automatically, the Package stage got disabled for now.
+#
+# - stage: 'Package'
+#  condition: and(succeeded(), eq(variables.deployRelease, 'True'))
+#  jobs:
+#  - job:
+#     pool:
+#       vmImage: ubuntu-16.04
+#     variables:
+#       rust_backtrace: 1
+# 
+#     steps:
+#     - bash: |
+#         set -e
+#         rustup default stable
+#         rustup update stable
+#         rustc -Vv
+#         cargo -V
+#       displayName: 'Update Rust and Print Versions'
+# 
+#     # skia-bindings gets packaged without verification, because the build process modifies the src directory.
+#     # TODO: reenable package verification as soon CLion and rust-analyzer supports !include macros.
+#     - bash: |
+#         set -e
+#         (cd skia-bindings && cargo package -vv --no-verify --target-dir /tmp/)
+#         mkdir -p "$(Build.ArtifactStagingDirectory)/package/"
+#         cp /tmp/package/skia-bindings-*.crate "$(Build.ArtifactStagingDirectory)/package/"
+#         # pseudo-verification:
+#         (cd /tmp/package && tar xzf skia-bindings-*.crate && rm skia-bindings-*.crate)
+#         (cd /tmp/package/skia-bindings-* && cargo build -vv --release)
+#       displayName: 'Package and Verify skia-bindings'
+# 
+#     # TODO: why does this fail with
+#     # error: 1 files in the working directory contain changes that were not yet committed into git:
+#     #   src/prelude.rs
+#     # to proceed despite this, pass the `--allow-dirty` flag
+#     # TODO: find a better way to extract the GITHUB_RELEASE_TAG
+#     - bash: |
+#         set -e
+#         cd skia-safe && cargo package -vv --offline --no-verify --allow-dirty --target-dir "$(Build.ArtifactStagingDirectory)"
+#         export GITHUB_RELEASE_TAG=$(cd "$(Build.ArtifactStagingDirectory)/package" && find skia-safe-*.crate | cut -d'-' -f3 | cut -d'.' -f1-3)
+#         echo "##vso[task.setvariable variable=GITHUB_RELEASE_TAG;]${GITHUB_RELEASE_TAG}"
+#       displayName: 'Package skia-safe'
+# 
+#     - task: GithubRelease@0
+#       displayName: 'Release to GitHub rust-skia/rust-skia'
+#       inputs:
+#         action: 'edit'
+#         gitHubConnection: 'rust-skia-github-connection'
+#         repositoryName: 'rust-skia/rust-skia'
+#         tagSource: 'manual'
+#         target: 'release'
+#         tag: '$(GITHUB_RELEASE_TAG)'
+#         assets: '$(Build.ArtifactStagingDirectory)/package/*.crate'
+#         assetUploadMode: 'replace'
+#         isPreRelease: true
+#         addChangeLog: false


### PR DESCRIPTION
…way right now.

I guess it would be better to publish the packages to crates.io instead of releasing them to github.
