### PR TITLE
Remove bz2 from linking libraries

### DIFF
--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -441,7 +441,7 @@ impl BinariesConfiguration {
 
         match target.as_strs() {
             (_, "unknown", "linux", Some("gnu")) => {
-                link_libraries.extend(vec!["stdc++", "bz2", "GL", "fontconfig", "freetype"]);
+                link_libraries.extend(vec!["stdc++", "GL", "fontconfig", "freetype"]);
             }
             (_, "apple", "darwin", _) => {
                 link_libraries.extend(vec![


### PR DESCRIPTION
I don't think it is used. Tested on linux locally.