### PR TITLE
Improve error message when the download of an archive fails

### DIFF
--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -1148,7 +1148,7 @@ mod prerequisites {
             let archive_url = &format!("{}/{}", repo_url, short_hash);
             println!("DOWNLOADING: {}", archive_url);
             let archive = utils::download(archive_url)
-                .unwrap_or_else(|_| panic!("Failed to download {}", archive_url));
+                .unwrap_or_else(|err| panic!("Failed to download {} ({})", archive_url, err));
 
             // unpack
             {


### PR DESCRIPTION
A more precise error message would be nice if a download of an archive fails (related to #283).