### PR TITLE
Added canvas.save_layer_alpha()

### DIFF
--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -426,6 +426,21 @@ impl Canvas {
             .unwrap()
     }
 
+    pub fn save_layer_alpha(
+        &mut self,
+        bounds: impl Into<Option<Rect>>,
+        alpha: u8,
+    ) -> usize {
+        let bounds = match bounds.into() {
+            Some(bounds) => bounds.native(),
+            None => std::ptr::null(),
+        };
+
+        unsafe { self.native_mut().saveLayerAlpha(bounds, alpha.into()) }
+            .try_into()
+            .unwrap()
+    }
+
     pub fn restore(&mut self) -> &mut Self {
         unsafe { self.native_mut().restore() };
         self

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use crate::{gpu, Drawable, Pixmap};
+use crate::{gpu, u8cpu, Drawable, Pixmap};
 use crate::{
     scalar, vertices, Bitmap, BlendMode, ClipOp, Color, Data, Font, IPoint, IRect, ISize, Image,
     ImageFilter, ImageInfo, Matrix, Paint, Path, Picture, Point, QuickReject, RRect, Rect, Region,
@@ -426,19 +426,13 @@ impl Canvas {
             .unwrap()
     }
 
-    pub fn save_layer_alpha(
-        &mut self,
-        bounds: impl Into<Option<Rect>>,
-        alpha: u8,
-    ) -> usize {
-        let bounds = match bounds.into() {
-            Some(bounds) => bounds.native(),
-            None => std::ptr::null(),
-        };
-
-        unsafe { self.native_mut().saveLayerAlpha(bounds, alpha.into()) }
-            .try_into()
-            .unwrap()
+    pub fn save_layer_alpha(&mut self, bounds: impl Into<Option<Rect>>, alpha: u8cpu) -> usize {
+        unsafe {
+            self.native_mut()
+                .saveLayerAlpha(bounds.into().native().as_ptr_or_null(), alpha)
+        }
+        .try_into()
+        .unwrap()
     }
 
     pub fn restore(&mut self) -> &mut Self {


### PR DESCRIPTION
I just tried to implement this [example](https://fiddle.skia.org/c/@Canvas_saveLayerAlpha) and found that `Canvas` doesn't have an implementation of [`save_layer_alpha`](https://api.skia.org/classSkCanvas.html#a853514477dff62c15ced03f5141b2eb7) method.