### PR TITLE
Remove feature "shaper"

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ There no support for WebAssembly yet. If you'd like to help out, take a look at 
 
 ### Bindings & Supported Features
 
-The supported bindings and Skia features are described in the [skia-safe package's readme](skia-safe/README.md) and prebuilt binaries are available for all feature combinations.
+The supported bindings and Skia features are described in the [skia-safe package's readme](skia-safe/README.md) and prebuilt binaries are available for most feature combinations.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ There no support for WebAssembly yet. If you'd like to help out, take a look at 
 
 ### Bindings & Supported Features
 
-The supported bindings and Skia features are described in the [skia-safe package's readme](skia-safe/README.md) and prebuilt binaries are available for any single feature or for all features combined.
+The supported bindings and Skia features are described in the [skia-safe package's readme](skia-safe/README.md) and prebuilt binaries are available for all feature combinations.
 
 ## Building
 

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -15,39 +15,43 @@ jobs:
           toolchain: stable
           features: ''
           exampleArgs: ''
-        stable-vulkan:
-          toolchain: stable
-          features: 'vulkan'
-          exampleArgs: ''
         stable-gl:
           toolchain: stable
           features: 'gl'
           exampleArgs: ''
-        stable-shaper:
+        stable-vulkan:
           toolchain: stable
-          features: 'shaper'
+          features: 'vulkan'
           exampleArgs: ''
         stable-textlayout:
           toolchain: stable
           features: 'textlayout'
           exampleArgs: ''
+        stable-gl-textlayout:
+          toolchain: stable
+          features: 'gl,textlayout'
+          exampleArgs: ''
+        stable-vulkan-textlayout:
+          toolchain: stable
+          features: 'vulkan,textlayout'
+          exampleArgs: ''
         stable-all-features:
           toolchain: stable
-          features: 'gl,vulkan,shaper,textlayout'
+          features: 'gl,vulkan,textlayout'
           exampleArgs: ''
       ${{ if eq(parameters.deployRelease, 'False') }}:
         stable-all-features:
           toolchain: stable
-          features: 'gl,vulkan,shaper,textlayout'
+          features: 'gl,vulkan,textlayout'
           exampleArgs: '--driver cpu --driver pdf --driver svg'
         stable-all-features-debug:
           toolchain: stable
-          features: 'gl,vulkan,shaper,textlayout'
+          features: 'gl,vulkan,textlayout'
           exampleArgs: ''
           skia_debug: '1'
         beta-all-features:
           toolchain: beta
-          features: 'gl,vulkan,shaper,textlayout'
+          features: 'gl,vulkan,textlayout'
           exampleArgs: ''
 
   variables:

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -26,10 +26,10 @@ depot_tools = "a110bf6"
 default = []
 gl = []
 vulkan = []
-shaper = []
-textlayout = ["shaper"]
-# deprecated
+textlayout = []
+# deprecated since 0.25.0
 svg = []
+shaper = ["textlayout"]
 
 [dependencies]
 

--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -32,7 +32,7 @@ fn main() {
     }
     // since 0.25.0
     if cfg!(feature = "shaper") {
-        cargo::warning("The feature 'shaper' has been removed. To use the SkShaper bindings, enable the feature 'textlayout' only.");
+        cargo::warning("The feature 'shaper' has been removed. To use the SkShaper bindings, enable the feature 'textlayout'.");
     }
 
     let build_config = skia::BuildConfiguration::default();

--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -26,8 +26,13 @@ const SRC_BINDINGS_RS: &str = "src/bindings.rs";
 const SKIA_LICENSE: &str = "skia/LICENSE";
 
 fn main() {
+    // since 0.25.0
     if cfg!(feature = "svg") {
         cargo::warning("the feature 'svg' has been removed. SVG and XML support is available in all build configurations");
+    }
+    // since 0.25.0
+    if cfg!(feature = "shaper") {
+        cargo::warning("the feature 'shaper' has been combined with the feature 'textlayout', please use 'textlayout' only");
     }
 
     let build_config = skia::BuildConfiguration::default();

--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -28,11 +28,11 @@ const SKIA_LICENSE: &str = "skia/LICENSE";
 fn main() {
     // since 0.25.0
     if cfg!(feature = "svg") {
-        cargo::warning("the feature 'svg' has been removed. SVG and XML support is available in all build configurations");
+        cargo::warning("The feature 'svg' has been removed. SVG and XML support is available in all build configurations.");
     }
     // since 0.25.0
     if cfg!(feature = "shaper") {
-        cargo::warning("the feature 'shaper' has been combined with the feature 'textlayout', please use 'textlayout' only");
+        cargo::warning("The feature 'shaper' has been removed. To use the SkShaper bindings, enable the feature 'textlayout' only.");
     }
 
     let build_config = skia::BuildConfiguration::default();

--- a/skia-bindings/src/lib.rs
+++ b/skia-bindings/src/lib.rs
@@ -11,5 +11,5 @@ pub use defaults::*;
 mod impls;
 pub use impls::*;
 
-#[cfg(feature = "shaper")]
+#[cfg(feature = "textlayout")]
 pub mod icu;

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -22,12 +22,12 @@ doctest = false
 default = []
 gl = ["gpu", "skia-bindings/gl"]
 vulkan = ["gpu", "skia-bindings/vulkan"]
-shaper = ["skia-bindings/shaper"]
-textlayout = ["shaper", "skia-bindings/textlayout"]
+textlayout = ["skia-bindings/textlayout"]
 # implied only, do not use
 gpu = []
-# deprecated since 0.25.0, forwarded to skia-bindings, which will warn.
+# deprecated since 0.25.0, forwarded to skia-bindings with the intend to print some warnings while build.rs is running
 svg = ["skia-bindings/svg"]
+shaper = ["textlayout", "skia-bindings/shaper"]
 
 [dependencies]
 bitflags = "1.0.4"

--- a/skia-safe/README.md
+++ b/skia-safe/README.md
@@ -50,21 +50,15 @@ Vulkan support can be enabled by enabling the feature `vulkan`. To render the ex
 
 Note that Vulkan drivers need to be available. On Windows, they are most likely available already, on Linux [this article on linuxconfig.org](<https://linuxconfig.org/install-and-test-vulkan-on-linux>) might get you started, and on macOS with Metal support, [install the Vulkan SDK](<https://vulkan.lunarg.com/sdk/home>) for Mac and configure MoltenVK by setting the `DYLD_LIBRARY_PATH`, `VK_LAYER_PATH`, and `VK_ICD_FILENAMES` environment variables as described in `Documentation/getting_started_macos.html`.
 
-### `svg`
-
-This feature enables the SVG rendering backend. To create a new Skia canvas that renders to SVG, use the function `skia_safe::svg::Canvas::new()`.
-
-### `shaper`
-
-The Cargo feature `shaper` enables text shaping with Harfbuzz and ICU. 
-
-On **Windows**, the file `icudtl.dat` must be available in your executable's directory. To provide the data file, either copy it from the build's output directory (shown when skia-bindings is compiled with `cargo build -vv | grep "ninja: Entering directory"`), or - if your executable directory is writable - invoke the function `skia_safe::icu::init()` before creating the `skia_safe::Shaper` object. 
-
-A simple example can be found [in the skia-org command line application](https://github.com/rust-skia/rust-skia/blob/master/skia-safe/examples/skia-org/skshaper_example.rs).
-
 ### `textlayout`
 
-This feature makes the Skia module skparagraph available, which contains types that are used to lay out paragraphs. In Rust, the types are available from the `skia_safe::textlayout` module. 
+The Cargo feature `textlayout` enables text shaping with Harfbuzz and ICU by providing bindings to the Skia modules skshaper and skparagraph. 
 
-A code snippet that lays out a paragraph can be found [in the skia-org example](https://github.com/rust-skia/rust-skia/blob/master/skia-safe/examples/skia-org/skshaper_example.rs).
+The skshaper module can be accessed through `skia_safe::Shaper` and the Rust bindings for skparagraph are in the `skia_safe::textlayout` module. 
+
+On **Windows**, the file `icudtl.dat` must be available in your executable's directory. To provide the data file, either copy it from the build's output directory (shown when skia-bindings is compiled with `cargo build -vv | grep "ninja: Entering directory"`), or - if your executable directory is writable - invoke the function `skia_safe::icu::init()` before using the `skia_safe::Shaper` object or the `skia_safe::textlayout` module. 
+
+Simple examples of the skshaper and skparagraph module bindings can be found [in the skia-org example command line application](https://github.com/rust-skia/rust-skia/blob/master/skia-safe/examples/skia-org).
+
+
 

--- a/skia-safe/examples/skia-org/main.rs
+++ b/skia-safe/examples/skia-org/main.rs
@@ -18,7 +18,7 @@ mod skpaint_overview;
 #[cfg(feature = "textlayout")]
 mod skparagraph_example;
 mod skpath_overview;
-#[cfg(feature = "shaper")]
+#[cfg(feature = "textlayout")]
 mod skshaper_example;
 
 fn main() {
@@ -120,7 +120,7 @@ fn main() {
         skpath_overview::draw::<Driver>(&out_path);
         skpaint_overview::draw::<Driver>(&out_path);
 
-        #[cfg(feature = "shaper")]
+        #[cfg(feature = "textlayout")]
         skshaper_example::draw::<Driver>(&out_path);
 
         #[cfg(feature = "textlayout")]

--- a/skia-safe/src/modules.rs
+++ b/skia-safe/src/modules.rs
@@ -1,8 +1,8 @@
 #[cfg(feature = "textlayout")]
 pub(crate) mod paragraph;
-#[cfg(feature = "shaper")]
+#[cfg(feature = "textlayout")]
 pub mod shaper;
-#[cfg(feature = "shaper")]
+#[cfg(feature = "textlayout")]
 pub use shaper::{icu, Shaper};
 
 // Export everything below paragraph under textlayout


### PR DESCRIPTION
As proposed in #261, the feature `shaper` is removed. The skshaper's bindings can be used by enabling the `textlayout` feature.

This PR is based on #273 