### PR TITLE
Update readme regarding LLVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For other platforms, more information is available at the [OpenSSL crate documen
 
 ### Platform Support, Build Targets, and Prebuilt Binaries
 
-Because building Skia takes a lot of time and needs tools that may not be installed, the skia-bindings crate's `build.rs` tries to download prebuilt binaries from [the skia-binaries repository](<https://github.com/rust-skia/skia-binaries/releases>).
+Because building Skia takes a lot of time and needs tools that may be missing, the skia-bindings crate's `build.rs` tries to download prebuilt binaries from [the skia-binaries repository](<https://github.com/rust-skia/skia-binaries/releases>).
 
 | Platform | Binaries |
 | -------- | -------- |
@@ -47,7 +47,7 @@ There no support for WebAssembly yet. If you'd like to help out, take a look at 
 
 ### Bindings & Supported Features
 
-The supported bindings and Skia features are described in the [skia-safe package's readme](skia-safe/README.md) and prebuilt binaries are available for any single feature, or for all features combined.
+The supported bindings and Skia features are described in the [skia-safe package's readme](skia-safe/README.md) and prebuilt binaries are available for any single feature or for all features combined.
 
 ## Building
 
@@ -57,7 +57,7 @@ To prepare for that, **LLVM** and **Python 2** are needed:
 
 **LLVM**
 
-We recommend the version that comes preinstalled with your platform or, if not available, the [latest official LLVM release](http://releases.llvm.org/download.html). To see which version of LLVM/Clang is installed on your system, use `clang --version`. 
+We recommend the version that comes preinstalled with your platform, or, if not available, the [latest official LLVM release](http://releases.llvm.org/download.html). To see which version of LLVM/Clang is installed on your system, use `clang --version`. 
 
 **Python 2**
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For other platforms, more information is available at the [OpenSSL crate documen
 
 ### Platform Support, Build Targets, and prebuilt Binaries
 
-Because building Skia takes a lot of time and needs tools that may not be installed, the skia-bindings crate's `build.rs` tries to download prebuilt binaries [skia-binaries](<https://github.com/rust-skia/skia-binaries/releases>).
+Because building Skia takes a lot of time and needs tools that may not be installed, the skia-bindings crate's `build.rs` tries to download prebuilt binaries from [the skia-binaries repository](<https://github.com/rust-skia/skia-binaries/releases>).
 
 | Platform | Binaries |
 | ---- | ---- |

--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ The build script probes for `python --version` and `python2 --version` and uses 
 
   otherwise the Skia build _may_ fail to build `SkJpegUtility.cpp` and the binding generation _will_ fail with  `'TargetConditionals.h' file not found` . Also note that the command line developer tools _and_ SDK headers _should_ be reinstalled after an update of XCode.
 
-- As an alternative to Apple's XCode LLVM, install LLVM via `brew install llvm` or `brew install llvm` and then set `PATH`, `CPPFLAGS`, and `LDFLAGS` like instructed.
+- As an alternative to Apple's XCode LLVM, install LLVM via `brew install llvm` or `brew install llvm` and then set `PATH`, `CPPFLAGS`, and `LDFLAGS` like instructed. 
+
+  Note that if these environment variables are not set, [bindgen](https://github.com/rust-lang/rust-bindgen) most likely uses to the wrong `libclang.dylib`, causing spurious compilation errors (see #228).
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ Because building Skia takes a lot of time and needs tools that may not be instal
 |  Windows   | `x86_64-pc-windows-msvc` |
 | Linux Ubuntu 18 (16 should work, too).    | `x86_64-unknown-linux-gnu` |
 | macOS    | `x86_64-apple-darwin` |
-| Android (via macOS or Linux) | `aarch64-linux-android`<br/>`x86_64-linux-android` |
+| Android | `aarch64-linux-android`<br/>`x86_64-linux-android` |
 | iOS     | `aarch64-apple-ios`<br/>`x86_64-apple-ios` |
 
 There is no WebAssembly support. If you'd like to help out, take a look at issue [#42](https://github.com/rust-skia/rust-skia/pull/42).
 
 ### Bindings & Supported Features
 
-The supported bindings and Skia features are described in the [skia-safe package's readme](skia-safe/README.md) and prebuilt binaries are available for any single feature, or for all features combined.
+The supported bindings and Skia features are described in the [skia-safe package's readme](skia-safe/README.md) and prebuilt binaries are available for any single feature, or for all features combined.
 
 ## Building
 
@@ -57,7 +57,7 @@ To prepare for that, a number of prerequisites are needed:
 
 ### Prerequisites
 
-Building skia-bindings and Skia needs **LLVM** and **Python 2**.
+Building skia-bindings and Skia needs **LLVM** and **Python 2**.
 
 #### LLVM
 

--- a/README.md
+++ b/README.md
@@ -53,23 +53,19 @@ The supported bindings and Skia features are described in the [skia-safe package
 
 If the target platform or feature configuration is not available as a prebuilt binary, skia-bindings' `build.rs` will try to build Skia and the generate the Rust bindings. 
 
-To prepare for that, a number of prerequisites are needed:
+To prepare for that, **LLVM** and **Python 2** are needed:
 
-### Prerequisites
-
-Building skia-bindings and Skia needs **LLVM** and **Python 2**.
-
-#### LLVM
+**LLVM**
 
 We recommend the version that comes preinstalled with your platform or, if not available, the [latest official LLVM release](http://releases.llvm.org/download.html). To see which version of LLVM/Clang is installed on your system, use `clang --version`. 
 
-#### Python 2
+**Python 2**
 
 Python version 2.7 _must_ be available.
 
 The build script probes for `python --version` and `python2 --version` and uses the first one that looks like a version 2 executable for building Skia.
 
-### macOS
+### On macOS
 
 - Install the XCode command line developer tools with
 
@@ -89,7 +85,7 @@ The build script probes for `python --version` and `python2 --version` and uses 
 
   Note that if these environment variables are not set, [bindgen](https://github.com/rust-lang/rust-bindgen) most likely uses to the wrong `libclang.dylib`, causing spurious compilation errors (see #228).
 
-### Windows
+### On Windows
 
 - Have the latest versions of `git` and Rust ready.
 - [Install Visual Studio 2019 Build Tools](https://visualstudio.microsoft.com/downloads/) or one of the other IDE releases. If you installed the IDE version, make sure that the [Desktop Development with C++ workload](https://docs.microsoft.com/en-us/cpp/build/vscpp-step-0-installation?view=vs-2019) is installed.
@@ -106,7 +102,7 @@ The build script probes for `python --version` and `python2 --version` and uses 
   rustup default stable-msvc
   ```
 
-### Linux
+### On Linux
 
 - LLVM/Clang should be available already, if not, [install the latest version](http://releases.llvm.org/download.html).
 
@@ -118,7 +114,7 @@ cargo build -vv
 
 OpenGL libraries _may_ be missing, if that is the case, install OpenGL drivers for you graphics card, or install a mesa OpenGL package like `libgl1-mesa-dev`.
 
-### Android
+### For Android
 
 Cross compilation to Android is supported for targeting 64 bit ARM and Intel x86 architectures (`aarch64` and `x86_64`) for API Level 26 (Oreo, Android 8):
 
@@ -154,7 +150,7 @@ _Notes:_
 - In some older shells (for example macOS High Sierra), environment variable replacement can not be used when the variable was defined on the same line. Therefore the `ANDROID_NDK` variable must be defined before it's used in the `PATH` variable.
 - Rebuilding skia-bindings with a different target may cause linker errors, in that case `touch skia-bindings/build.rs` will force a rebuild ([#10](https://github.com/rust-skia/rust-skia/issues/10)).
 
-### iOS
+### For iOS
 
 Compilation to iOS is supported on macOS targeting the iOS simulator (`--target x86_64-apple-ios`) and 64 bit ARM devices (`--target aarch64-apple-ios`).
 

--- a/README.md
+++ b/README.md
@@ -31,19 +31,19 @@ sudo apt-get install pkg-config libssl-dev
 
 For other platforms, more information is available at the [OpenSSL crate documentation](https://docs.rs/openssl/0.10.24/openssl/#automatic).
 
-### Platform Support, Build Targets, and prebuilt Binaries
+### Platform Support, Build Targets, and Prebuilt Binaries
 
 Because building Skia takes a lot of time and needs tools that may not be installed, the skia-bindings crate's `build.rs` tries to download prebuilt binaries from [the skia-binaries repository](<https://github.com/rust-skia/skia-binaries/releases>).
 
 | Platform | Binaries |
-| ---- | ---- |
-|  Windows   | `x86_64-pc-windows-msvc` |
-| Linux Ubuntu 18 (16 should work, too).    | `x86_64-unknown-linux-gnu` |
+| -------- | -------- |
+|  Windows | `x86_64-pc-windows-msvc` |
+| Linux Ubuntu 18 (16 should work, too). | `x86_64-unknown-linux-gnu` |
 | macOS    | `x86_64-apple-darwin` |
-| Android | `aarch64-linux-android`<br/>`x86_64-linux-android` |
-| iOS     | `aarch64-apple-ios`<br/>`x86_64-apple-ios` |
+| Android  | `aarch64-linux-android`<br/>`x86_64-linux-android` |
+| iOS      | `aarch64-apple-ios`<br/>`x86_64-apple-ios` |
 
-There is no WebAssembly support. If you'd like to help out, take a look at issue [#42](https://github.com/rust-skia/rust-skia/pull/42).
+There no support for WebAssembly yet. If you'd like to help out, take a look at issue [#39](https://github.com/rust-skia/rust-skia/issues/39).
 
 ### Bindings & Supported Features
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The supported bindings and Skia features are described in the [skia-safe package
 
 ## Building
 
-If the target platform or feature configuration is not available as a prebuilt binary, skia-bindings' `build.rs` will try to build Skia and the generate the Rust bindings. 
+If the target platform or feature configuration is not available as a prebuilt binary, skia-bindings' `build.rs` will try to build Skia and generate the Rust bindings. 
 
 To prepare for that, **LLVM** and **Python 2** are needed:
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The build script probes for `python --version` and `python2 --version` and uses 
   xcode-select --install
   ```
 
-- **macOS Mojave Version 10.14**: install the SDK headers:
+- **macOS Mojave and newer**: install the SDK headers, for example:
 
   ```bash
   sudo open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
@@ -83,17 +83,18 @@ The build script probes for `python --version` and `python2 --version` and uses 
 
 - As an alternative to Apple's XCode LLVM, install LLVM via `brew install llvm` or `brew install llvm` and then set `PATH`, `CPPFLAGS`, and `LDFLAGS` like instructed. 
 
-  Note that if these environment variables are not set, [bindgen](https://github.com/rust-lang/rust-bindgen) most likely uses to the wrong `libclang.dylib`, causing spurious compilation errors (see #228).
+  If the environment variables are not set, [bindgen](https://github.com/rust-lang/rust-bindgen) will most likely use the wrong `libclang.dylib` and cause confusing compilation errors (see #228).
 
 ### On Windows
 
 - Have the latest versions of `git` and Rust ready.
-- [Install Visual Studio 2019 Build Tools](https://visualstudio.microsoft.com/downloads/) or one of the other IDE releases. If you installed the IDE version, make sure that the [Desktop Development with C++ workload](https://docs.microsoft.com/en-us/cpp/build/vscpp-step-0-installation?view=vs-2019) is installed.
+- [Install Visual Studio 2019 Build Tools](https://visualstudio.microsoft.com/downloads/) or one of the IDE releases. If you installed the IDE, make sure that the [Desktop Development with C++ workload](https://docs.microsoft.com/en-us/cpp/build/vscpp-step-0-installation?view=vs-2019) is installed.
 - Install the [latest LLVM](http://releases.llvm.org/download.html) distribution.
+
+  `clang.exe` is expected to be located at `C:/Program Files/LLVM/bin`, so be sure it's available from there.
 - [MSYS2](https://www.msys2.org/):
   
   - Install Python2 with `pacman -S python2`.
-  - `clang.exe` is expected to be located at `C:/Program Files/LLVM/bin`, so be sure it's available from there.
 - Windows Shell (`Cmd.exe`):
   
   - Download and install Python version 2 from [python.org](https://www.python.org/downloads/release/python-2716/).
@@ -112,7 +113,7 @@ Then use:
 cargo build -vv
 ```
 
-OpenGL libraries _may_ be missing, if that is the case, install OpenGL drivers for you graphics card, or install a mesa OpenGL package like `libgl1-mesa-dev`.
+If OpenGL libraries are missing, install the drivers for you graphics card, or a mesa package like `libgl1-mesa-dev`.
 
 ### For Android
 


### PR DESCRIPTION
This PR updates the readme regarding LLVM 9 and tries to clarify why and what prebuilt binaries are available.

[rendered](https://github.com/pragmatrix/rust-skia/blob/readme-llvm9/README.md).