### PR TITLE
Added gpu::gl::Interface::new_load_with()

### DIFF
--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -97,6 +97,7 @@
 // gpu/gl
 #include "include/gpu/gl/GrGLExtensions.h"
 #include "include/gpu/gl/GrGLInterface.h"
+#include "include/gpu/gl/GrGLAssembleInterface.h"
 // pathops/
 #include "include/pathops/SkPathOps.h"
 // utils/
@@ -2781,6 +2782,17 @@ extern "C" const GrGLInterface* C_GrGLInterface_MakeNativeInterface() {
 extern "C" GrGLExtensions* C_GrGLInterface_extensions(GrGLInterface* self) {
     return &self->fExtensions;
 }
+
+//
+// gpu/gl/GrGLAssembleInterface.h
+//
+
+typedef const void* (*GLGetProcFnVoidPtr)(void* ctx, const char name[]);
+
+extern "C" const GrGLInterface* C_GrGLInterface_MakeAssembledInterface(void *ctx, GLGetProcFnVoidPtr get) {
+  return GrGLMakeAssembledInterface(ctx, reinterpret_cast<GrGLGetProc>(get)).release();
+}
+
 //
 // gpu/GrContext.h
 //

--- a/skia-safe/src/gpu/gl/interface.rs
+++ b/skia-safe/src/gpu/gl/interface.rs
@@ -23,13 +23,16 @@ impl RCHandle<GrGLInterface> {
         Self::from_ptr(unsafe {
             sb::C_GrGLInterface_MakeAssembledInterface(
                 &loadfn as *const _ as *mut c_void,
-                Some(wrapper::<F>),
+                Some(gl_get_proc_fn_wrapper::<F>),
             ) as _
         })
     }
 }
 
-unsafe extern "C" fn wrapper<F>(ctx: *mut c_void, name: *const raw::c_char) -> *const c_void
+unsafe extern "C" fn gl_get_proc_fn_wrapper<F>(
+    ctx: *mut c_void,
+    name: *const raw::c_char,
+) -> *const c_void
 where
     F: FnMut(&str) -> *const c_void,
 {

--- a/skia-safe/src/gpu/gl/interface.rs
+++ b/skia-safe/src/gpu/gl/interface.rs
@@ -17,19 +17,21 @@ impl RCHandle<GrGLInterface> {
     }
 
     pub fn new_load_with<F>(loadfn: F) -> Option<Interface>
-    where F: FnMut(&str) -> *const c_void
+    where
+        F: FnMut(&str) -> *const c_void,
     {
         Self::from_ptr(unsafe {
             sb::C_GrGLInterface_MakeAssembledInterface(
-                &loadfn as *const _ as *mut c_void, Some(wrapper::<F>)
+                &loadfn as *const _ as *mut c_void,
+                Some(wrapper::<F>),
             ) as _
         })
     }
 }
 
-unsafe extern "C" fn wrapper<F>(ctx: *mut c_void, name: *const raw::c_char)
-                                -> *const c_void
-where F: FnMut(&str) -> *const c_void
+unsafe extern "C" fn wrapper<F>(ctx: *mut c_void, name: *const raw::c_char) -> *const c_void
+where
+    F: FnMut(&str) -> *const c_void,
 {
     (*(ctx as *mut F))(std::ffi::CStr::from_ptr(name).to_str().unwrap())
 }


### PR DESCRIPTION
Usage quite similar to `load_with()` from [gl](https://crates.io/crates/gl) crate:
```rust
    let interface = gpu::gl::Interface::new_load_with(|name| {
        gl_context.get_proc_address(name)
    });
```