### PR TITLE
Don't try to download binaries when building on azure.

### DIFF
--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -1,6 +1,6 @@
 mod build_support;
 use crate::build_support::skia::FinalBuildConfiguration;
-use build_support::{azure, binaries, cargo, git, skia, utils};
+use build_support::{binaries, cargo, git, skia, utils};
 use std::io::Cursor;
 use std::path::Path;
 use std::{fs, io};

--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -96,8 +96,8 @@ fn should_try_download_binaries(config: &skia::BinariesConfiguration) -> Option<
         return Some((tag, config.key(&half_hash)));
     }
 
-    // are we building inside a package?
-    if let Ok(ref full_hash) = cargo::package_repository_hash() {
+    // are we building inside a crate?
+    if let Ok(ref full_hash) = cargo::crate_repository_hash() {
         let half_hash = git::trim_hash(full_hash);
         return Some((tag, config.key(&half_hash)));
     }

--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -69,8 +69,6 @@ fn main() {
     // publish binaries?
     //
 
-    // TODO: we may not want to deliver binaries when we downloaded the binaries
-    //       but how to inform azure if we don't want to?
     if let Some(staging_directory) = binaries::should_export() {
         println!(
             "DETECTED AZURE, exporting binaries to {}",
@@ -101,12 +99,6 @@ fn should_try_download_binaries(config: &skia::BinariesConfiguration) -> Option<
     // are we building inside a package?
     if let Ok(ref full_hash) = cargo::package_repository_hash() {
         let half_hash = git::trim_hash(full_hash);
-        return Some((tag, config.key(&half_hash)));
-    }
-
-    if azure::is_active() {
-        // and if we can resolve the hash and the key
-        let half_hash = git::half_hash()?;
         return Some((tag, config.key(&half_hash)));
     }
 

--- a/skia-bindings/build_support/azure.rs
+++ b/skia-bindings/build_support/azure.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use crate::build_support::cargo;
 use std::path::PathBuf;
 

--- a/skia-bindings/build_support/cargo.rs
+++ b/skia-bindings/build_support/cargo.rs
@@ -133,14 +133,14 @@ pub fn build_release() -> bool {
     }
 }
 
-/// Are we inside the crate?
+/// Are we inside a crate?
 pub fn is_crate() -> bool {
-    package_repository_hash().is_ok()
+    crate_repository_hash().is_ok()
 }
 
-// If we are builing from within a packaged crate, return the full commit hash
-// of the original repository we were packaged from.
-pub fn package_repository_hash() -> io::Result<String> {
+// If we are building from within a crate, return the full commit hash
+// of the repository the crate was packaged from.
+pub fn crate_repository_hash() -> io::Result<String> {
     let vcs_info = fs::read_to_string(".cargo_vcs_info.json")?;
     let value: serde_json::Value = serde_json::from_str(&vcs_info)?;
     let git = value.get("git").expect("failed to get 'git' property");


### PR DESCRIPTION
This was originally meant to speed up azure builds if the appropriate binaries were available. But it turned out not to be useful, because the release branch is usually built only once and a download of the binaries would also cause a re-export, which is another special case I'd rather avoid to consider.

