### PR TITLE
Support quality on SkImage encodeToData

### DIFF
--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -470,8 +470,8 @@ extern "C" void C_SkImage_getBackendTexture(
     *result = self->getBackendTexture(flushPendingGrContextIO, origin);
 }
 
-extern "C" SkData* C_SkImage_encodeToData(const SkImage* self, SkEncodedImageFormat imageFormat) {
-    return self->encodeToData(imageFormat, 100).release();
+extern "C" SkData* C_SkImage_encodeToData(const SkImage* self, SkEncodedImageFormat imageFormat, int quality) {
+    return self->encodeToData(imageFormat, quality).release();
 }
 
 extern "C" SkData* C_SkImage_refEncodedData(const SkImage* self) {

--- a/skia-safe/src/core/image.rs
+++ b/skia-safe/src/core/image.rs
@@ -471,10 +471,17 @@ impl RCHandle<SkImage> {
         }
     }
 
-    // TODO: support quality!
     pub fn encode_to_data(&self, image_format: EncodedImageFormat) -> Option<Data> {
+        self.encode_to_data_with_quality(image_format, 100)
+    }
+
+    pub fn encode_to_data_with_quality(
+        &self,
+        image_format: EncodedImageFormat,
+        quality: i32,
+    ) -> Option<Data> {
         Data::from_ptr(unsafe {
-            sb::C_SkImage_encodeToData(self.native(), image_format.into_native())
+            sb::C_SkImage_encodeToData(self.native(), image_format.into_native(), quality)
         })
     }
 


### PR DESCRIPTION
Adds in the option to use the quality field within the encodeToData method from SkImage. Remains backwards compatible with the previous version, so no updates are required on consumers. 

Now highly compressed monstrosities like the one below are possible with the skia jpeg encoder.
![image](https://user-images.githubusercontent.com/45034035/72694170-2294f580-3b88-11ea-8911-2f1afc43e889.png)
