### PR TITLE
Chrome Milestone 81

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project (skia-bindings)
 
 include_directories(skia-bindings/skia)
 
-add_compile_definitions(SK_SHAPER_HARFBUZZ_AVAILABLE, SK_VULKAN, SK_XML)
+add_compile_definitions(SK_SHAPER_HARFBUZZ_AVAILABLE, SK_VULKAN, SK_XML, SK_METAL)
 
 add_library(skiabindings
         skia-bindings/src/bindings.cpp
@@ -15,4 +15,5 @@ add_library(skiabindings
         skia-bindings/src/shaper.cpp 
         skia-bindings/src/svg.cpp
         skia-bindings/src/vulkan.cpp
+        skia-bindings/src/metal.cpp
         )

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![Build Status](https://dev.azure.com/pragmatrix-github/rust-skia/_apis/build/status/rust-skia.rust-skia?branchName=master)](https://dev.azure.com/pragmatrix-github/rust-skia/_build/latest?definitionId=2&branchName=master)
 
-Skia Submodule Status: chrome/m80 ([pending changes][skiapending], [our changes][skiaours]).
+Skia Submodule Status: chrome/m81 ([pending changes][skiapending], [our changes][skiaours]).
 
-[skiapending]: https://github.com/rust-skia/skia/compare/m80-0.26.8...google:chrome/m80
-[skiaours]: https://github.com/google/skia/compare/chrome/m80...rust-skia:m80-0.26.8
+[skiapending]: https://github.com/rust-skia/skia/compare/m81-0.26.8...google:chrome/m81
+[skiaours]: https://github.com/google/skia/compare/chrome/m81...rust-skia:m81-0.26.8
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m81 ([pending changes][skiapending], [our changes][skiaours]).
 
-[skiapending]: https://github.com/rust-skia/skia/compare/m81-0.26.8...google:chrome/m81
-[skiaours]: https://github.com/google/skia/compare/chrome/m81...rust-skia:m81-0.26.8
+[skiapending]: https://github.com/rust-skia/skia/compare/m81-0.27.0...google:chrome/m81
+[skiaours]: https://github.com/google/skia/compare/chrome/m81...rust-skia:m81-0.27.0
 
 ## Goals
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.26.8"
+version = "0.27.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"
@@ -29,7 +29,7 @@ include = [
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m81-0.26.8"
+skia = "m81-0.27.0"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -29,7 +29,7 @@ include = [
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m80-0.26.8"
+skia = "m81-0.26.8"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -736,6 +736,7 @@ const OPAQUE_TYPES: &[&str] = &[
     "GrContextOptions_PersistentCache",
     "GrContextOptions_ShaderErrorHandler",
     "Sk1DPathEffect",
+    "SkBBoxHierarchy", // vtable
     "SkBBHFactory",
     "SkBitmap_Allocator",
     "SkBitmap_HeapAllocator",

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -778,6 +778,9 @@ const OPAQUE_TYPES: &[&str] = &[
     "SkRuntimeEffect_EffectResult",
     "SkRuntimeEffect_ByteCodeResult",
     "SkRuntimeEffect_SpecializeResult",
+    // derives from std::string
+    "SkSL::String",
+    "std::basic_string",
 ];
 
 #[derive(Debug)]

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -774,17 +774,19 @@ const OPAQUE_TYPES: &[&str] = &[
     "SkShaper_ScriptRunIterator",
     "SkContourMeasure",
     "SkDocument",
-    // tuples:
+    // m81: tuples:
     "SkRuntimeEffect_EffectResult",
     "SkRuntimeEffect_ByteCodeResult",
     "SkRuntimeEffect_SpecializeResult",
-    // derives from std::string
+    // m81: derives from std::string
     "SkSL::String",
     "std::basic_string",
     "std::basic_string_value_type",
-    // wrong size on macOS and Linux
+    // m81: wrong size on macOS and Linux
     "SkRuntimeEffect",
     "GrShaderCaps",
+    // m81: yet experimental
+    "SkM44",
 ];
 
 #[derive(Debug)]

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -544,6 +544,8 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
         .blacklist_type("SkLRUCache_Entry")
         //   not used at all:
         .blacklist_type("std::vector.*")
+        // too much template magic:
+        .blacklist_type("SkRuntimeEffect_ConstIterable.*")
         // Vulkan reexports that got swallowed by making them opaque.
         // (these can not be whitelisted by a extern "C" function)
         .whitelist_type("VkPhysicalDeviceFeatures")
@@ -772,6 +774,10 @@ const OPAQUE_TYPES: &[&str] = &[
     "SkShaper_ScriptRunIterator",
     "SkContourMeasure",
     "SkDocument",
+    // tuples:
+    "SkRuntimeEffect_EffectResult",
+    "SkRuntimeEffect_ByteCodeResult",
+    "SkRuntimeEffect_SpecializeResult",
 ];
 
 #[derive(Debug)]
@@ -865,6 +871,7 @@ const ENUM_TABLE: &[EnumEntry] = &[
     ("Op", rewrite::k_xxx_name_opt),
     // SkRRect_*
     // TODO: remove kLastType?
+    // SkRuntimeEffect_Variable_Type
     ("Type", rewrite::k_xxx_name_opt),
     ("Corner", rewrite::k_xxx_name),
     // SkShader_GradientType
@@ -882,6 +889,10 @@ const ENUM_TABLE: &[EnumEntry] = &[
     ("VertexMode", rewrite::k_xxx_name),
     // SkYUVAIndex_Index
     ("Index", rewrite::k_xxx_name),
+    // SkRuntimeEffect_Variable_Qualifier
+    ("Qualifier", rewrite::k_xxx),
+    // private type that leaks through SkRuntimeEffect_Variable
+    ("GrSLType", rewrite::k_xxx_name),
     //
     // gpu/
     //

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -848,7 +848,7 @@ const ENUM_TABLE: &[EnumEntry] = &[
     // SkImage_*
     ("BitDepth", rewrite::k_xxx),
     ("CachingHint", rewrite::k_xxx_name),
-    ("CompressionType", rewrite::k_xxx_name),
+    ("CompressionType", rewrite::k_xxx),
     // SkImageFilter_MapDirection
     ("MapDirection", rewrite::k_xxx_name),
     // SkInterpolatorBase_Result

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -784,6 +784,7 @@ const OPAQUE_TYPES: &[&str] = &[
     "std::basic_string_value_type",
     // wrong size on macOS and Linux
     "SkRuntimeEffect",
+    "GrShaderCaps",
 ];
 
 #[derive(Debug)]

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -799,6 +799,7 @@ const ENUM_TABLE: &[EnumEntry] = &[
     //
     // core/ effects/
     //
+    ("SkApplyPerspectiveClip", rewrite::k_xxx),
     ("SkBlendMode", rewrite::k_xxx),
     ("SkBlendModeCoeff", rewrite::k_xxx),
     ("SkBlurStyle", rewrite::k_xxx_name),
@@ -828,7 +829,7 @@ const ENUM_TABLE: &[EnumEntry] = &[
     // SkStrokeRec_InitStyle
     ("InitStyle", rewrite::k_xxx_name),
     // SkBlurImageFilter_TileMode
-    // SkMatrixConvulutionImageFilter_TileMode
+    // SkMatrixConvolutionImageFilter_TileMode
     ("TileMode", rewrite::k_xxx_name),
     // SkCanvas_*
     ("PointMode", rewrite::k_xxx_name),

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -781,6 +781,7 @@ const OPAQUE_TYPES: &[&str] = &[
     // derives from std::string
     "SkSL::String",
     "std::basic_string",
+    "std::basic_string_value_type",
 ];
 
 #[derive(Debug)]

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -782,6 +782,8 @@ const OPAQUE_TYPES: &[&str] = &[
     "SkSL::String",
     "std::basic_string",
     "std::basic_string_value_type",
+    // wrong size on macOS and Linux
+    "SkRuntimeEffect",
 ];
 
 #[derive(Debug)]

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1519,7 +1519,7 @@ extern "C" const SkImageFilter* C_SkImageFilter_getInput(const SkImageFilter* se
 }
 
 //
-// SkImageGenerator
+// core/SkImageGenerator.h
 //
 
 extern "C" void C_SkImageGenerator_delete(SkImageGenerator *self) {
@@ -1528,6 +1528,10 @@ extern "C" void C_SkImageGenerator_delete(SkImageGenerator *self) {
 
 extern "C" SkData *C_SkImageGenerator_refEncodedData(SkImageGenerator *self) {
     return self->refEncodedData().release();
+}
+
+extern "C" bool C_SkImageGenerator_texturesAreCacheable(const SkImageGenerator* self) {
+    return self->texturesAreCacheable();
 }
 
 extern "C" SkImageGenerator *C_SkImageGenerator_MakeFromEncoded(SkData *data) {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1538,10 +1538,6 @@ extern "C" SkData *C_SkImageGenerator_refEncodedData(SkImageGenerator *self) {
     return self->refEncodedData().release();
 }
 
-extern "C" bool C_SkImageGenerator_texturesAreCacheable(const SkImageGenerator* self) {
-    return self->texturesAreCacheable();
-}
-
 extern "C" SkImageGenerator *C_SkImageGenerator_MakeFromEncoded(SkData *data) {
     return SkImageGenerator::MakeFromEncoded(sp(data)).release();
 }

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -553,6 +553,10 @@ extern "C" bool C_SkCanvas_isClipRect(const SkCanvas* self) {
     return self->isClipRect();
 }
 
+extern "C" void C_SkCanvas_getTotalMatrix(const SkCanvas* self, SkMatrix* matrix) {
+    *matrix = self->getTotalMatrix();
+}
+
 extern "C" void C_SkCanvas_discard(SkCanvas* self) {
     self->discard();
 }

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -227,8 +227,13 @@ extern "C" void C_SkSurfaceCharacterization_createColorSpace(const SkSurfaceChar
 }
 
 //
-// SkImage
+// core/SkImage.h
 //
+
+extern "C" SkImage *C_SkImage_MakeRasterFromCompressed(SkData *data, int width, int height, SkImage::CompressionType
+type) {
+    return SkImage::MakeRasterFromCompressed(sp(data), width, height, type).release();
+}
 
 extern "C" SkImage* C_SkImage_MakeRasterData(const SkImageInfo* info, SkData* pixels, size_t rowBytes) {
     return SkImage::MakeRasterData(*info, sp(pixels), rowBytes).release();
@@ -280,8 +285,8 @@ extern "C" SkImage* C_SkImage_makeNonTextureImage(const SkImage* self) {
     return self->makeNonTextureImage().release();
 }
 
-extern "C" SkImage* C_SkImage_makeRasterImage(const SkImage* self) {
-    return self->makeRasterImage().release();
+extern "C" SkImage* C_SkImage_makeRasterImage(const SkImage* self, SkImage::CachingHint cachingHint) {
+    return self->makeRasterImage(cachingHint).release();
 }
 
 // note: available without GPU support (GrContext may be null).

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -2276,6 +2276,18 @@ SkColorFilter* C_SkRuntimeEffect_makeColorFilter(SkRuntimeEffect* self, SkData* 
     return self->makeColorFilter(sp(inputs)).release();
 }
 
+const SkString *C_SkRuntimeEffect_source(const SkRuntimeEffect *self) {
+    return &self->source();
+}
+
+int C_SkRuntimeEffect_index(const SkRuntimeEffect *self) {
+    return self->index();
+}
+
+size_t C_SkRuntimeEffect_uniformSize(const SkRuntimeEffect *self) {
+    return self->uniformSize();
+}
+
 const SkRuntimeEffect::Variable* C_SkRuntimeEffect_inputs(const SkRuntimeEffect* self, size_t* count) {
     auto inputs = self->inputs();
     *count = inputs.count();

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -708,7 +708,7 @@ extern "C" void C_SkMatrix44_MulV4(const SkMatrix44* self, const SkVector4* rhs,
 }
 
 //
-// SkMatrix
+// core/SkMatrix.h
 //
 
 extern "C" bool C_SkMatrix_Equals(const SkMatrix* self, const SkMatrix* rhs) {
@@ -741,6 +741,10 @@ extern "C" void C_SkMatrix_setScaleTranslate(SkMatrix* self, SkScalar sx, SkScal
 
 extern "C" bool C_SkMatrix_isFinite(const SkMatrix* self) {
     return self->isFinite();
+}
+
+extern "C" void C_SkMatrix_normalizePerspective(SkMatrix* self) {
+    self->normalizePerspective();
 }
 
 //

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -691,7 +691,7 @@ extern "C" bool C_SkMatrix44_Equals(const SkMatrix44* self, const SkMatrix44* rh
 
 // SkMatrix44_SkMatrix conversion.
 extern "C" void C_SkMatrix44_SkMatrix(const SkMatrix44* self, SkMatrix* m) {
-    *m = *self;
+    *m = SkMatrix(*self);
 }
 
 extern "C" void C_SkMatrix44_Mul(const SkMatrix44* self, const SkMatrix44* rhs, SkMatrix44* result) {
@@ -728,10 +728,6 @@ extern "C" bool C_SkMatrix_hasPerspective(const SkMatrix* self) {
 
 extern "C" bool C_SkMatrix_invert(const SkMatrix* self, SkMatrix* inverse) {
     return self->invert(inverse);
-}
-
-extern "C" bool C_SkMatrix_cheapEqualTo(const SkMatrix* self, const SkMatrix* other) {
-    return self->cheapEqualTo(*other);
 }
 
 extern "C" void C_SkMatrix_setScaleTranslate(SkMatrix* self, SkScalar sx, SkScalar sy, SkScalar tx, SkScalar ty) {

--- a/skia-bindings/src/gpu.cpp
+++ b/skia-bindings/src/gpu.cpp
@@ -121,19 +121,6 @@ extern "C" const SkImageInfo* C_SkSurfaceCharacterization_imageInfo(const SkSurf
 }
 
 //
-// core/SkImage.h
-//
-
-extern "C" void C_SkImage_getBackendTexture(
-        const SkImage* self,
-        bool flushPendingGrContextIO,
-        GrSurfaceOrigin* origin,
-        GrBackendTexture* result)
-{
-    *result = self->getBackendTexture(flushPendingGrContextIO, origin);
-}
-
-//
 // core/SkImageGenerator.h
 //
 
@@ -266,12 +253,30 @@ extern "C" void C_SkDrawable_GpuDrawHandler_draw(SkDrawable::GpuDrawHandler *sel
 // core/SkImage.h
 //
 
-extern "C" SkImage* C_SkImage_DecodeToTexture(GrContext* ctx, const void* encoded, size_t length, const SkIRect* subset) {
-    return SkImage::DecodeToTexture(ctx, encoded, length, subset).release();
+
+extern "C" SkImage *C_SkImage_MakeTextureFromCompressed(GrContext *context, SkData *data, int width, int height,
+                                                SkImage::CompressionType type, GrMipMapped mipMapped,
+                                                GrProtected prot) {
+    return SkImage::MakeTextureFromCompressed(context, sp(data), width, height, type, mipMapped, prot).release();
 }
 
-extern "C" SkImage* C_SkImage_MakeFromCompressed(GrContext* context, SkData* encoded, int width, int height, SkImage::CompressionType type) {
-    return SkImage::MakeFromCompressed(context, sp(encoded), width, height, type).release();
+extern "C" void C_SkImage_getBackendTexture(
+        const SkImage* self,
+        bool flushPendingGrContextIO,
+        GrSurfaceOrigin* origin,
+        GrBackendTexture* result)
+{
+    *result = self->getBackendTexture(flushPendingGrContextIO, origin);
+}
+
+extern "C" SkImage *C_SkImage_MakeFromCompressed(GrContext *context, SkData *encoded, int width, int height,
+                                                 SkImage::CompressionType type, GrMipMapped mipMapped, GrProtected 
+                                                 prot) {
+    return SkImage::MakeFromCompressed(context, sp(encoded), width, height, type, mipMapped, prot).release();
+}
+
+extern "C" SkImage* C_SkImage_DecodeToTexture(GrContext* ctx, const void* encoded, size_t length, const SkIRect* subset) {
+    return SkImage::DecodeToTexture(ctx, encoded, length, subset).release();
 }
 
 extern "C" SkImage* C_SkImage_MakeFromTexture(

--- a/skia-bindings/src/gpu.cpp
+++ b/skia-bindings/src/gpu.cpp
@@ -381,3 +381,12 @@ extern "C" SkImage* C_SkImage_makeTextureImage(
         GrMipMapped mipMapped) {
     return self->makeTextureImage(context, mipMapped).release();
 }
+
+//
+// core/SkImageGenerator.h
+//
+
+extern "C" bool C_SkImageGenerator_texturesAreCacheable(const SkImageGenerator* self) {
+    return self->texturesAreCacheable();
+}
+

--- a/skia-bindings/src/gpu.cpp
+++ b/skia-bindings/src/gpu.cpp
@@ -198,6 +198,10 @@ extern "C" void C_GrContext_defaultBackendFormat(const GrContext* self, SkColorT
     *result = self->defaultBackendFormat(ct, renderable);
 }
 
+extern "C" void C_GrContext_compressedBackendFormat(const GrContext* self, SkImage::CompressionType compression, GrBackendFormat* result) {
+    *result = self->compressedBackendFormat(compression);
+}
+
 //
 // gpu/GrBackendDrawableInfo.h
 //

--- a/skia-bindings/src/impls.rs
+++ b/skia-bindings/src/impls.rs
@@ -6,7 +6,10 @@
 //!
 //! See also: https://github.com/rust-lang/rfcs/issues/1880
 
-use crate::{SkAlphaType, SkBlendMode, SkBlendModeCoeff, SkPathFillType, SkPathVerb};
+use crate::{
+    SkAlphaType, SkBlendMode, SkBlendModeCoeff, SkImage_CompressionType,
+    SkImage_kCompressionTypeCount, SkPathFillType, SkPathVerb,
+};
 use std::ffi::CStr;
 
 impl SkBlendMode {
@@ -68,4 +71,10 @@ impl SkAlphaType {
     pub fn is_opaque(self) -> bool {
         self == SkAlphaType::Opaque
     }
+}
+
+impl SkImage_CompressionType {
+    pub const COUNT: usize = SkImage_kCompressionTypeCount as _;
+    #[deprecated(since = "0.0.0", note = "same as ETC2_RGB8_UNORM")]
+    pub const ETC1: Self = SkImage_CompressionType::ETC2_RGB8_UNORM;
 }

--- a/skia-bindings/src/impls.rs
+++ b/skia-bindings/src/impls.rs
@@ -75,6 +75,6 @@ impl SkAlphaType {
 
 impl SkImage_CompressionType {
     pub const COUNT: usize = SkImage_kCompressionTypeCount as _;
-    #[deprecated(since = "0.0.0", note = "same as ETC2_RGB8_UNORM")]
+    #[deprecated(since = "0.27.0", note = "same as ETC2_RGB8_UNORM")]
     pub const ETC1: Self = SkImage_CompressionType::ETC2_RGB8_UNORM;
 }

--- a/skia-bindings/src/metal.cpp
+++ b/skia-bindings/src/metal.cpp
@@ -1,4 +1,33 @@
+#include "bindings.h"
+#include "include/core/SkSurface.h"
 #include "include/gpu/GrContext.h"
+
+//
+// core/SkSurface.h
+//
+
+extern "C" SkSurface *C_SkSurface_MakeFromCAMetalLayer(GrContext *context,
+                                                       GrMTLHandle layer,
+                                                       GrSurfaceOrigin origin,
+                                                       int sampleCnt,
+                                                       SkColorType colorType,
+                                                       SkColorSpace *colorSpace,
+                                                       const SkSurfaceProps *surfaceProps,
+                                                       GrMTLHandle *drawable) {
+    return SkSurface::MakeFromCAMetalLayer(context, layer, origin, sampleCnt, colorType, sp(colorSpace), surfaceProps,
+                                           drawable).release();
+}
+
+static SkSurface *MakeFromMTKView(GrContext *context,
+                                  GrMTLHandle mtkView,
+                                  GrSurfaceOrigin origin,
+                                  int sampleCnt,
+                                  SkColorType colorType,
+                                  SkColorSpace *colorSpace,
+                                  const SkSurfaceProps *surfaceProps) {
+    return SkSurface::MakeFromMTKView(context, mtkView, origin, sampleCnt, colorType, sp(colorSpace), surfaceProps
+    ).release();
+}
 
 //
 // gpu/GrContext.h

--- a/skia-bindings/src/paragraph.cpp
+++ b/skia-bindings/src/paragraph.cpp
@@ -336,6 +336,14 @@ extern "C" {
         self->resetShadows();
     }
 
+    void C_TextStyle_addFontFeature(TextStyle* self, const SkString* fontFeature, int value) {
+        self->addFontFeature(*fontFeature, value);
+    }
+
+    void C_TextStyle_resetFontFeatures(TextStyle* self) {
+        self->resetFontFeatures();
+    }
+    
     const SkString* C_TextStyle_getFontFamilies(const TextStyle* self, size_t* count) {
         auto& v = self->getFontFamilies();
         *count = v.size();
@@ -351,16 +359,22 @@ extern "C" {
     }
 }
 
+struct FontFeatures {
+    std::vector<FontFeature> fontFeatures;
+};
+
+extern "C" const FontFeature *C_FontFeatures_ptr_count(const FontFeatures *features, size_t *count) {
+    *count = features->fontFeatures.size();
+    return &features->fontFeatures.front();
+}
 
 struct TextShadows {
     std::vector<TextShadow> textShadows;
 };
 
-extern "C" {
-    const TextShadow* C_TextShadows_ptr_count(const TextShadows* shadows, size_t* count) {
-        *count = shadows->textShadows.size();
-        return &shadows->textShadows.front();
-    }
+extern "C" const TextShadow *C_TextShadows_ptr_count(const TextShadows *shadows, size_t *count) {
+    *count = shadows->textShadows.size();
+    return &shadows->textShadows.front();
 }
 
 //

--- a/skia-bindings/src/shaper.cpp
+++ b/skia-bindings/src/shaper.cpp
@@ -17,6 +17,10 @@ extern "C" SkShaper* C_SkShaper_MakeShapeDontWrapOrReorder(SkFontMgr* fontMgr) {
     return SkShaper::MakeShapeDontWrapOrReorder(sk_sp<SkFontMgr>(fontMgr)).release();
 }
 
+extern "C" SkShaper* C_SkShaper_MakeCoreText() {
+    return SkShaper::MakeCoreText().release();
+}
+
 extern "C" SkShaper* C_SkShaper_Make(SkFontMgr* fontMgr) {
     return SkShaper::Make(sk_sp<SkFontMgr>(fontMgr)).release();
 }
@@ -179,6 +183,19 @@ C_SkShaper_shape2(const SkShaper *self, const char *utf8, size_t utf8Bytes, SkSh
                   SkShaper::LanguageRunIterator *languageRunIterator, SkScalar width,
                   SkShaper::RunHandler *runHandler) {
     self->shape(utf8, utf8Bytes, *fontRunIterator, *bidiRunIterator, *scriptRunIterator, *languageRunIterator, width,
+                runHandler);
+}
+
+extern "C" void
+C_SkShaper_shape3(const SkShaper *self, const char *utf8, size_t utf8Bytes, SkShaper::FontRunIterator *fontRunIterator,
+                  SkShaper::BiDiRunIterator *bidiRunIterator,
+                  SkShaper::ScriptRunIterator *scriptRunIterator,
+                  SkShaper::LanguageRunIterator *languageRunIterator,
+                  const SkShaper::Feature *features, size_t featuresSize,
+                  SkScalar width,
+                  SkShaper::RunHandler *runHandler) {
+    self->shape(utf8, utf8Bytes, *fontRunIterator, *bidiRunIterator, *scriptRunIterator, *languageRunIterator, features,
+                featuresSize, width,
                 runHandler);
 }
 

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.26.8"
+version = "0.27.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -32,7 +32,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 
 [dependencies]
 bitflags = "1.0.4"
-skia-bindings = { version = "=0.26.8", path = "../skia-bindings" }
+skia-bindings = { version = "=0.27.0", path = "../skia-bindings" }
 lazy_static = "1.4"
 
 [dev-dependencies]

--- a/skia-safe/src/core/bbh_factory.rs
+++ b/skia-safe/src/core/bbh_factory.rs
@@ -1,7 +1,10 @@
 use crate::prelude::*;
-use skia_bindings::SkBBHFactory;
+use skia_bindings::{SkBBHFactory, SkBBoxHierarchy};
 
-// TODO: complete the implementation
+// TODO: complete the wrapper
+pub type BBoxHierarchy = RCHandle<SkBBoxHierarchy>;
+
+// TODO: complete the wrapper
 pub type BBHFactory = Handle<SkBBHFactory>;
 
 impl NativeDrop for SkBBHFactory {

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -1034,8 +1034,8 @@ impl Canvas {
         unsafe { sb::C_SkCanvas_isClipEmpty(self.native()) }
     }
 
-    pub fn total_matrix(&self) -> &Matrix {
-        Matrix::from_native_ref(unsafe { &self.native().getTotalMatrix() })
+    pub fn total_matrix(&self) -> Matrix {
+        Matrix::from_native(unsafe { self.native().getTotalMatrix() })
     }
 
     //

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -1035,7 +1035,11 @@ impl Canvas {
     }
 
     pub fn total_matrix(&self) -> Matrix {
-        Matrix::from_native(unsafe { self.native().getTotalMatrix() })
+        let mut matrix = Matrix::default();
+        // TODO: why is Matrix not safe to return from getTotalMatrix()
+        // testcase `test_total_matrix` below crashes with an access violation.
+        unsafe { sb::C_SkCanvas_getTotalMatrix(self.native(), matrix.native_mut()) };
+        matrix
     }
 
     //
@@ -1244,13 +1248,13 @@ mod tests {
     }
 
     #[test]
-    fn test_total_matrix_transmutation() {
+    fn test_total_matrix() {
         let mut c = Canvas::new((2, 2), None).unwrap();
-        let matrix_ref = c.total_matrix();
-        assert_eq!(Matrix::default(), *matrix_ref);
+        let total = c.total_matrix();
+        assert_eq!(Matrix::default(), total);
         c.rotate(0.1, None);
-        let matrix_ref = c.total_matrix();
-        assert_ne!(Matrix::default(), *matrix_ref);
+        let total = c.total_matrix();
+        assert_ne!(Matrix::default(), total);
     }
 
     #[test]

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -1035,7 +1035,7 @@ impl Canvas {
     }
 
     pub fn total_matrix(&self) -> &Matrix {
-        Matrix::from_native_ref(unsafe { &*self.native().getTotalMatrix() })
+        Matrix::from_native_ref(unsafe { &self.native().getTotalMatrix() })
     }
 
     //

--- a/skia-safe/src/core/image.rs
+++ b/skia-safe/src/core/image.rs
@@ -25,6 +25,9 @@ fn test_caching_hint_naming() {
 pub use skia_bindings::SkImage_CompressionType as CompressionType;
 #[test]
 fn test_compression_type_naming() {
+    // legacy type (replaced in m81 by ETC2_RGB8_UNORM)
+    #[allow(deprecated)]
+    let _ = CompressionType::ETC1;
     // m81: preserve the underscore characters for consistency.
     let _ = CompressionType::BC1_RGBA8_UNORM;
 }

--- a/skia-safe/src/core/image.rs
+++ b/skia-safe/src/core/image.rs
@@ -25,7 +25,8 @@ fn test_caching_hint_naming() {
 pub use skia_bindings::SkImage_CompressionType as CompressionType;
 #[test]
 fn test_compression_type_naming() {
-    let _ = CompressionType::ETC1;
+    // m81: preserve the underscore characters for consistency.
+    let _ = CompressionType::BC1_RGBA8_UNORM;
 }
 
 pub type Image = RCHandle<SkImage>;

--- a/skia-safe/src/core/image.rs
+++ b/skia-safe/src/core/image.rs
@@ -128,7 +128,7 @@ impl RCHandle<SkImage> {
     }
 
     #[deprecated(
-        since = "0.0.0",
+        since = "0.27.0",
         note = "soon to be deprecated (m81), use new_text_from_compressed"
     )]
     #[cfg(feature = "gpu")]
@@ -195,7 +195,7 @@ impl RCHandle<SkImage> {
 
     // TODO: MakeFromCompressedTexture
 
-    #[deprecated(since = "0.0.0", note = "renamed, use new_cross_context_from_pixmap")]
+    #[deprecated(since = "0.27.0", note = "renamed, use new_cross_context_from_pixmap")]
     #[cfg(feature = "gpu")]
     pub fn from_pixmap_cross_context(
         context: &mut gpu::Context,

--- a/skia-safe/src/core/image_generator.rs
+++ b/skia-safe/src/core/image_generator.rs
@@ -105,6 +105,10 @@ impl RefHandle<SkImageGenerator> {
 
     // TODO: generateTexture()
 
+    pub fn textures_are_cacheable(&self) -> bool {
+        unsafe { sb::C_SkImageGenerator_texturesAreCacheable(self.native()) }
+    }
+
     pub fn from_encoded(encoded: Data) -> Option<Self> {
         Self::from_ptr(unsafe { sb::C_SkImageGenerator_MakeFromEncoded(encoded.into_ptr()) })
     }

--- a/skia-safe/src/core/image_generator.rs
+++ b/skia-safe/src/core/image_generator.rs
@@ -105,6 +105,7 @@ impl RefHandle<SkImageGenerator> {
 
     // TODO: generateTexture()
 
+    #[cfg(feature = "gpu")]
     pub fn textures_are_cacheable(&self) -> bool {
         unsafe { sb::C_SkImageGenerator_texturesAreCacheable(self.native()) }
     }

--- a/skia-safe/src/core/image_info.rs
+++ b/skia-safe/src/core/image_info.rs
@@ -363,7 +363,12 @@ impl Handle<SkImageInfo> {
     }
 
     pub fn valid_row_bytes(&self, row_bytes: usize) -> bool {
-        row_bytes >= self.min_row_bytes()
+        if row_bytes < self.min_row_bytes() {
+            return false;
+        }
+        let shift = self.shift_per_pixel();
+        let aligned_row_bytes = row_bytes >> shift << shift;
+        return aligned_row_bytes == row_bytes;
     }
 
     pub fn reset(&mut self) -> &mut Self {

--- a/skia-safe/src/core/image_info.rs
+++ b/skia-safe/src/core/image_info.rs
@@ -368,7 +368,7 @@ impl Handle<SkImageInfo> {
         }
         let shift = self.shift_per_pixel();
         let aligned_row_bytes = row_bytes >> shift << shift;
-        return aligned_row_bytes == row_bytes;
+        aligned_row_bytes == row_bytes
     }
 
     pub fn reset(&mut self) -> &mut Self {

--- a/skia-safe/src/core/matrix.rs
+++ b/skia-safe/src/core/matrix.rs
@@ -479,7 +479,7 @@ impl Matrix {
     }
 
     #[deprecated(
-        since = "0.0.0",
+        since = "0.27.0",
         note = "use post_scale((1.0 / x as scalar, 1.0 / y as scalar), None)"
     )]
     pub fn post_idiv(&mut self, (div_x, div_y): (i32, i32)) -> bool {
@@ -717,17 +717,17 @@ impl Matrix {
         }
     }
 
-    #[deprecated(since = "0.0.0", note = "removed without replacement")]
+    #[deprecated(since = "0.27.0", note = "removed without replacement")]
     pub fn is_fixed_step_in_x(&self) -> ! {
         unimplemented!("removed without replacement")
     }
 
-    #[deprecated(since = "0.0.0", note = "removed without replacement")]
+    #[deprecated(since = "0.27.0", note = "removed without replacement")]
     pub fn fixed_step_in_x(&self, _y: scalar) -> ! {
         unimplemented!("removed without replacement")
     }
 
-    #[deprecated(since = "0.0.0", note = "removed without replacement")]
+    #[deprecated(since = "0.27.0", note = "removed without replacement")]
     pub fn cheap_equal_to(&self, _other: &Matrix) -> ! {
         unimplemented!("removed without replacement")
     }

--- a/skia-safe/src/core/matrix.rs
+++ b/skia-safe/src/core/matrix.rs
@@ -723,12 +723,12 @@ impl Matrix {
     }
 
     #[deprecated(since = "0.0.0", note = "removed without replacement")]
-    pub fn fixed_step_in_x(&self, y: scalar) -> ! {
+    pub fn fixed_step_in_x(&self, _y: scalar) -> ! {
         unimplemented!("removed without replacement")
     }
 
     #[deprecated(since = "0.0.0", note = "removed without replacement")]
-    pub fn cheap_equal_to(&self, other: &Matrix) -> ! {
+    pub fn cheap_equal_to(&self, _other: &Matrix) -> ! {
         unimplemented!("removed without replacement")
     }
 

--- a/skia-safe/src/core/milestone.rs
+++ b/skia-safe/src/core/milestone.rs
@@ -1,1 +1,1 @@
-pub const MILESTONE: usize = 80;
+pub const MILESTONE: usize = 81;

--- a/skia-safe/src/core/path.rs
+++ b/skia-safe/src/core/path.rs
@@ -1,3 +1,4 @@
+use crate::core::matrix::ApplyPerspectiveClip;
 use crate::interop::DynamicMemoryWStream;
 use crate::prelude::*;
 use crate::{
@@ -796,14 +797,36 @@ impl Handle<SkPath> {
 
     #[must_use]
     pub fn with_transform(&self, matrix: &Matrix) -> Path {
+        self.with_transform_with_perspective_clip(matrix, ApplyPerspectiveClip::Yes)
+    }
+
+    pub fn with_transform_with_perspective_clip(
+        &self,
+        matrix: &Matrix,
+        perspective_clip: ApplyPerspectiveClip,
+    ) -> Path {
         let mut path = Path::default();
-        unsafe { self.native().transform(matrix.native(), path.native_mut()) };
+        unsafe {
+            self.native()
+                .transform(matrix.native(), path.native_mut(), perspective_clip)
+        };
         path
     }
 
     pub fn transform(&mut self, matrix: &Matrix) -> &mut Self {
+        self.transform_with_perspective_clip(matrix, ApplyPerspectiveClip::Yes)
+    }
+
+    pub fn transform_with_perspective_clip(
+        &mut self,
+        matrix: &Matrix,
+        perspective_clip: ApplyPerspectiveClip,
+    ) -> &mut Self {
         let self_ptr = self.native_mut() as *mut _;
-        unsafe { self.native().transform(matrix.native(), self_ptr) };
+        unsafe {
+            self.native()
+                .transform(matrix.native(), self_ptr, perspective_clip)
+        };
         self
     }
 

--- a/skia-safe/src/core/picture_recorder.rs
+++ b/skia-safe/src/core/picture_recorder.rs
@@ -28,6 +28,8 @@ impl Handle<SkPictureRecorder> {
         Self::from_native(unsafe { SkPictureRecorder::new() })
     }
 
+    // TODO: beginRecording with BBoxHierarchy
+
     pub fn begin_recording(
         &mut self,
         bounds: impl AsRef<Rect>,
@@ -35,7 +37,7 @@ impl Handle<SkPictureRecorder> {
         record_flags: impl Into<Option<RecordFlags>>,
     ) -> &mut Canvas {
         let canvas_ref = unsafe {
-            &mut *self.native_mut().beginRecording(
+            &mut *self.native_mut().beginRecording1(
                 bounds.as_ref().native(),
                 bbh_factory.native_ptr_or_null_mut(),
                 record_flags

--- a/skia-safe/src/core/point3.rs
+++ b/skia-safe/src/core/point3.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use crate::scalar;
 use skia_bindings::SkPoint3;
-use std::ops::{Add, AddAssign, Neg, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};
 
 pub type Vector3 = Point3;
 pub type Color3f = Point3;
@@ -57,6 +57,14 @@ impl Sub for Point3 {
 impl SubAssign for Point3 {
     fn sub_assign(&mut self, rhs: Point3) {
         *self = *self - rhs;
+    }
+}
+
+impl Mul<(scalar, Point3)> for Point3 {
+    type Output = Self;
+
+    fn mul(self, (t, p): (scalar, Point3)) -> Self::Output {
+        Self::new(t * p.x, t * p.y, t * p.z)
     }
 }
 

--- a/skia-safe/src/core/rect.rs
+++ b/skia-safe/src/core/rect.rs
@@ -276,7 +276,7 @@ impl IRect {
         )
     }
 
-    #[deprecated(since = "0.0.0", note = "removed without replacement")]
+    #[deprecated(since = "0.27.0", note = "removed without replacement")]
     #[must_use]
     pub fn empty() -> &'static Self {
         &EMPTY_IRECT

--- a/skia-safe/src/core/rect.rs
+++ b/skia-safe/src/core/rect.rs
@@ -276,6 +276,7 @@ impl IRect {
         )
     }
 
+    #[deprecated(since = "0.0.0", note = "removed without replacement")]
     #[must_use]
     pub fn empty() -> &'static Self {
         &EMPTY_IRECT

--- a/skia-safe/src/core/surface.rs
+++ b/skia-safe/src/core/surface.rs
@@ -143,6 +143,54 @@ impl RCHandle<SkSurface> {
         })
     }
 
+    #[cfg(feature = "metal")]
+    pub fn from_ca_metal_layer(
+        context: &mut gpu::Context,
+        layer: gpu::mtl::Handle,
+        origin: gpu::SurfaceOrigin,
+        sample_count: impl Into<Option<usize>>,
+        color_type: crate::Colortype,
+        color_space: impl Into<Option<crate::ColorSpace>>,
+        surface_props: Option<&SurfaceProps>,
+    ) -> Option<(Self, gpu::mtl::Handle)> {
+        let mut drawable = ptr::null_mut();
+        Self::from_ptr(unsafe {
+            sb::C_SkSurface_MakeFromCAMetalLayer(
+                context.native_mut(),
+                layer,
+                origin,
+                sample_count.into().unwrap_or(0).try_into().unwrap(),
+                color_type.into_native(),
+                color_space.into().into_ptr_or_null(),
+                surface_props.native_ptr_or_null(),
+                &mut drawable,
+            )
+        })
+        .map(|surface| (surface, drawable))
+    }
+
+    #[cfg(feature = "metal")]
+    pub fn from_ca_mtk_view(
+        context: &mut gpu::Context,
+        mtk_view: gpu::mtl::Handle,
+        origin: gpu::SurfaceOrigin,
+        sample_count: impl Into<Option<usize>>,
+        color_type: crate::Colortype,
+        color_space: impl Into<Option<crate::ColorSpace>>,
+        surface_props: Option<&SurfaceProps>,
+    ) -> Option<Self> {
+        Self::from_ptr(unsafe {
+            sb::C_SkSurface_MakeFromMTKView(
+                context.native_mut(),
+                mtk_view,
+                origin,
+                sample_count.into().unwrap_or(0).try_into().unwrap(),
+                color_type.into_native(),
+                color_space.into().into_ptr_or_null(),
+                surface_props.native_ptr_or_null(),
+            )
+        })
+    }
     pub fn new_render_target(
         context: &mut gpu::Context,
         budgeted: crate::Budgeted,

--- a/skia-safe/src/effects.rs
+++ b/skia-safe/src/effects.rs
@@ -42,6 +42,7 @@ pub mod overdraw_color_filter;
 pub mod paint_image_filter;
 pub mod perlin_noise_shader;
 pub mod picture_image_filter;
+pub mod runtime_effect;
 pub mod shader_mask_filter;
 pub mod table_color_filter;
 pub mod table_mask_filter;

--- a/skia-safe/src/effects/runtime_effect.rs
+++ b/skia-safe/src/effects/runtime_effect.rs
@@ -123,11 +123,11 @@ impl RCHandle<SkRuntimeEffect> {
     }
 
     pub fn source(&self) -> &str {
-        self.native().fSkSL.as_str()
+        unsafe { (*sb::C_SkRuntimeEffect_source(self.native())).as_str() }
     }
 
     pub fn index(&self) -> i32 {
-        self.native().fIndex
+        unsafe { sb::C_SkRuntimeEffect_index(self.native()) }
     }
 
     pub fn input_size(&self) -> usize {
@@ -135,7 +135,7 @@ impl RCHandle<SkRuntimeEffect> {
     }
 
     pub fn uniform_size(&self) -> usize {
-        self.native().fUniformSize
+        unsafe { sb::C_SkRuntimeEffect_uniformSize(self.native()) }
     }
 
     pub fn inputs(&self) -> &[Variable] {

--- a/skia-safe/src/effects/runtime_effect.rs
+++ b/skia-safe/src/effects/runtime_effect.rs
@@ -1,0 +1,160 @@
+use crate::interop::AsStr;
+use crate::prelude::*;
+use crate::{interop, ColorFilter, Data, Matrix, Shader};
+use skia_bindings as sb;
+use skia_bindings::{SkRefCntBase, SkRuntimeEffect, SkRuntimeEffect_Variable};
+use std::slice;
+
+pub type Variable = Handle<SkRuntimeEffect_Variable>;
+
+impl NativeDrop for SkRuntimeEffect_Variable {
+    fn drop(&mut self) {
+        panic!("native type SkRuntimeEffect_Variable can't be owned in Rust");
+    }
+}
+
+impl Handle<SkRuntimeEffect_Variable> {
+    pub fn name(&self) -> &str {
+        self.native().fName.as_str()
+    }
+
+    pub fn offset(&self) -> usize {
+        self.native().fOffset
+    }
+
+    pub fn qualifier(&self) -> variable::Qualifier {
+        self.native().fQualifier
+    }
+
+    pub fn ty(&self) -> variable::Type {
+        self.native().fType
+    }
+
+    pub fn count(&self) -> i32 {
+        self.native().fCount
+    }
+
+    pub fn flags(&self) -> variable::Flags {
+        variable::Flags::from_bits(self.native().fFlags).unwrap()
+    }
+
+    #[cfg(feature = "gpu")]
+    pub fn gpu_type(&self) -> crate::private::gpu::SLType {
+        self.native().fGPUType
+    }
+
+    pub fn is_array(&self) -> bool {
+        self.flags().contains(variable::Flags::ARRAY)
+    }
+
+    pub fn size_in_bytes(&self) -> usize {
+        unsafe { self.native().sizeInBytes() }
+    }
+}
+
+pub mod variable {
+    use skia_bindings as sb;
+
+    pub use sb::SkRuntimeEffect_Variable_Qualifier as Qualifier;
+    #[test]
+    fn test_qualifier_naming() {
+        let _ = Qualifier::In;
+    }
+
+    pub use sb::SkRuntimeEffect_Variable_Type as Type;
+    #[test]
+    fn test_type_naming() {
+        let _ = Type::Bool;
+    }
+
+    bitflags! {
+        pub struct Flags : u32 {
+            const ARRAY = sb::SkRuntimeEffect_Variable_Flags_kArray_Flag as _;
+        }
+    }
+}
+
+pub type RuntimeEffect = RCHandle<SkRuntimeEffect>;
+
+impl NativeRefCountedBase for SkRuntimeEffect {
+    type Base = SkRefCntBase;
+}
+
+pub fn new(sksl: impl AsRef<str>) -> Result<RuntimeEffect, String> {
+    let str = interop::String::from_str(sksl);
+    let mut error = interop::String::default();
+    let effect = RuntimeEffect::from_ptr(unsafe {
+        sb::C_SkRuntimeEffect_Make(str.native(), error.native_mut())
+    });
+    match effect {
+        Some(runtime_effect) => Ok(runtime_effect),
+        None => Err(error.as_str().to_owned()),
+    }
+}
+
+impl RCHandle<SkRuntimeEffect> {
+    pub fn make_shader<'a>(
+        &mut self,
+        inputs: Data,
+        children: impl IntoIterator<Item = Shader>,
+        local_matrix: impl Into<Option<&'a Matrix>>,
+        is_opaque: bool,
+    ) -> Option<Shader> {
+        let mut children: Vec<_> = children
+            .into_iter()
+            .map(|shader| shader.into_ptr())
+            .collect();
+        Shader::from_ptr(unsafe {
+            sb::C_SkRuntimeEffect_makeShader(
+                self.native_mut(),
+                inputs.into_ptr(),
+                children.as_mut_ptr(),
+                children.len(),
+                local_matrix.into().native_ptr_or_null(),
+                is_opaque,
+            )
+        })
+    }
+
+    pub fn make_color_filter(&mut self, inputs: Data) -> Option<ColorFilter> {
+        ColorFilter::from_ptr(unsafe {
+            sb::C_SkRuntimeEffect_makeColorFilter(self.native_mut(), inputs.into_ptr())
+        })
+    }
+
+    pub fn source(&self) -> &str {
+        self.native().fSkSL.as_str()
+    }
+
+    pub fn index(&self) -> i32 {
+        self.native().fIndex
+    }
+
+    pub fn input_size(&self) -> usize {
+        unsafe { self.native().inputSize() }
+    }
+
+    pub fn uniform_size(&self) -> usize {
+        self.native().fUniformSize
+    }
+
+    pub fn inputs(&self) -> &[Variable] {
+        unsafe {
+            let mut count: usize = 0;
+            let ptr = sb::C_SkRuntimeEffect_inputs(self.native(), &mut count);
+            slice::from_raw_parts(Variable::from_native_ref(&*ptr), count)
+        }
+    }
+
+    pub fn children(&self) -> impl Iterator<Item = &str> {
+        unsafe {
+            let mut count: usize = 0;
+            let ptr = sb::C_SkRuntimeEffect_children(self.native(), &mut count);
+            let slice = slice::from_raw_parts(ptr, count);
+            slice.iter().map(|str| str.as_str())
+        }
+    }
+
+    // TODO: wrap toPipelineStage()
+    // TODO: wrap toByteCode()
+}

--- a/skia-safe/src/gpu/backend_surface.rs
+++ b/skia-safe/src/gpu/backend_surface.rs
@@ -336,6 +336,10 @@ impl Handle<GrBackendRenderTarget> {
         self.native().fBackend
     }
 
+    pub fn is_framebuffer_only(&self) -> bool {
+        self.native().fFramebufferOnly
+    }
+
     #[cfg(feature = "gl")]
     pub fn gl_framebuffer_info(&self) -> Option<gl::FramebufferInfo> {
         let mut info = gl::FramebufferInfo::default();

--- a/skia-safe/src/gpu/context.rs
+++ b/skia-safe/src/gpu/context.rs
@@ -4,7 +4,7 @@ use super::gl;
 use super::vk;
 use crate::gpu::{BackendFormat, MipMapped, Renderable};
 use crate::prelude::*;
-use crate::{ColorType, Data, Image};
+use crate::{image, ColorType, Data, Image};
 use skia_bindings as sb;
 use skia_bindings::{GrContext, SkRefCntBase};
 
@@ -247,8 +247,25 @@ impl RCHandle<GrContext> {
         format
     }
 
-    // TODO: support createBackendTexture (several variants) and deleteBackendTexture(),
+    // TODO: wrap createBackendTexture (several variants)
     //       introduced in m76, m77, and m79
+
+    pub fn compressed_backend_format(&self, compression: image::CompressionType) -> BackendFormat {
+        let mut backend_format = BackendFormat::default();
+        unsafe {
+            sb::C_GrContext_compressedBackendFormat(
+                self.native(),
+                compression,
+                backend_format.native_mut(),
+            )
+        };
+        backend_format
+    }
+
+    // TODO: wrap createCompressedBackendTexture (several variants)
+    //       introduced in m81
+
+    // TODO: wrap deleteBackendTexture(),
 
     pub fn precompile_shader(&mut self, key: &Data, data: &Data) -> bool {
         unsafe {

--- a/skia-safe/src/lib.rs
+++ b/skia-safe/src/lib.rs
@@ -8,7 +8,8 @@ mod interop;
 mod modules;
 mod pathops;
 mod prelude;
-mod private;
+// The module private may contain types that leak.
+pub mod private;
 pub mod svg;
 // TODO: We don't export utils/* into the crate's root yet. Should we?
 pub mod utils;

--- a/skia-safe/src/modules/paragraph/text_style.rs
+++ b/skia-safe/src/modules/paragraph/text_style.rs
@@ -66,7 +66,25 @@ fn placeholder_alignment_member_naming() {
     let _ = PlaceholderAlignment::AboveBaseline;
 }
 
-#[derive(Clone, PartialEq, Default, Debug)]
+pub type FontFeature = Handle<sb::skia_textlayout_FontFeature>;
+
+impl NativeDrop for sb::skia_textlayout_FontFeature {
+    fn drop(&mut self) {
+        panic!("internal error, a FontFeature value can't be dropped in Rust");
+    }
+}
+
+impl Handle<sb::skia_textlayout_FontFeature> {
+    pub fn name(&self) -> &str {
+        self.native().fName.as_str()
+    }
+
+    pub fn value(&self) -> i32 {
+        self.native().fValue
+    }
+}
+
+#[derive(Clone, Default, Debug)]
 pub struct PlaceholderStyle {
     pub width: scalar,
     pub height: scalar,
@@ -79,6 +97,12 @@ impl NativeTransmutable<sb::skia_textlayout_PlaceholderStyle> for PlaceholderSty
 #[test]
 fn placeholder_style_layout() {
     PlaceholderStyle::test_layout()
+}
+
+impl PartialEq for PlaceholderStyle {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { self.native().equals(other.native()) }
+    }
 }
 
 impl PlaceholderStyle {
@@ -136,6 +160,10 @@ impl Handle<sb::skia_textlayout_TextStyle> {
 
     pub fn equals(&self, other: &TextStyle) -> bool {
         *self == *other
+    }
+
+    pub fn equals_by_fonts(&self, that: &TextStyle) -> bool {
+        unsafe { self.native().equalsByFonts(that.native()) }
     }
 
     pub fn match_one_attribute(&self, style_type: StyleType, other: &TextStyle) -> bool {
@@ -215,6 +243,24 @@ impl Handle<sb::skia_textlayout_TextStyle> {
     pub fn reset_shadows(&mut self) -> &mut Self {
         unsafe { sb::C_TextStyle_resetShadows(self.native_mut()) }
         self
+    }
+
+    pub fn font_features(&self) -> &[FontFeature] {
+        unsafe {
+            let ff: &sb::FontFeatures = transmute_ref(&self.native().fFontFeatures);
+            let mut cnt = 0;
+            let ptr = FontFeature::from_native_ref(&*sb::C_FontFeatures_ptr_count(ff, &mut cnt));
+            slice::from_raw_parts(ptr, cnt)
+        }
+    }
+
+    pub fn add_font_feature(&mut self, font_feature: impl AsRef<str>, value: i32) {
+        let font_feature = interop::String::from_str(font_feature);
+        unsafe { sb::C_TextStyle_addFontFeature(self.native_mut(), font_feature.native(), value) }
+    }
+
+    pub fn reset_font_features(&mut self) {
+        unsafe { sb::C_TextStyle_resetFontFeatures(self.native_mut()) }
     }
 
     pub fn font_size(&self) -> scalar {

--- a/skia-safe/src/private.rs
+++ b/skia-safe/src/private.rs
@@ -1,1 +1,3 @@
+#[cfg(feature = "gpu")]
+pub mod gpu;
 pub(crate) mod safe32;

--- a/skia-safe/src/private/gpu.rs
+++ b/skia-safe/src/private/gpu.rs
@@ -1,0 +1,2 @@
+mod types_priv;
+pub use types_priv::*;

--- a/skia-safe/src/private/gpu/types_priv.rs
+++ b/skia-safe/src/private/gpu/types_priv.rs
@@ -1,0 +1,5 @@
+pub use skia_bindings::GrSLType as SLType;
+#[test]
+fn test_sl_type_naming() {
+    let _ = SLType::UByte4;
+}

--- a/skia-safe/src/utils/_3d.rs
+++ b/skia-safe/src/utils/_3d.rs
@@ -3,7 +3,7 @@
 //!       Should we place them into a module?
 use crate::prelude::*;
 use crate::{Matrix44, Point, Point3};
-use skia_bindings::{Sk3LookAt, Sk3MapPts, Sk3Perspective};
+use skia_bindings::{Sk3LookAt1, Sk3MapPts, Sk3Perspective1};
 
 pub fn look_at(
     eye: impl Into<Point3>,
@@ -12,7 +12,7 @@ pub fn look_at(
 ) -> Matrix44 {
     let mut m4 = Matrix44::default();
     unsafe {
-        Sk3LookAt(
+        Sk3LookAt1(
             m4.native_mut(),
             eye.into().native(),
             center.into().native(),
@@ -25,7 +25,7 @@ pub fn look_at(
 pub fn perspective(near: f32, far: f32, angle: f32) -> Matrix44 {
     let mut m4 = Matrix44::default();
     unsafe {
-        Sk3Perspective(m4.native_mut(), near, far, angle);
+        Sk3Perspective1(m4.native_mut(), near, far, angle);
     }
     m4
 }


### PR DESCRIPTION
This PR updates rust-skia to support Skia's `chrome/m81` branch.

- [x] Update `README.md` ([rendered](https://github.com/pragmatrix/rust-skia/blob/m81/README.md))  
  > Most important here is to change the Skia branch name and the current commit hash at the top of the `README.md` file.
- [x] Skia can be built ([release notes](https://github.com/google/skia/blob/chrome/m81/RELEASE_NOTES.txt)).
- [x] skia-bindings.
- [x] skia-safe: Update & add new wrappers by diffing include files.  
  > Add TODOs for everything that can not be updated right now, and attempt to stay compatible with previous versions of skia-safe without trying too hard before version 1.0. Use `deprecated` attributes if needed.
  - [x] `codec/`
  - [x] `core/`
  - [x] `docs/`
  - [x] `effects/`
  - [x] `gpu/`
    - [x] `gl/`
    - [x] `vk/`
  - [x] `modules/`
    - [x] `skparagraph/`
    - [x] `skshaper/`
  - [x] `pathops/`
  - [x] `svg/`
  - [x] `utils/`
- [x] Remove unused bindings from `skia-bindings/src/bindings.rs` (for example `SkM44`)
- [x] ~One week before Chrome 81 stable will be released? ([Schedule](https://www.chromestatus.com/features/schedule))
- [x] Any pending changes in the Skia `chrome/m81` branch that aren't synchronized yet?
- [x] Do the hashes in `skia-bindings/Cargo.toml` under `[package.metadata]` match the submodules `depot_tools` and `skia`?
- [x] Rebase on or merge with master.
- [x] Update versions of `skia-bindings/Cargo.toml` and `skia-safe/Cargo.toml` and also add the version to the new `deprecated` attributes.
