### PR TITLE
Added support to build Android armv7-linux-androideabi target

### DIFF
--- a/skia-bindings/build_support/clang.rs
+++ b/skia-bindings/build_support/clang.rs
@@ -1,6 +1,7 @@
 /// Convert a Rust target architecture identifier to a clang target architecture identifier.
 pub fn target_arch(arch: &str) -> &str {
     match arch {
+        "armv7" => "arm",
         "aarch64" => "arm64",
         "i686" => "x86",
         arch => arch,

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -233,7 +233,7 @@ impl FinalBuildConfiguration {
                         );
                     }
                 }
-                (arch, "linux", "android", _) => {
+                (arch, "linux", "android", _) | (arch, "linux", "androideabi", _) => {
                     args.push(("ndk", quote(&android::ndk())));
                     // TODO: make API-level configurable?
                     args.push(("ndk_api", android::API_LEVEL.into()));
@@ -390,7 +390,7 @@ impl BinariesConfiguration {
                     link_libraries.push("opengl32");
                 }
             }
-            (_, "linux", "android", _) => {
+            (_, "linux", "android", _) | (_, "linux", "androideabi", _) => {
                 link_libraries.extend(android::link_libraries(features));
             }
             (_, "apple", "ios", _) => {
@@ -639,7 +639,7 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
                 cargo::warning("failed to get macosx SDK path")
             }
         }
-        (arch, "linux", "android", _) => {
+        (arch, "linux", "android", _) | (arch, "linux", "androideabi", _) => {
             let target = &target.to_string();
             cc_build.target(target);
             for arg in android::additional_clang_args(target, arch) {


### PR DESCRIPTION
Adding support for building armv7-a (arm) targets of Android.

Tested it using NDK and CC predefines:

```
export CC_armv7_linux_androideabi=armv7a-linux-androideabi21-clang
export CXX_armv7_linux_androideabi=armv7a-linux-androideabi21-clang++
export CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=armv7a-linux-androideabi21-clang
```