### PR TITLE
Use a customized Skia fork for the rust-skia build to avoid patches and to be able to use Python3.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "skia"]
 	path = skia-bindings/skia
-	url = https://github.com/google/skia.git
+	url = https://github.com/rust-skia/skia.git
 [submodule "skia-bindings/depot_tools"]
 	path = skia-bindings/depot_tools
 	url = https://github.com/rust-skia/depot_tools.git

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![Build Status](https://dev.azure.com/pragmatrix-github/rust-skia/_apis/build/status/rust-skia.rust-skia?branchName=master)](https://dev.azure.com/pragmatrix-github/rust-skia/_build/latest?branchName=master)
 
-Skia Submodule Status: chrome/m79 ([pending changes][skiapending]).
+Skia Submodule Status: chrome/m79 ([pending changes][skiapending], [our changes][skiaours]).
 
 [skiapending]: https://github.com/rust-skia/skia/compare/15a19f57bb...google:chrome/m79
+[skiaours]: https://github.com/google/skia/compare/chrome/m79...rust-skia:15a19f57bb
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m79 ([pending changes][skiapending], [our changes][skiaours]).
 
-[skiapending]: https://github.com/rust-skia/skia/compare/15a19f57bb...google:chrome/m79
-[skiaours]: https://github.com/google/skia/compare/chrome/m79...rust-skia:15a19f57bb
+[skiapending]: https://github.com/rust-skia/skia/compare/d41103cab8...google:chrome/m79
+[skiaours]: https://github.com/google/skia/compare/chrome/m79...rust-skia:d41103cab8
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Skia Submodule Status: chrome/m79 ([pending changes][skiapending]).
 
-[skiapending]: https://github.com/google/skia/compare/2542bdfcd6...chrome/m79
+[skiapending]: https://github.com/rust-skia/skia/compare/15a19f57bb...google:chrome/m79
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m79 ([pending changes][skiapending], [our changes][skiaours]).
 
-[skiapending]: https://github.com/rust-skia/skia/compare/d41103cab8...google:chrome/m79
-[skiaours]: https://github.com/google/skia/compare/chrome/m79...rust-skia:d41103cab8
+[skiapending]: https://github.com/rust-skia/skia/compare/03e4ad801c...google:chrome/m79
+[skiaours]: https://github.com/google/skia/compare/chrome/m79...rust-skia:03e4ad801c
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -54,17 +54,17 @@ The supported bindings and Skia features are described in the [skia-safe package
 
 If the target platform or feature configuration is not available as a prebuilt binary, skia-bindings' `build.rs` will try to build Skia and generate the Rust bindings. 
 
-To prepare for that, **LLVM** and **Python 2** are needed:
+To prepare for that, **LLVM** and **Python 3** are needed:
 
 **LLVM**
 
 We recommend the version that comes preinstalled with your platform, or, if not available, the [latest official LLVM release](http://releases.llvm.org/download.html). To see which version of LLVM/Clang is installed on your system, use `clang --version`. 
 
-**Python 2**
+**Python 3**
 
-Python version 2.7 _must_ be available.
+Python 3 _must_ be available.
 
-The build script probes for `python --version` and `python2 --version` and uses the first one that looks like a version 2 executable for building Skia.
+The build script probes for `python --version` and `python3 --version` and uses the first one that looks like a version 3 executable for building Skia.
 
 ### On macOS
 
@@ -95,10 +95,12 @@ The build script probes for `python --version` and `python2 --version` and uses 
   `clang.exe` is expected to be located at `C:/Program Files/LLVM/bin`, so be sure it's available from there.
 - [MSYS2](https://www.msys2.org/):
   
-  - Install Python2 with `pacman -S python2`.
+  - Install Python3 with `pacman -S python`.
+  
+    **Important:** If there is a side-by-side installation of a MinGW python3 _and_ a MSYS2 python3, the MSYS2 shell must be used, otherwise the MinGW python3 based build will fail.
 - Windows Shell (`Cmd.exe`):
   
-  - Download and install Python version 2 from [python.org](https://www.python.org/downloads/release/python-2716/).
+  - Download and install Python version 3 from [python.org](https://www.python.org/downloads).
 - Install and select the MSVC toolchain:
   ```bash
   rustup default stable-msvc

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -76,7 +76,7 @@ jobs:
     # Windows.
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '2.x'
+        versionSpec: '3.x'
         addToPath: true
         architecture: 'x64'
     - script: |

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -19,7 +19,7 @@ include = [ "Cargo.toml", "build.rs", "build_support.rs", "build_support/**/*.rs
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "d41103cab8"
+skia = "03e4ad801c"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -19,7 +19,7 @@ include = [ "Cargo.toml", "build.rs", "build_support.rs", "build_support/**/*.rs
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "2542bdfcd6"
+skia = "15a19f57bb"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -19,7 +19,7 @@ include = [ "Cargo.toml", "build.rs", "build_support.rs", "build_support/**/*.rs
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "15a19f57bb"
+skia = "d41103cab8"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-bindings/build_support/git.rs
+++ b/skia-bindings/build_support/git.rs
@@ -1,4 +1,5 @@
 //! git build helper.
+#![allow(dead_code)]
 
 use std::path::Path;
 use std::process::{Command, Stdio};
@@ -27,7 +28,7 @@ pub fn trim_hash(hash: &str) -> String {
 /// Panics if the git command fails.
 pub fn run<'a>(args: &[impl AsRef<str>], dir: impl Into<Option<&'a Path>>) -> Vec<u8> {
     let args: Vec<&str> = args.iter().map(|s| s.as_ref()).collect();
-    let (status, output) = _run2(&args, dir);
+    let (status, output) = run2(&args, dir);
     if status == 0 {
         return output;
     }
@@ -37,7 +38,7 @@ pub fn run<'a>(args: &[impl AsRef<str>], dir: impl Into<Option<&'a Path>>) -> Ve
 /// Like run, but returns the status code _and_ the output or None if
 /// there is no status code (for example the command was interrupted).
 /// Panics if the git command could not be run at all.
-pub fn _run2<'a>(args: &[impl AsRef<str>], dir: impl Into<Option<&'a Path>>) -> (i32, Vec<u8>) {
+pub fn run2<'a>(args: &[impl AsRef<str>], dir: impl Into<Option<&'a Path>>) -> (i32, Vec<u8>) {
     let args: Vec<&str> = args.iter().map(|s| s.as_ref()).collect();
 
     let mut cmd = Command::new("git");

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -525,11 +525,11 @@ pub fn build(build: &FinalBuildConfiguration, config: &BinariesConfiguration) {
 
     // call Skia's git-sync-deps
 
-    let python2 = &prerequisites::locate_python2_cmd();
-    println!("Python 2 found: {:?}", python2);
+    let python3 = &prerequisites::locate_python3_cmd();
+    println!("Python 3 found: {:?}", python3);
 
     assert!(
-        Command::new(python2)
+        Command::new(python3)
             .arg("skia/tools/git-sync-deps")
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
@@ -566,7 +566,7 @@ pub fn build(build: &FinalBuildConfiguration, config: &BinariesConfiguration) {
         .args(&[
             "gen",
             output_directory_str,
-            &format!("--script-executable={}", python2),
+            &format!("--script-executable={}", python3),
             &format!("--args={}", gn_args),
         ])
         .envs(env::vars())
@@ -1003,21 +1003,21 @@ mod prerequisites {
     use std::path::{Path, PathBuf};
     use std::process::{Command, Stdio};
 
-    pub fn locate_python2_cmd() -> &'static str {
-        const PYTHON_CMDS: [&str; 2] = ["python", "python2"];
+    pub fn locate_python3_cmd() -> &'static str {
+        const PYTHON_CMDS: [&str; 2] = ["python", "python3"];
         for python in PYTHON_CMDS.as_ref() {
             println!("Probing '{}'", python);
-            if let Some(true) = is_python_version_2(python) {
+            if let Some(true) = is_python_version_3(python) {
                 return python;
             }
         }
 
-        panic!(">>>>> Probing for Python 2 failed, please make sure that it's available in PATH, probed executables are: {:?} <<<<<", PYTHON_CMDS);
+        panic!(">>>>> Probing for Python 3 failed, please make sure that it's available in PATH, probed executables are: {:?} <<<<<", PYTHON_CMDS);
     }
 
-    /// Returns true if the given python executable is python version 2.
+    /// Returns true if the given python executable is python version 3.
     /// or None if the executable was not found.
-    pub fn is_python_version_2(exe: impl AsRef<str>) -> Option<bool> {
+    pub fn is_python_version_3(exe: impl AsRef<str>) -> Option<bool> {
         Command::new(exe.as_ref())
             .arg("--version")
             .output()
@@ -1029,7 +1029,7 @@ mod prerequisites {
                 }
                 // Don't parse version output, for example output
                 // might be "Python 2.7.15+"
-                str.starts_with("Python 2.")
+                str.starts_with("Python 3.")
             })
             .ok()
     }

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -1,6 +1,6 @@
 //! Full build support for the Skia library, SkiaBindings library and bindings.rs file.
 
-use crate::build_support::{android, binaries, cargo, clang, git, ios, vs};
+use crate::build_support::{android, binaries, cargo, clang, ios, vs};
 use cc::Build;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -1100,7 +1100,7 @@ mod prerequisites {
         return &[
             Dependency {
                 repo: "skia",
-                url: "https://codeload.github.com/google/skia/tar.gz",
+                url: "https://codeload.github.com/rust-skia/skia/tar.gz",
                 path_filter: filter_skia,
             },
             Dependency {


### PR DESCRIPTION
This PR uses a customized fork from https://github.com/rust-skia/skia to build Skia in the rust-skia repository and - if no prebuilt suitable binary is available - in the crate.

rendered [README.md](https://github.com/pragmatrix/rust-skia/blob/skia-fork/README.md)
