### PR TITLE
Fix skia-bindings crate build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,23 @@ all:
 	@echo "make publish: publish the rust-skia packages to crates.io"
 	@echo "make publish-only: do not verify or build packages, only publish the the packages"
 
+# test various configuration from inside crates.
+
+.PHONY: crate-tests
+crate-tests: crate-bindings-binaries crate-bindings-build
+
+.PHONY: crate-bindings-binaries
+crate-bindings-binaries: export FORCE_SKIA_BINARIES_DOWNLOAD=1
+crate-bindings-binaries:
+	cd skia-bindings && cargo publish -vv --dry-run --all-features 
+	cd skia-bindings && cargo publish -vv --dry-run 
+
+.PHONY: crate-bindings-build
+crate-bindings-build: export FORCE_SKIA_BUILD=1
+crate-bindings-build: 
+	cd skia-bindings && cargo publish -vv --dry-run --all-features 
+	cd skia-bindings && cargo publish -vv --dry-run 
+
 .PHONY: publish
 publish: package-bindings package-safe publish-bindings wait publish-safe
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -14,7 +14,18 @@ authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org
 edition = "2018"
 build = "build.rs"
 links = "skia"
-include = [ "Cargo.toml", "build.rs", "build_support.rs", "build_support/**/*.rs", "src/**/*.h", "src/**/*.cpp", "src/defaults.rs", "src/icu.rs", "src/lib.rs", "skparagraph.patch" ]
+include = [ 
+	"Cargo.toml", 
+	"build.rs", 
+	"build_support.rs", 
+	"build_support/**/*.rs", 
+	"src/**/*.h", 
+	"src/**/*.cpp", 
+	"src/defaults.rs", 
+	"src/icu.rs", 
+	"src/impls.rs",
+	"src/lib.rs", 
+	"skparagraph.patch" ]
 
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.


### PR DESCRIPTION
There was a small oversight that caused `src/impls.rs` to be left out from the crate. This PR fixes that.
