### PR TITLE
Add remaining env vars to the build script dependencies

### DIFF
--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -7,16 +7,18 @@ use std::{fs, io};
 
 /// Environment variables used by this build script.
 mod env {
-    use std::env;
+    use crate::build_support::cargo;
 
-    /// Returns true if the download should be forced, independent of the situation detected.
+    /// Returns true if the download should be forced. This can be used to test downloads
+    /// from within a repository build. If this environment variable is not set, binaries
+    /// are downloaded only in crate builds.
     pub fn force_skia_binaries_download() -> bool {
-        env::var("FORCE_SKIA_BINARIES_DOWNLOAD").is_ok()
+        cargo::env_var("FORCE_SKIA_BINARIES_DOWNLOAD").is_some()
     }
 
-    /// Force to build skia.
+    /// Force to build skia, even if there is a binary available.
     pub fn force_skia_build() -> bool {
-        env::var("FORCE_SKIA_BUILD").is_ok()
+        cargo::env_var("FORCE_SKIA_BUILD").is_some()
     }
 }
 

--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -9,7 +9,7 @@ use std::{fs, io};
 mod env {
     use crate::build_support::cargo;
 
-    /// Returns true if the download should be forced. This can be used to test downloads
+    /// Returns true if the download should be forced. This can be used to test prebuilt binaries
     /// from within a repository build. If this environment variable is not set, binaries
     /// are downloaded only in crate builds.
     pub fn force_skia_binaries_download() -> bool {

--- a/skia-bindings/build_support/android.rs
+++ b/skia-bindings/build_support/android.rs
@@ -1,11 +1,10 @@
 use crate::build_support::cargo;
-use std::env;
 
 /// API level Android 8, Oreo (the first one with full Vulkan support)
 pub const API_LEVEL: &str = "26";
 
 pub fn ndk() -> String {
-    env::var("ANDROID_NDK").expect("ANDROID_NDK variable not set")
+    cargo::env_var("ANDROID_NDK").expect("ANDROID_NDK variable not set")
 }
 
 pub fn additional_clang_args(target: &str, target_arch: &str) -> Vec<String> {

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -373,7 +373,7 @@ fn no() -> String {
     "false".into()
 }
 
-/// The resulting binaries configuration.
+/// The configuration of the resulting binaries.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct BinariesConfiguration {
     /// The feature identifiers we built with.


### PR DESCRIPTION
This PR adds the remaining env vars that are used in the build script to the cargo dependencies:

`FORCE_SKIA_BINARIES_DOWNLOAD`, `FORCE_SKIA_BUILD`, and `ANDROID_NDK`.
