### PR TITLE
Remove the GL library dependency on Linux

### DIFF
--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -441,7 +441,7 @@ impl BinariesConfiguration {
 
         match target.as_strs() {
             (_, "unknown", "linux", Some("gnu")) => {
-                link_libraries.extend(vec!["stdc++", "GL", "fontconfig", "freetype"]);
+                link_libraries.extend(vec!["stdc++", "fontconfig", "freetype"]);
             }
             (_, "apple", "darwin", _) => {
                 link_libraries.extend(vec![


### PR DESCRIPTION
Since Skia is resolving the OpenGL library and its entry points dynamically, I don't see why this is needed.

Closes #267 