### PR TITLE
Revert "build(deps): update foreign-types requirement from 0.3 to 0.5"

### DIFF
--- a/skia-org/Cargo.toml
+++ b/skia-org/Cargo.toml
@@ -36,7 +36,7 @@ ash = { version = "0.29", optional = true }
 # need to rename the package because of the feature with the same name.
 metal-rs = { package = "metal", version = "0.17.1", optional = true }
 # ... to access raw metal ptrs.
-foreign-types = { version = "0.5", optional = true }
+foreign-types = { version = "0.3", optional = true }
 # ... for that NSAutoReleasePool to be able to free metal devices.
 cocoa = { version = "0.19", optional = true }
 objc = { version = "0.2.4", optional = true }


### PR DESCRIPTION
cocoa 0.20 (#277) still uses version 0.3, so we do need to stick to it for now.

Reverts rust-skia/rust-skia#276