### PR TITLE
TypefaceFontProvider Into FontMgr

### DIFF
--- a/skia-safe/src/modules/paragraph/typeface_font_provider.rs
+++ b/skia-safe/src/modules/paragraph/typeface_font_provider.rs
@@ -69,6 +69,12 @@ impl Default for RCHandle<sb::skia_textlayout_TypefaceFontProvider> {
     }
 }
 
+impl Into<Option<FontMgr>> for TypefaceFontProvider {
+    fn into(self) -> Option<FontMgr> {
+        Some(self.deref().clone())
+    }
+}
+
 impl RCHandle<sb::skia_textlayout_TypefaceFontProvider> {
     pub fn new() -> Self {
         Self::from_ptr(unsafe { sb::C_TypefaceFontProvider_new() }).unwrap()


### PR DESCRIPTION
I was trying to load custom fonts for text layout using `SkParagraph` by the example of [TestFontCollection](https://github.com/google/skia/blob/d445e2b6fcf1a051049b2e527feb1fca9a0a4946/modules/skparagraph/utils/TestFontCollection.cpp#L32) and I couldn't do it with the current API.

```
let mut manager = TypefaceFontProvider::new();
manager.register_typeface(typeface, Some("AlArabiya"));
font_collection.set_asset_font_manager(manager);
```

To get the above working I added an impl for the `Into` trait on `TypefaceFontProvider`.

Let me know if there is a better way! 