### PR TITLE
Remove feature svg

### DIFF
--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -23,10 +23,6 @@ jobs:
           toolchain: stable
           features: 'gl'
           exampleArgs: ''
-        stable-svg:
-          toolchain: stable
-          features: 'svg'
-          exampleArgs: ''
         stable-shaper:
           toolchain: stable
           features: 'shaper'
@@ -37,21 +33,21 @@ jobs:
           exampleArgs: ''
         stable-all-features:
           toolchain: stable
-          features: 'gl,vulkan,svg,shaper,textlayout'
+          features: 'gl,vulkan,shaper,textlayout'
           exampleArgs: ''
       ${{ if eq(parameters.deployRelease, 'False') }}:
         stable-all-features:
           toolchain: stable
-          features: 'gl,vulkan,svg,shaper,textlayout'
+          features: 'gl,vulkan,shaper,textlayout'
           exampleArgs: '--driver cpu --driver pdf --driver svg'
         stable-all-features-debug:
           toolchain: stable
-          features: 'gl,vulkan,svg,shaper,textlayout'
+          features: 'gl,vulkan,shaper,textlayout'
           exampleArgs: ''
           skia_debug: '1'
         beta-all-features:
           toolchain: beta
-          features: 'gl,vulkan,svg,shaper,textlayout'
+          features: 'gl,vulkan,shaper,textlayout'
           exampleArgs: ''
 
   variables:

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -26,9 +26,10 @@ depot_tools = "a110bf6"
 default = []
 gl = []
 vulkan = []
-svg = []
 shaper = []
 textlayout = ["shaper"]
+# deprecated
+svg = []
 
 [dependencies]
 

--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -26,6 +26,10 @@ const SRC_BINDINGS_RS: &str = "src/bindings.rs";
 const SKIA_LICENSE: &str = "skia/LICENSE";
 
 fn main() {
+    if cfg!(feature = "svg") {
+        cargo::warning("the feature 'svg' has been removed. SVG and XML support is available in all build configurations");
+    }
+
     let build_config = skia::BuildConfiguration::default();
     let binaries_config = skia::BinariesConfiguration::from_cargo_env(&build_config);
 

--- a/skia-bindings/build_support/cargo.rs
+++ b/skia-bindings/build_support/cargo.rs
@@ -6,6 +6,10 @@ use std::fmt::{Display, Formatter};
 use std::path::{Path, PathBuf};
 use std::{env, fmt, fs, io};
 
+pub fn warning(warn: impl AsRef<str>) {
+    println!("cargo:warning={}", warn.as_ref());
+}
+
 pub fn output_directory() -> PathBuf {
     PathBuf::from(env::var("OUT_DIR").unwrap())
 }

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -18,7 +18,6 @@ mod lib {
 mod feature_id {
     pub const GL: &str = "gl";
     pub const VULKAN: &str = "vulkan";
-    pub const SVG: &str = "svg";
     pub const SHAPER: &str = "shaper";
     pub const TEXTLAYOUT: &str = "textlayout";
 }
@@ -61,7 +60,6 @@ impl Default for BuildConfiguration {
             features: Features {
                 gl: cfg!(feature = "gl"),
                 vulkan: cfg!(feature = "vulkan"),
-                svg: cfg!(feature = "svg"),
                 text_layout,
                 animation: false,
                 dng: false,
@@ -104,9 +102,6 @@ pub struct Features {
 
     /// Build with Vulkan support?
     pub vulkan: bool,
-
-    /// Build with SVG support?
-    pub svg: bool,
 
     /// Features related to text layout.
     pub text_layout: TextLayout,
@@ -286,7 +281,7 @@ impl FinalBuildConfiguration {
             }
 
             let mut flags: Vec<&str> = vec![];
-            let mut use_expat = features.svg;
+            let mut use_expat = true;
 
             // target specific gn args.
             let target = cargo::target();
@@ -381,9 +376,7 @@ impl FinalBuildConfiguration {
             if features.gpu() {
                 sources.push("src/gpu.cpp".into());
             }
-            if features.svg {
-                sources.push("src/svg.cpp".into())
-            }
+            sources.push("src/svg.cpp".into());
             sources
         };
 
@@ -446,9 +439,6 @@ impl BinariesConfiguration {
         }
         if features.vulkan {
             feature_ids.push(feature_id::VULKAN);
-        }
-        if features.svg {
-            feature_ids.push(feature_id::SVG);
         }
         match features.text_layout {
             TextLayout::None => {}

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -22,11 +22,12 @@ doctest = false
 default = []
 gl = ["gpu", "skia-bindings/gl"]
 vulkan = ["gpu", "skia-bindings/vulkan"]
-svg = ["skia-bindings/svg"]
 shaper = ["skia-bindings/shaper"]
 textlayout = ["shaper", "skia-bindings/textlayout"]
 # implied only, do not use
 gpu = []
+# deprecated since 0.25.0, forwarded to skia-bindings, which will warn.
+svg = ["skia-bindings/svg"]
 
 [dependencies]
 bitflags = "1.0.4"

--- a/skia-safe/examples/skia-org/drivers.rs
+++ b/skia-safe/examples/skia-org/drivers.rs
@@ -9,9 +9,7 @@ pub mod gl;
 pub use gl::OpenGL;
 pub mod pdf;
 pub use pdf::PDF;
-#[cfg(feature = "svg")]
 pub mod svg;
-#[cfg(feature = "svg")]
 pub use svg::SVG;
 #[cfg(feature = "vulkan")]
 pub mod vulkan;

--- a/skia-safe/examples/skia-org/main.rs
+++ b/skia-safe/examples/skia-org/main.rs
@@ -65,11 +65,8 @@ fn main() {
         draw_all::<drivers::PDF>(&out_path);
     }
 
-    #[cfg(feature = "svg")]
-    {
-        if drivers.contains(&drivers::SVG::NAME) {
-            draw_all::<drivers::SVG>(&out_path);
-        }
+    if drivers.contains(&drivers::SVG::NAME) {
+        draw_all::<drivers::SVG>(&out_path);
     }
 
     #[cfg(feature = "gl")]
@@ -132,15 +129,12 @@ fn main() {
 }
 
 fn get_available_drivers() -> Vec<&'static str> {
-    let mut drivers = vec!["cpu", "pdf"];
+    let mut drivers = vec!["cpu", "pdf", "svg"];
     if cfg!(feature = "gl") {
         drivers.extend(vec!["opengl", "opengl-es"]);
     }
     if cfg!(feature = "vulkan") {
         drivers.push("vulkan")
-    }
-    if cfg!(feature = "svg") {
-        drivers.push("svg");
     }
     drivers
 }

--- a/skia-safe/src/lib.rs
+++ b/skia-safe/src/lib.rs
@@ -9,7 +9,6 @@ mod modules;
 mod pathops;
 mod prelude;
 mod private;
-#[cfg(feature = "svg")]
 pub mod svg;
 // TODO: We don't export utils/* into the crate's root yet. Should we?
 pub mod utils;


### PR DESCRIPTION
As proposed in #261, this PR removes the feature svg. All XML based features, like the SVGCanvas, are now available in all feature configurations.