### PR TITLE
Make sure that the skia-bindings/skia directory is a git working tree.

### DIFF
--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.23.1"
+version = "0.23.2"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -526,7 +526,7 @@ pub fn build(build: &FinalBuildConfiguration, config: &BinariesConfiguration) {
 
     // apply patches
 
-    let ref patch_root = PathBuf::from("skia");
+    let patch_root = &PathBuf::from("skia");
 
     // if there is any patch to be applied, be sure there is a git repository in the skia
     // subdirectory, because otherwise git apply will silently fail.

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -526,9 +526,18 @@ pub fn build(build: &FinalBuildConfiguration, config: &BinariesConfiguration) {
 
     // apply patches
 
+    let ref patch_root = PathBuf::from("skia");
+
+    // if there is any patch to be applied, be sure there is a git repository in the skia
+    // subdirectory, because otherwise git apply will silently fail.
+
+    if !build.skia_patches.is_empty() {
+        git::run(&["init"], Some(patch_root.as_path()));
+    }
+
     for patch in &build.skia_patches {
         println!("applying patch: {}", patch.name);
-        patch.apply(&PathBuf::from("skia"));
+        patch.apply(patch_root);
     }
 
     // configure Skia
@@ -588,7 +597,7 @@ pub fn build(build: &FinalBuildConfiguration, config: &BinariesConfiguration) {
 
     for patch in &build.skia_patches {
         println!("reversing patch: {}", patch.name);
-        patch.reverse(&PathBuf::from("skia"));
+        patch.reverse(patch_root);
     }
 
     assert!(

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.23.1"
+version = "0.23.2"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -27,7 +27,7 @@ textlayout = ["skia-bindings/textlayout", "shaper"]
 
 [dependencies]
 bitflags = "1.0.4"
-skia-bindings = { version = "=0.23.1", path = "../skia-bindings" }
+skia-bindings = { version = "=0.23.2", path = "../skia-bindings" }
 lazy_static = "1.4"
 
 [dev-dependencies]


### PR DESCRIPTION
This is a follow-up hotfix to #255. 

Because we can't assume that the `patch` command is available on the various platforms, the build script applies the skia patches with `git apply`, which silently fail when the skia directory is not inside a git repository. This happens when a full build is triggered from a downloaded skia-bindings crate. 

This PR makes sure that the skia directory always contains an initialized git repository by executing `git init` if any patches need to be applied.

This feels like a hack, and also the patching mechanism is only a temporary workaround that needs to be removed soon by maintaining an own fork of Skia.