### PR TITLE
Azure: use macOS 10.15 catalina image to test and for the prebuilt binaries.

### DIFF
--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -71,10 +71,8 @@ jobs:
   - ${{ if eq(parameters.platform, 'macOS') }}:
     # macOS
     - bash: |
-        sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
-        curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${TOOLCHAIN}
-        echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
-      displayName: Install SDK Headers & Rust
+        echo "##vso[task.setvariable variable=PATH;]/usr/local/opt/llvm/bin:$PATH"
+      displayName: Set path to clang / llvm-config
 
   - ${{ if eq(parameters.platform, 'Windows') }}:
     # Windows.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ stages:
       androidNDK: 'r20b'
       androidAPILevel: '26'
       androidBinExt: ''
-      image: 'macOS-10.14'
+      image: 'macOS-10.15'
       deployRelease: ${{ eq(variables['build.SourceBranchName'], 'release') }}
 
   - template: 'azure-pipelines-template.yml'


### PR DESCRIPTION
Seems that all macOS Azure images come with LLVM 9.0.1 preinstalled, which messes up our macOS builds on the CI.

With this PR, I'll try to update to the Catalina images and then fix the build errors if they reappear.

Ref: https://github.com/rust-skia/rust-skia/issues/228#issuecomment-568016250