### PR TITLE
Export unsafe wrapper traits

### DIFF
--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -26,7 +26,7 @@ metal = ["gpu", "skia-bindings/metal"]
 textlayout = ["skia-bindings/textlayout"]
 # implied only, do not use
 gpu = []
-# deprecated since 0.25.0, forwarded to skia-bindings with the intend to print some warnings while build.rs is running
+# deprecated since 0.25.0, forwarded to skia-bindings with the intent to show warnings while build.rs is running
 svg = ["skia-bindings/svg"]
 shaper = ["textlayout", "skia-bindings/shaper"]
 

--- a/skia-safe/src/lib.rs
+++ b/skia-safe/src/lib.rs
@@ -8,6 +8,7 @@ mod interop;
 mod modules;
 mod pathops;
 mod prelude;
+pub mod wrapper;
 // The module private may contain types that leak.
 pub mod private;
 pub mod svg;

--- a/skia-safe/src/prelude.rs
+++ b/skia-safe/src/prelude.rs
@@ -271,6 +271,13 @@ impl<N: NativeDrop> Handle<N> {
         mem::swap(&mut self.0, native);
         self
     }
+
+    /// Consumes the wrapper and returns the native type.
+    pub(crate) fn into_native(mut self) -> N {
+        let r = mem::replace(&mut self.0, unsafe { mem::zeroed() });
+        mem::forget(self);
+        r
+    }
 }
 
 pub(crate) trait ReplaceWith<Other> {
@@ -449,6 +456,12 @@ impl<N: NativeDrop> RefHandle<N> {
     /// to and will call its NativeDrop implementation if it goes out of scope.
     pub(crate) fn from_ptr(ptr: *mut N) -> Option<Self> {
         ptr.into_option().map(Self)
+    }
+
+    pub(crate) fn into_ptr(self) -> *mut N {
+        let p = self.0;
+        mem::forget(self);
+        p
     }
 }
 

--- a/skia-safe/src/prelude.rs
+++ b/skia-safe/src/prelude.rs
@@ -644,7 +644,7 @@ where
 
 /// Trait to use native types that as a rust type
 /// _inplace_ with the same size and field layout.
-pub(crate) trait NativeTransmutable<NT: Sized>: Sized {
+pub trait NativeTransmutable<NT: Sized>: Sized {
     /// Provides access to the native value through a
     /// transmuted reference to the Rust value.
     fn native(&self) -> &NT {

--- a/skia-safe/src/prelude.rs
+++ b/skia-safe/src/prelude.rs
@@ -191,10 +191,14 @@ where
     }
 }
 
-/// Trait that enables access to a native representation by reference.
-pub(crate) trait NativeAccess<N> {
+/// Trait that enables access to a native representation of a wrapper type.
+pub trait NativeAccess<N> {
+    /// Provides shared access to the native type of the wrapper.
     fn native(&self) -> &N;
+
+    /// Provides exclusive access to the native type of the wrapper.
     fn native_mut(&mut self) -> &mut N;
+
     // Returns a ptr to the native mutable value.
     unsafe fn native_mut_force(&self) -> *mut N {
         self.native() as *const N as *mut N
@@ -441,8 +445,8 @@ impl<N: NativeDrop> NativeAccess<N> for RefHandle<N> {
 impl<N: NativeDrop> RefHandle<N> {
     /// Creates a RefHandle from a native pointer.
     ///
-    /// From this time on the RefHandle ownes the object that the pointer points
-    /// to and will call it's NativeDrop implementation it it goes out of scope.
+    /// From this time on, the handle owns the object that the pointer points
+    /// to and will call its NativeDrop implementation if it goes out of scope.
     pub(crate) fn from_ptr(ptr: *mut N) -> Option<Self> {
         ptr.into_option().map(Self)
     }

--- a/skia-safe/src/wrapper.rs
+++ b/skia-safe/src/wrapper.rs
@@ -4,15 +4,16 @@
 ///! the `prelude` module.
 use crate::prelude::*;
 
-/// This trait supports the conversion of a wrapper type into it's native C/C++ and back.
+/// This trait supports the conversion of a wrapper into it's wrapped C/C++ pointer and back.
+///
+/// The wrapped value can be accessed through the functions `inner` and `inner_mut`.
 ///
 /// # Safety
 ///
-/// The native type `N` _should_ be treated as opaque, because its definition may change
-/// without adhering to semantic versioning and largely depends on what the tool bindgen
-/// is able to generate.
+/// The native value `N` _should_ be treated as opaque, because its definition may change
+/// without adhering to semantic versioning and depends on what the tool bindgen is able to generate.
 ///
-/// Converting from a Rust wrapper type to a native type loses the automatic ability to free associated memory.
+/// Converting from a Rust wrapper to the wrapped value loses the automatic ability to free associated resources.
 pub unsafe trait PointerWrapper<N>
 where
     Self: Sized,
@@ -28,17 +29,18 @@ where
     fn inner_mut(&mut self) -> &mut N;
 }
 
-/// A trait that supports the conversion from a native value into its Rust wrapper type and back.
+/// A trait that supports the conversion from a C/C++ value into its Rust wrapper and back.
 ///
-/// This is implemented for all wrapper types that manage memory in Rust without an pointer indirection.
+/// The wrapped value can be accessed through the functions `inner` and `inner_mut`.
+///
+/// This trait is implemented for all wrapper types that manage C++/C values in Rust without an pointer indirection.
 ///
 /// # Safety
 ///
 /// The native type `N` _should_ be treated as opaque, because its definition may change
-/// without adhering to semantic versioning and largely depends on what the tool bindgen
-/// is able to generate.
+/// without adhering to semantic versioning and depends on what the tool bindgen is able to generate.
 ///
-/// Converting from a Rust wrapper type to a native type may lose the automatic ability to free associated memory.
+/// Converting from a Rust wrapper to a wrapped value may lose the automatic ability to free associated memory.
 pub unsafe trait ValueWrapper<N> {
     fn wrap(native: N) -> Self;
     fn unwrap(self) -> N;
@@ -46,6 +48,37 @@ pub unsafe trait ValueWrapper<N> {
     fn inner_mut(&mut self) -> &mut N;
 }
 
+/// A trait that supports the conversion from a C/C++ value into its Rust wrapper and back.
+///
+/// The wrapped value can be accessed through the functions `inner` and `inner_mut`.
+///
+/// This trait is implemented for for all types that implement `NativeTransmutable<N>`.
+///
+/// # Safety
+///
+/// The native type `N` _should_ be treated as opaque, because its definition may change
+/// without adhering to semantic versioning and depends on what the tool bindgen is able to generate.
+///
+/// Converting from a Rust wrapper to a wrapped value may lose the automatic ability to free associated memory.
+pub unsafe trait NativeTransmutableWrapper<N> {
+    fn wrap(native: N) -> Self;
+    fn unwrap(self) -> N;
+    fn inner(&self) -> &N;
+    fn inner_mut(&mut self) -> &mut N;
+}
+
+/// A trait that supports the conversion from a C/C++ reference into its Rust wrapper and back.
+///
+/// The wrapped value can be accessed through the functions `inner` and `inner_mut`.
+///
+/// This trait is implemented for all wrapper types that wrap C/C++ references.
+///
+/// # Safety
+///
+/// The native type `N` _should_ be treated as opaque, because its definition may change
+/// without adhering to semantic versioning and depends on what the tool bindgen is able to generate.
+///
+/// Converting from a Rust wrapper to a wrapped value may lose the automatic ability to free associated memory.
 pub unsafe trait RefWrapper<N> {
     fn wrap_ref(native: &N) -> &Self;
     fn wrap_mut(native: &mut N) -> &mut Self;

--- a/skia-safe/src/wrapper.rs
+++ b/skia-safe/src/wrapper.rs
@@ -1,4 +1,4 @@
-///! FFI Interopability for skia-safe's wrapper types.
+///! FFI interopability for skia-safe's wrapper types.
 ///!
 ///! This module is only meant to be used by external code. Internal code should continue to use the traits in
 ///! the `prelude` module.
@@ -22,6 +22,10 @@ where
     fn wrap(ptr: *mut N) -> Option<Self>;
     /// Unwraps the wrapper type into the native pointer.
     fn unwrap(self) -> *mut N;
+    /// Access the wrapped pointer.
+    fn inner(&self) -> &N;
+    /// Access the wrapped pointer.
+    fn inner_mut(&mut self) -> &mut N;
 }
 
 /// A trait that supports the conversion from a native value into its Rust wrapper type and back.
@@ -38,11 +42,15 @@ where
 pub unsafe trait ValueWrapper<N> {
     fn wrap(native: N) -> Self;
     fn unwrap(self) -> N;
+    fn inner(&self) -> &N;
+    fn inner_mut(&mut self) -> &mut N;
 }
 
 pub unsafe trait RefWrapper<N> {
     fn wrap_ref(native: &N) -> &Self;
     fn wrap_mut(native: &mut N) -> &mut Self;
+    fn inner(&self) -> &N;
+    fn inner_mut(&mut self) -> &mut N;
 }
 
 //
@@ -63,7 +71,16 @@ where
     fn unwrap(self) -> N {
         self.into_native()
     }
+
+    fn inner(&self) -> &N {
+        self.native()
+    }
+
+    fn inner_mut(&mut self) -> &mut N {
+        self.native_mut()
+    }
 }
+
 unsafe impl<N> RefWrapper<N> for Handle<N>
 where
     N: NativeDrop,
@@ -74,6 +91,14 @@ where
 
     fn wrap_mut(native: &mut N) -> &mut Self {
         Self::from_native_ref_mut(native)
+    }
+
+    fn inner(&self) -> &N {
+        self.native()
+    }
+
+    fn inner_mut(&mut self) -> &mut N {
+        self.native_mut()
     }
 }
 
@@ -92,6 +117,14 @@ where
     fn unwrap(self) -> *mut N {
         self.into_ptr()
     }
+
+    fn inner(&self) -> &N {
+        self.native()
+    }
+
+    fn inner_mut(&mut self) -> &mut N {
+        self.native_mut()
+    }
 }
 
 //
@@ -108,5 +141,13 @@ where
 
     fn unwrap(self) -> *mut N {
         self.into_ptr()
+    }
+
+    fn inner(&self) -> &N {
+        self.native()
+    }
+
+    fn inner_mut(&mut self) -> &mut N {
+        self.native_mut()
     }
 }

--- a/skia-safe/src/wrapper.rs
+++ b/skia-safe/src/wrapper.rs
@@ -184,3 +184,30 @@ where
         self.native_mut()
     }
 }
+
+//
+// NativeTransmutable<N>
+//
+
+unsafe impl<N, T> NativeTransmutableWrapper<N> for T
+where
+    N: Sized,
+    T: Sized,
+    T: NativeTransmutable<N>,
+{
+    fn wrap(native: N) -> Self {
+        Self::from_native(native)
+    }
+
+    fn unwrap(self) -> N {
+        Self::into_native(self)
+    }
+
+    fn inner(&self) -> &N {
+        self.native()
+    }
+
+    fn inner_mut(&mut self) -> &mut N {
+        self.native_mut()
+    }
+}

--- a/skia-safe/src/wrapper.rs
+++ b/skia-safe/src/wrapper.rs
@@ -2,6 +2,7 @@
 ///!
 ///! This module is only meant to be used by external code. Internal code should continue to use the traits in
 ///! the `prelude` module.
+use crate::prelude::*;
 
 /// This trait supports the conversion of a wrapper type into it's native C/C++ and back.
 ///

--- a/skia-safe/src/wrapper.rs
+++ b/skia-safe/src/wrapper.rs
@@ -1,0 +1,111 @@
+///! FFI Interopability for skia-safe's wrapper types.
+///!
+///! This module is only meant to be used by external code. Internal code should continue to use the traits in
+///! the `prelude` module.
+
+/// This trait supports the conversion of a wrapper type into it's native C/C++ and back.
+///
+/// # Safety
+///
+/// The native type `N` _should_ be treated as opaque, because its definition may change
+/// without adhering to semantic versioning and largely depends on what the tool bindgen
+/// is able to generate.
+///
+/// Converting from a Rust wrapper type to a native type loses the automatic ability to free associated memory.
+pub unsafe trait PointerWrapper<N>
+where
+    Self: Sized,
+{
+    /// Wraps a native pointer into a wrapper type.
+    /// Returns `None` if the pointer is `null`.
+    fn wrap(ptr: *mut N) -> Option<Self>;
+    /// Unwraps the wrapper type into the native pointer.
+    fn unwrap(self) -> *mut N;
+}
+
+/// A trait that supports the conversion from a native value into its Rust wrapper type and back.
+///
+/// This is implemented for all wrapper types that manage memory in Rust without an pointer indirection.
+///
+/// # Safety
+///
+/// The native type `N` _should_ be treated as opaque, because its definition may change
+/// without adhering to semantic versioning and largely depends on what the tool bindgen
+/// is able to generate.
+///
+/// Converting from a Rust wrapper type to a native type may lose the automatic ability to free associated memory.
+pub unsafe trait ValueWrapper<N> {
+    fn wrap(native: N) -> Self;
+    fn unwrap(self) -> N;
+}
+
+pub unsafe trait RefWrapper<N> {
+    fn wrap_ref(native: &N) -> &Self;
+    fn wrap_mut(native: &mut N) -> &mut Self;
+}
+
+//
+// Handle<N>
+//
+
+unsafe impl<N> ValueWrapper<N> for Handle<N>
+where
+    N: NativeDrop,
+{
+    fn wrap(native: N) -> Self
+    where
+        N: NativeDrop,
+    {
+        Self::from_native(native)
+    }
+
+    fn unwrap(self) -> N {
+        self.into_native()
+    }
+}
+unsafe impl<N> RefWrapper<N> for Handle<N>
+where
+    N: NativeDrop,
+{
+    fn wrap_ref(native: &N) -> &Self {
+        Self::from_native_ref(native)
+    }
+
+    fn wrap_mut(native: &mut N) -> &mut Self {
+        Self::from_native_ref_mut(native)
+    }
+}
+
+//
+// RefHandle<N>
+//
+
+unsafe impl<N> PointerWrapper<N> for RefHandle<N>
+where
+    N: NativeDrop,
+{
+    fn wrap(ptr: *mut N) -> Option<Self> {
+        Self::from_ptr(ptr)
+    }
+
+    fn unwrap(self) -> *mut N {
+        self.into_ptr()
+    }
+}
+
+//
+// RCHandle<N>
+//
+
+unsafe impl<N> PointerWrapper<N> for RCHandle<N>
+where
+    N: NativeRefCounted,
+{
+    fn wrap(ptr: *mut N) -> Option<Self> {
+        Self::from_ptr(ptr)
+    }
+
+    fn unwrap(self) -> *mut N {
+        self.into_ptr()
+    }
+}


### PR DESCRIPTION
This PR adds some public wrapper traits to convert from C/C++ values to Rust values and back and also supports access to the wrapped values.

I've decided to implement a separate set of traits for the following reasons:
- There are a lot more functions in the prelude that needed to create wrapping code compared to just code that wraps, unwraps, and supports access to C/C++ values, and so the prelude may evolve faster than the exported wrapper traits.
- There are no safety guarantees when it comes to wrappers, so all the exported traits are unsafe.
- The exported traits should be documented in more detail and separately.
- The exported traits function names should be more Rust idiomatic.

Closes #310 