### PR TITLE
Fix a build error on macOS if the feature textlayout is disabled.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m80 ([pending changes][skiapending], [our changes][skiaours]).
 
-[skiapending]: https://github.com/rust-skia/skia/compare/m80-0.26.5...chrome/m80
-[skiaours]: https://github.com/google/skia/compare/chrome/m80...rust-skia:m80-0.26.5
+[skiapending]: https://github.com/rust-skia/skia/compare/m80-0.26.6...chrome/m80
+[skiaours]: https://github.com/google/skia/compare/chrome/m80...rust-skia:m80-0.26.6
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m80 ([pending changes][skiapending], [our changes][skiaours]).
 
-[skiapending]: https://github.com/rust-skia/skia/compare/m80-0.26.6...chrome/m80
-[skiaours]: https://github.com/google/skia/compare/chrome/m80...rust-skia:m80-0.26.6
+[skiapending]: https://github.com/rust-skia/skia/compare/m80-0.26.7...chrome/m80
+[skiaours]: https://github.com/google/skia/compare/chrome/m80...rust-skia:m80-0.26.7
 
 ## Goals
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.26.6"
+version = "0.26.7"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"
@@ -29,7 +29,7 @@ include = [
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m80-0.26.6"
+skia = "m80-0.26.7"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.26.5"
+version = "0.26.6"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"
@@ -29,7 +29,7 @@ include = [
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m80-0.26.5"
+skia = "m80-0.26.6"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.26.6"
+version = "0.26.7"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -32,7 +32,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 
 [dependencies]
 bitflags = "1.0.4"
-skia-bindings = { version = "=0.26.6", path = "../skia-bindings" }
+skia-bindings = { version = "=0.26.7", path = "../skia-bindings" }
 lazy_static = "1.4"
 
 [dev-dependencies]

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.26.5"
+version = "0.26.6"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -32,7 +32,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 
 [dependencies]
 bitflags = "1.0.4"
-skia-bindings = { version = "=0.26.5", path = "../skia-bindings" }
+skia-bindings = { version = "=0.26.6", path = "../skia-bindings" }
 lazy_static = "1.4"
 
 [dev-dependencies]


### PR DESCRIPTION
Before #293, the patch file `skparagraph.patch` file was applied only if the feature `textlayout` was enabled, but with the recent custom fork of Skia, the patch is now in effect in every feature configuration and caused non-textlayout  builds to fail on macOS. 

This PR attempts to fix that by making the skparagraph module ~~a complete static library again~~ available only when `skia_use_icu` is set to true.

Manual test with and without `textlayout` on
- [x] Windows
- [x] macOS
- [x] Ubuntu 19

[rendered README.md](https://github.com/pragmatrix/rust-skia/blob/skparagraph-complete-static/README.md) [Skia changes](https://github.com/google/skia/compare/chrome/m80...rust-skia:m80-0.26.7)