### PR TITLE
Pass a FontCollection ref when creating a ParagraphBuilder

### DIFF
--- a/skia-safe/examples/skia-org/skparagraph_example.rs
+++ b/skia-safe/examples/skia-org/skparagraph_example.rs
@@ -24,7 +24,7 @@ fn draw_lorem_ipsum(canvas: &mut Canvas) {
         font_collection.disable_font_fallback();
 
         let paragraph_style = ParagraphStyle::new();
-        let mut paragraph_builder = ParagraphBuilder::new(&paragraph_style, font_collection);
+        let mut paragraph_builder = ParagraphBuilder::new(&paragraph_style, &font_collection);
         let mut ts = TextStyle::new();
         ts.set_foreground_color(Paint::default());
         paragraph_builder.push_style(&ts);

--- a/skia-safe/src/modules/paragraph/paragraph_builder.rs
+++ b/skia-safe/src/modules/paragraph/paragraph_builder.rs
@@ -56,9 +56,9 @@ impl RefHandle<sb::skia_textlayout_ParagraphBuilder> {
         Paragraph::from_ptr(unsafe { sb::C_ParagraphBuilder_Build(self.native_mut()) }).unwrap()
     }
 
-    pub fn new(style: &ParagraphStyle, font_collection: FontCollection) -> Self {
+    pub fn new(style: &ParagraphStyle, font_collection: &FontCollection) -> Self {
         Self::from_ptr(unsafe {
-            sb::C_ParagraphBuilder_make(style.native(), font_collection.into_ptr())
+            sb::C_ParagraphBuilder_make(style.native(), font_collection.native())
         })
         .unwrap()
     }


### PR DESCRIPTION
Does this change make sense or am I missing something? 
Is it okay to share a FontCollection reference across ParagraphBuilders?