### PR TITLE
Fix metal builds targeting iOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m80 ([pending changes][skiapending], [our changes][skiaours]).
 
-[skiapending]: https://github.com/rust-skia/skia/compare/m80-0.26.7...chrome/m80
-[skiaours]: https://github.com/google/skia/compare/chrome/m80...rust-skia:m80-0.26.7
+[skiapending]: https://github.com/rust-skia/skia/compare/m80-0.26.8...chrome/m80
+[skiaours]: https://github.com/google/skia/compare/chrome/m80...rust-skia:m80-0.26.8
 
 ## Goals
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.26.7"
+version = "0.26.8"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"
@@ -29,7 +29,7 @@ include = [
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m80-0.26.7"
+skia = "m80-0.26.8"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.26.7"
+version = "0.26.8"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -32,7 +32,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 
 [dependencies]
 bitflags = "1.0.4"
-skia-bindings = { version = "=0.26.7", path = "../skia-bindings" }
+skia-bindings = { version = "=0.26.8", path = "../skia-bindings" }
 lazy_static = "1.4"
 
 [dev-dependencies]


### PR DESCRIPTION
On builds that target iOS with metal enabled, skottie and its test application get automatically enabled for some reason. This PR disables both.

Skia changes:

https://github.com/rust-skia/skia/compare/b066e53c4cf965b3c12bec4cb3d25059f0654036...ca3a0c37f73bda669b886f0cad564f9f55e5616b


Closes #296 