### PR TITLE
Remove directories in the skia repository that are not needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m81 ([pending changes][skiapending], [our changes][skiaours]).
 
-[skiapending]: https://github.com/rust-skia/skia/compare/m81-0.27.0...google:chrome/m81
-[skiaours]: https://github.com/google/skia/compare/chrome/m81...rust-skia:m81-0.27.0
+[skiapending]: https://github.com/rust-skia/skia/compare/m81-0.27.3...google:chrome/m81
+[skiaours]: https://github.com/google/skia/compare/chrome/m81...rust-skia:m81-0.27.3
 
 ## Goals
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.27.2"
+version = "0.27.3"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"
@@ -29,7 +29,7 @@ include = [
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m81-0.27.0"
+skia = "m81-0.27.3"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.27.2"
+version = "0.27.3"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -32,7 +32,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 
 [dependencies]
 bitflags = "1.0.4"
-skia-bindings = { version = "=0.27.2", path = "../skia-bindings" }
+skia-bindings = { version = "=0.27.3", path = "../skia-bindings" }
 lazy_static = "1.4"
 
 [dev-dependencies]


### PR DESCRIPTION
Since version 0.26, rust-skia maintains it's own fork of skia that adds a handful of commits on top of it. 

This PR adds one more commit that removes all directories that are not needed for a build. For full builds, this should make the checkout (repo) or download (crate) process faster and should prevent errors like [this one](https://github.com/Kethku/neovide/issues/264).