### PR TITLE
Chrome Milestone 84

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m84 ([pending changes][skiapending], [our changes][skiaours]).
 
-[skiapending]: https://github.com/rust-skia/skia/compare/m84-0.30.0...google:chrome/m84
-[skiaours]: https://github.com/google/skia/compare/chrome/m84...rust-skia:m84-0.30.0
+[skiapending]: https://github.com/rust-skia/skia/compare/m84-0.30.1...google:chrome/m84
+[skiaours]: https://github.com/google/skia/compare/chrome/m84...rust-skia:m84-0.30.1
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![Build Status](https://dev.azure.com/pragmatrix-github/rust-skia/_apis/build/status/rust-skia.rust-skia?branchName=master)](https://dev.azure.com/pragmatrix-github/rust-skia/_build/latest?definitionId=2&branchName=master)
 
-Skia Submodule Status: chrome/m83 ([pending changes][skiapending], [our changes][skiaours]).
+Skia Submodule Status: chrome/m84 ([pending changes][skiapending], [our changes][skiaours]).
 
 [skiapending]: https://github.com/rust-skia/skia/compare/m84-0.30.0...google:chrome/m84
 [skiaours]: https://github.com/google/skia/compare/chrome/m84...rust-skia:m84-0.30.0

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m83 ([pending changes][skiapending], [our changes][skiaours]).
 
-[skiapending]: https://github.com/rust-skia/skia/compare/m83-0.29.3...google:chrome/m83
-[skiaours]: https://github.com/google/skia/compare/chrome/m83...rust-skia:m83-0.29.3
+[skiapending]: https://github.com/rust-skia/skia/compare/m84-0.30.0...google:chrome/m84
+[skiaours]: https://github.com/google/skia/compare/chrome/m84...rust-skia:m84-0.30.0
 
 ## Goals
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.29.3"
+version = "0.30.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"
@@ -29,7 +29,7 @@ include = [
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m83-0.29.3"
+skia = "m84-0.30.0"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -29,7 +29,7 @@ include = [
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m84-0.30.0"
+skia = "m84-0.30.1"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -995,6 +995,10 @@ const ENUM_TABLE: &[EnumEntry] = &[
     ("VkSamplerYcbcrModelConversion", rewrite::vk),
     ("VkSamplerYcbcrRange", rewrite::vk),
     ("VkStructureType", rewrite::vk),
+    //
+    // m84 SkPath::Verb
+    //
+    ("Verb", rewrite::k_xxx_name),
 ];
 
 pub(crate) mod rewrite {

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -978,6 +978,7 @@ const ENUM_TABLE: &[EnumEntry] = &[
     ("TextAlign", rewrite::k_xxx),
     ("TextDirection", rewrite::k_xxx_uppercase),
     ("TextBaseline", rewrite::k_xxx),
+    ("TextHeightBehavior", rewrite::k_xxx),
     //
     // TextStyle.h
     //

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -982,6 +982,7 @@ const ENUM_TABLE: &[EnumEntry] = &[
     // TextStyle.h
     //
     ("TextDecorationStyle", rewrite::k_xxx),
+    ("TextDecorationMode", rewrite::k_xxx),
     ("StyleType", rewrite::k_xxx),
     ("PlaceholderAlignment", rewrite::k_xxx),
     //

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -996,10 +996,10 @@ const ENUM_TABLE: &[EnumEntry] = &[
     ("VkSamplerYcbcrModelConversion", rewrite::vk),
     ("VkSamplerYcbcrRange", rewrite::vk),
     ("VkStructureType", rewrite::vk),
-    //
-    // m84 SkPath::Verb
-    //
+    // m84: SkPath::Verb
     ("Verb", rewrite::k_xxx_name),
+    // m84: SkVertices::Attribute::Usage
+    ("Usage", rewrite::k_xxx),
 ];
 
 pub(crate) mod rewrite {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -463,10 +463,6 @@ extern "C" void C_SkPath_RawIter_destruct(SkPath::RawIter* self) {
     self->~RawIter();
 }
 
-extern "C" SkPath::Verb C_SkPath_RawIter_next(SkPath::RawIter* self, SkPoint pts[4]) {
-    return self->next(pts);
-}
-
 extern "C" SkPath::Verb C_SkPath_RawIter_peek(const SkPath::RawIter* self) {
     return self->peek();
 }

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -12,6 +12,7 @@
 #include "include/core/SkColor.h"
 #include "include/core/SkColorFilter.h"
 #include "include/core/SkContourMeasure.h"
+#include "include/core/SkCoverageMode.h"
 #include "include/core/SkCubicMap.h"
 #include "include/core/SkDataTable.h"
 #include "include/core/SkDeferredDisplayListRecorder.h"
@@ -153,7 +154,7 @@ extern "C" void C_SkEncodedOriginToMatrix(SkEncodedOrigin origin, int w, int h, 
 // core/
 //
 
-extern "C" void C_Core_Types(SkCubicMap *, SkGraphics *) {};
+extern "C" void C_Core_Types(SkCubicMap *, SkGraphics *, SkCoverageMode *) {};
 
 //
 // core/SkSurface.h

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -2452,12 +2452,12 @@ SkImageFilter *C_SkImageFilters_Xfermode(SkBlendMode blendMode, SkImageFilter *b
     return SkImageFilters::Xfermode(blendMode, sp(background), sp(foreground), cropRect).release();
 }
 
-SkImageFilter *C_SkImageFilters_Dilate(int radiusX, int radiusY, SkImageFilter *input,
+SkImageFilter *C_SkImageFilters_Dilate(SkScalar radiusX, SkScalar radiusY, SkImageFilter *input,
                                        const SkIRect *cropRect) {
     return SkImageFilters::Dilate(radiusX, radiusY, sp(input), cropRect).release();
 }
 
-SkImageFilter *C_SkImageFilters_Erode(int radiusX, int radiusY, SkImageFilter *input,
+SkImageFilter *C_SkImageFilters_Erode(SkScalar radiusX, SkScalar radiusY, SkImageFilter *input,
                                       const SkIRect *cropRect) {
     return SkImageFilters::Erode(radiusX, radiusY, sp(input), cropRect).release();
 }

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1674,14 +1674,6 @@ extern "C" SkMaskFilter* C_SkMaskFilter_MakeBlur(SkBlurStyle style, SkScalar sig
     return SkMaskFilter::MakeBlur(style, sigma, respectCTM).release();
 }
 
-extern "C" SkMaskFilter* C_SkMaskFilter_Compose(SkMaskFilter* outer, SkMaskFilter* inner) {
-    return SkMaskFilter::MakeCompose(sp(outer), sp(inner)).release();
-}
-
-extern "C" SkMaskFilter* C_SkMaskFilter_Combine(SkMaskFilter* filterA, SkMaskFilter* filterB, SkCoverageMode coverageMode) {
-    return SkMaskFilter::MakeCombine(sp(filterA), sp(filterB), coverageMode).release();
-}
-
 extern "C" SkMaskFilter* C_SkMaskFilter_Deserialize(const void* data, size_t length) {
     return SkMaskFilter::Deserialize(data, length).release();
 }
@@ -2278,10 +2270,6 @@ uint32_t C_SkRuntimeEffect_hash(const SkRuntimeEffect *self) {
     return self->hash();
 }
 
-size_t C_SkRuntimeEffect_uniformSize(const SkRuntimeEffect *self) {
-    return self->uniformSize();
-}
-
 const SkRuntimeEffect::Variable* C_SkRuntimeEffect_inputs(const SkRuntimeEffect* self, size_t* count) {
     auto inputs = self->inputs();
     *count = inputs.count();
@@ -2298,12 +2286,6 @@ const SkRuntimeEffect::Varying* C_SkRuntimeEffect_varyings(const SkRuntimeEffect
     auto varyings = self->varyings();
     *count = varyings.count();
     return &*varyings.begin();
-}
-
-SkSL::ByteCode* C_SkRuntimeEffect_toByteCode(SkRuntimeEffect* self, const void* inputs, SkString* error) {
-    auto r = self->toByteCode(inputs);
-    *error = std::get<1>(r);
-    return std::get<0>(r).release();
 }
 
 }

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -108,6 +108,7 @@
 #include "include/pathops/SkPathOps.h"
 // utils/
 #include "include/utils/SkCamera.h"
+#include "include/utils/SkCustomTypeface.h"
 #include "include/utils/SkInterpolator.h"
 #include "include/utils/SkNullCanvas.h"
 #include "include/utils/SkParsePath.h"
@@ -2554,7 +2555,12 @@ extern "C" void C_SkOpBuilder_destruct(SkOpBuilder* self) {
 // utils
 //
 
-extern "C" void C_Utils_Types(SkShadowFlags *, SkShadowUtils *, SkTextUtils *, SkParsePath *) {}
+extern "C" void C_Utils_Types(
+        SkShadowFlags *,
+        SkShadowUtils *,
+        SkTextUtils *,
+        SkParsePath *,
+        SkCustomTypefaceBuilder *) {}
 
 extern "C" Sk3DView* C_Sk3DView_new() {
     return new Sk3DView();
@@ -2564,6 +2570,33 @@ extern "C" void C_Sk3DView_delete(Sk3DView* self) {
     delete self;
 }
 
+extern "C" void C_SkCustomTypefaceBuilder_destruct(SkCustomTypefaceBuilder *self) {
+    self->~SkCustomTypefaceBuilder();
+}
+
+extern "C" SkTypeface *C_SkCustomTypefaceBuilder_detach(SkCustomTypefaceBuilder *self) {
+    return self->detach().release();
+}
+
+/* Th following wrappers may be needed as soon the Skia implementation finds its way into an official release (m84).
+extern "C" void
+C_SkCustomTypefaceBuilder_setGlyph1(SkCustomTypefaceBuilder *self, SkGlyphID glyph, float advance, const SkPath *path,
+                                    const SkPaint *paint) {
+    self->setGlyph(glyph, advance, *path, *paint);
+}
+
+extern "C" void
+C_SkCustomTypefaceBuilder_setGlyph2(SkCustomTypefaceBuilder *self, SkGlyphID glyph, float advance, SkImage *image,
+                                    float scale) {
+    self->setGlyph(glyph, advance, sp(image), scale);
+}
+
+extern "C" void
+C_SkCustomTypefaceBuilder_setGlyph3(SkCustomTypefaceBuilder *self, SkGlyphID glyph, float advance, SkPicture *picture) {
+    self->setGlyph(glyph, advance, sp(picture));
+}
+*/
+ 
 extern "C" void C_SkInterpolator_destruct(SkInterpolator* self) {
     self->~SkInterpolator();
 }

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -154,7 +154,7 @@ extern "C" void C_SkEncodedOriginToMatrix(SkEncodedOrigin origin, int w, int h, 
 // core/
 //
 
-extern "C" void C_Core_Types(SkCubicMap *, SkGraphics *, SkCoverageMode *) {};
+extern "C" void C_Core_Types(SkCubicMap *, SkGraphics *, SkCoverageMode *, SkColorChannelFlag *) {};
 
 //
 // core/SkSurface.h

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -2255,6 +2255,12 @@ SkShader *C_SkRuntimeEffect_makeShader(SkRuntimeEffect *self, SkData *inputs, Sk
     return self->makeShader(sp(inputs), childrenSPs, childCount, localMatrix, isOpaque).release();
 }
 
+SkColorFilter *
+C_SkRuntimeEffect_makeColorFilter2(SkRuntimeEffect *self, SkData *inputs, SkColorFilter **children, size_t childCount) {
+    auto childrenSPs = reinterpret_cast<sk_sp<SkColorFilter> *>(children);
+    return self->makeColorFilter(sp(inputs), childrenSPs, childCount).release();
+}
+
 SkColorFilter* C_SkRuntimeEffect_makeColorFilter(SkRuntimeEffect* self, SkData* inputs) {
     return self->makeColorFilter(sp(inputs)).release();
 }

--- a/skia-bindings/src/defaults.rs
+++ b/skia-bindings/src/defaults.rs
@@ -108,6 +108,12 @@ pub mod textlayout {
         }
     }
 
+    impl Default for crate::skia_textlayout_TextDecorationMode {
+        fn default() -> Self {
+            Self::Gaps
+        }
+    }
+
     impl Default for crate::skia_textlayout_StyleType {
         fn default() -> Self {
             Self::AllAttributes

--- a/skia-bindings/src/gpu.cpp
+++ b/skia-bindings/src/gpu.cpp
@@ -187,8 +187,8 @@ extern "C" bool C_GrContext_abandoned(GrContext* self) {
     return self->abandoned();
 }
 
-extern "C" void C_GrContext_flush(GrContext* self) {
-    self->flush();
+extern "C" void C_GrContext_flushAndSubmit(GrContext* self) {
+    self->flushAndSubmit();
 }
 
 extern "C" size_t C_GrContext_ComputeImageSize(SkImage* image, GrMipMapped mm, bool useNextPow2) {

--- a/skia-bindings/src/impls.rs
+++ b/skia-bindings/src/impls.rs
@@ -43,7 +43,6 @@ impl SkPathVerb {
             SkPathVerb::Conic => 4,
             SkPathVerb::Cubic => 4,
             SkPathVerb::Close => 0,
-            SkPathVerb::Done => 0,
         }
     }
 }

--- a/skia-bindings/src/impls.rs
+++ b/skia-bindings/src/impls.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     SkAlphaType, SkBlendMode, SkBlendModeCoeff, SkImage_CompressionType,
-    SkImage_kCompressionTypeCount, SkPathFillType, SkPathVerb,
+    SkImage_kCompressionTypeCount, SkPathFillType, SkPathVerb, SkPath_Verb,
 };
 use std::ffi::CStr;
 
@@ -31,18 +31,46 @@ impl SkBlendMode {
     }
 }
 
+//
+// m84 introduced two different variants of the Path verb types.
+// One with Done and one without.
+//
+
 impl SkPathVerb {
+    /// The maximum number of points an iterator will return for the verb.
+    pub const MAX_POINTS: usize = SkPath_Verb::MAX_POINTS;
+    /// The number of points an iterator will return for the verb.
+    pub fn points(self) -> usize {
+        SkPath_Verb::from(self).points()
+    }
+}
+
+impl SkPath_Verb {
     /// The maximum number of points an iterator will return for the verb.
     pub const MAX_POINTS: usize = 4;
     /// The number of points an iterator will return for the verb.
     pub fn points(self) -> usize {
         match self {
-            SkPathVerb::Move => 1,
-            SkPathVerb::Line => 2,
-            SkPathVerb::Quad => 3,
-            SkPathVerb::Conic => 4,
-            SkPathVerb::Cubic => 4,
-            SkPathVerb::Close => 0,
+            SkPath_Verb::Move => 1,
+            SkPath_Verb::Line => 2,
+            SkPath_Verb::Quad => 3,
+            SkPath_Verb::Conic => 3,
+            SkPath_Verb::Cubic => 4,
+            SkPath_Verb::Close => 0,
+            SkPath_Verb::Done => 0,
+        }
+    }
+}
+
+impl From<SkPathVerb> for SkPath_Verb {
+    fn from(v: SkPathVerb) -> Self {
+        match v {
+            SkPathVerb::Move => SkPath_Verb::Move,
+            SkPathVerb::Line => SkPath_Verb::Line,
+            SkPathVerb::Quad => SkPath_Verb::Quad,
+            SkPathVerb::Conic => SkPath_Verb::Conic,
+            SkPathVerb::Cubic => SkPath_Verb::Cubic,
+            SkPathVerb::Close => SkPath_Verb::Close,
         }
     }
 }

--- a/skia-bindings/src/paragraph.cpp
+++ b/skia-bindings/src/paragraph.cpp
@@ -13,6 +13,9 @@
 #include "modules/skparagraph/include/TextStyle.h"
 #include "modules/skparagraph/include/TypefaceFontProvider.h"
 
+// m84: needs definition of SkFontData
+#include "src/core/SkFontDescriptor.h"
+
 using namespace skia::textlayout;
 
 //

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.29.3"
+version = "0.30.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -32,7 +32,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 
 [dependencies]
 bitflags = "1.0.4"
-skia-bindings = { version = "=0.29.3", path = "../skia-bindings" }
+skia-bindings = { version = "=0.30.0", path = "../skia-bindings" }
 lazy_static = "1.4"
 
 [dev-dependencies]

--- a/skia-safe/src/core.rs
+++ b/skia-safe/src/core.rs
@@ -120,6 +120,7 @@ pub mod matrix;
 pub use matrix::Matrix;
 
 pub mod matrix44;
+#[allow(deprecated)]
 pub use matrix44::{Matrix44, Vector4};
 
 mod milestone;

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -483,7 +483,7 @@ impl Canvas {
     }
 
     pub fn concat_44(&mut self, m: &M44) -> &mut Self {
-        unsafe { self.native_mut().concat44(m.native()) }
+        unsafe { self.native_mut().concat1(m.native()) }
         self
     }
 

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -9,9 +9,8 @@ use crate::{
 use crate::{u8cpu, Drawable, Pixmap};
 use skia_bindings as sb;
 use skia_bindings::{
-    SkAutoCanvasRestore, SkCanvas, SkCanvas_SaveLayerFlagsSet_kF16ColorType,
-    SkCanvas_SaveLayerFlagsSet_kInitWithPrevious_SaveLayerFlag, SkCanvas_SaveLayerRec, SkImage,
-    SkImageFilter, SkMatrix, SkPaint, SkRect,
+    SkAutoCanvasRestore, SkCanvas, SkCanvas_SaveLayerRec, SkImage, SkImageFilter, SkMatrix,
+    SkPaint, SkRect,
 };
 use std::convert::TryInto;
 use std::ffi::CString;
@@ -23,8 +22,9 @@ pub use lattice::Lattice;
 
 bitflags! {
     pub struct SaveLayerFlags: u32 {
-        const INIT_WITH_PREVIOUS = SkCanvas_SaveLayerFlagsSet_kInitWithPrevious_SaveLayerFlag as _;
-        const F16_COLOR_TYPE = SkCanvas_SaveLayerFlagsSet_kF16ColorType as _;
+        const PRESERVE_LCD_TEXT = sb::SkCanvas_SaveLayerFlagsSet_kPreserveLCDText_SaveLayerFlag as _;
+        const INIT_WITH_PREVIOUS = sb::SkCanvas_SaveLayerFlagsSet_kInitWithPrevious_SaveLayerFlag as _;
+        const F16_COLOR_TYPE = sb::SkCanvas_SaveLayerFlagsSet_kF16ColorType as _;
     }
 }
 
@@ -1005,16 +1005,16 @@ impl Canvas {
         unsafe { sb::C_SkCanvas_isClipEmpty(self.native()) }
     }
 
+    pub fn local_to_device(&self) -> M44 {
+        M44::from_native(unsafe { self.native().getLocalToDevice() })
+    }
+
     pub fn total_matrix(&self) -> Matrix {
         let mut matrix = Matrix::default();
         // TODO: why is Matrix not safe to return from getTotalMatrix()
         // testcase `test_total_matrix` below crashes with an access violation.
         unsafe { sb::C_SkCanvas_getTotalMatrix(self.native(), matrix.native_mut()) };
         matrix
-    }
-
-    pub fn local_to_device(&self) -> M44 {
-        M44::from_native(unsafe { self.native().getLocalToDevice() })
     }
 
     //

--- a/skia-safe/src/core/color.rs
+++ b/skia-safe/src/core/color.rs
@@ -201,8 +201,21 @@ fn color_channel_naming() {
     let _ = ColorChannel::R;
 }
 
-// decided not to directly support SkRGBA4f for now because of the
-// lack of const generics.
+bitflags! {
+    pub struct ColorChannelFlag: u32 {
+        const RED = sb::SkColorChannelFlag::kRed_SkColorChannelFlag as _;
+        const GREEN = sb::SkColorChannelFlag::kGreen_SkColorChannelFlag as _;
+        const BLUE = sb::SkColorChannelFlag::kBlue_SkColorChannelFlag as _;
+        const ALPHA = sb::SkColorChannelFlag::kAlpha_SkColorChannelFlag as _;
+        const GRAY = sb::SkColorChannelFlag::kGray_SkColorChannelFlag as _;
+        const RG = Self::RED.bits | Self::GREEN.bits;
+        const RGB = Self::RG.bits | Self::BLUE.bits;
+        const RGBA = Self::RGB.bits | Self::ALPHA.bits;
+    }
+}
+
+// TODO: SkRGBA4f
+
 #[derive(Clone, PartialEq, Debug)]
 #[repr(C)]
 pub struct Color4f {

--- a/skia-safe/src/core/m44.rs
+++ b/skia-safe/src/core/m44.rs
@@ -505,20 +505,20 @@ impl M44 {
         unsafe { self.native().getRowMajor(v.as_mut_ptr()) }
     }
 
-    #[deprecated(since = "0.0.0", note = "use M44::col_major() instead")]
+    #[deprecated(since = "0.30.0", note = "use M44::col_major() instead")]
     pub fn set_col_major(&mut self, v: &[scalar; Self::COMPONENTS]) -> &mut Self {
         *self = Self::col_major(v);
         self
     }
 
-    #[deprecated(since = "0.0.0", note = "use M44::row_major() instead")]
+    #[deprecated(since = "0.30.0", note = "use M44::row_major() instead")]
     pub fn set_row_major(&mut self, v: &[scalar; Self::COMPONENTS]) -> &mut Self {
         *self = Self::row_major(v);
         self
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[deprecated(since = "0.0.0", note = "use Self::new() instead")]
+    #[deprecated(since = "0.30.0", note = "use Self::new() instead")]
     pub fn set_44(
         &mut self,
         m0: scalar,
@@ -638,7 +638,7 @@ impl M44 {
         self
     }
 
-    #[deprecated(since = "0.0.0", note = "use M44::col_major() and M44::set_concat()")]
+    #[deprecated(since = "0.30.0", note = "use M44::col_major() and M44::set_concat()")]
     pub fn set_concat_16(&mut self, a: &M44, col_major: &[scalar; Self::COMPONENTS]) -> &mut Self {
         self.set_concat(a, &Self::col_major(col_major))
     }
@@ -650,7 +650,7 @@ impl M44 {
         self
     }
 
-    #[deprecated(since = "0.0.0", note = "use M44::col_major() and M44::pre_concat()")]
+    #[deprecated(since = "0.30.0", note = "use M44::col_major() and M44::pre_concat()")]
     #[allow(deprecated)]
     pub fn pre_concat_16(&mut self, col_major: &[scalar; Self::COMPONENTS]) -> &mut Self {
         self.set_concat_16(&self.clone(), col_major)

--- a/skia-safe/src/core/m44.rs
+++ b/skia-safe/src/core/m44.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+#[allow(deprecated)]
 use crate::{scalar, Matrix, Matrix44, Scalars};
 use bitflags::_core::ops::{AddAssign, MulAssign};
 use skia_bindings as sb;
@@ -743,6 +744,7 @@ impl M44 {
 
     // helper
 
+    #[allow(deprecated)]
     pub fn to_matrix44(&self) -> Matrix44 {
         let mut m = Matrix44::default();
         m.set_col_major(&self.mat);
@@ -806,6 +808,7 @@ impl From<Matrix> for M44 {
     }
 }
 
+#[allow(deprecated)]
 impl From<&Matrix44> for M44 {
     fn from(m: &Matrix44) -> Self {
         let mut rm: [f32; 16] = Default::default();

--- a/skia-safe/src/core/mask_filter.rs
+++ b/skia-safe/src/core/mask_filter.rs
@@ -30,12 +30,12 @@ impl RCHandle<SkMaskFilter> {
         .unwrap()
     }
 
-    #[deprecated(since = "0.0.0", note = "removed without replacement")]
+    #[deprecated(since = "0.30.0", note = "removed without replacement")]
     pub fn compose(_outer: Self, _inner: Self) -> ! {
         panic!("removed without replacement")
     }
 
-    #[deprecated(since = "0.0.0", note = "removed without replacement")]
+    #[deprecated(since = "0.30.0", note = "removed without replacement")]
     pub fn combine(_filter_a: Self, _filter_b: Self, _mode: CoverageMode) -> ! {
         panic!("removed without replacement")
     }

--- a/skia-safe/src/core/mask_filter.rs
+++ b/skia-safe/src/core/mask_filter.rs
@@ -30,14 +30,14 @@ impl RCHandle<SkMaskFilter> {
         .unwrap()
     }
 
-    pub fn compose(outer: Self, inner: Self) -> Option<Self> {
-        Self::from_ptr(unsafe { sb::C_SkMaskFilter_Compose(outer.into_ptr(), inner.into_ptr()) })
+    #[deprecated(since = "0.0.0", note = "removed without replacement")]
+    pub fn compose(_outer: Self, _inner: Self) -> ! {
+        panic!("removed without replacement")
     }
 
-    pub fn combine(filter_a: Self, filter_b: Self, mode: CoverageMode) -> Option<Self> {
-        Self::from_ptr(unsafe {
-            sb::C_SkMaskFilter_Combine(filter_a.into_ptr(), filter_b.into_ptr(), mode)
-        })
+    #[deprecated(since = "0.0.0", note = "removed without replacement")]
+    pub fn combine(_filter_a: Self, _filter_b: Self, _mode: CoverageMode) -> ! {
+        panic!("removed without replacement")
     }
 
     #[deprecated(since = "0.29.0", note = "removed without replacement")]

--- a/skia-safe/src/core/matrix44.rs
+++ b/skia-safe/src/core/matrix44.rs
@@ -1,3 +1,8 @@
+#![deprecated(
+    since = "0.0.0",
+    note = "This entire module is deprecated, and will be removed at some point. SkCanvas has full support for 4x4 matrices using SkM44"
+)]
+#![allow(deprecated)]
 use crate::prelude::*;
 use crate::{scalar, Matrix, Scalar, Vector3};
 use skia_bindings as sb;
@@ -6,6 +11,7 @@ use std::ops;
 
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, Debug)]
+#[deprecated(since = "0.0.0", note = "use V4 instead")]
 pub struct Vector4 {
     x: scalar,
     y: scalar,
@@ -81,6 +87,7 @@ bitflags! {
 
 #[derive(Copy, Clone)]
 #[repr(transparent)]
+#[deprecated(since = "0.0.0", note = "use M44 instead")]
 pub struct Matrix44(SkMatrix44);
 
 impl NativeTransmutable<SkMatrix44> for Matrix44 {}

--- a/skia-safe/src/core/matrix44.rs
+++ b/skia-safe/src/core/matrix44.rs
@@ -7,7 +7,7 @@ use std::ops;
 
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-#[deprecated(since = "0.0.0", note = "use V4 instead")]
+#[deprecated(since = "0.30.0", note = "use V4 instead")]
 pub struct Vector4 {
     x: scalar,
     y: scalar,
@@ -83,7 +83,7 @@ bitflags! {
 
 #[derive(Copy, Clone)]
 #[repr(transparent)]
-#[deprecated(since = "0.0.0", note = "use M44 instead")]
+#[deprecated(since = "0.30.0", note = "use M44 instead")]
 pub struct Matrix44(SkMatrix44);
 
 impl NativeTransmutable<SkMatrix44> for Matrix44 {}

--- a/skia-safe/src/core/matrix44.rs
+++ b/skia-safe/src/core/matrix44.rs
@@ -1,7 +1,3 @@
-#![deprecated(
-    since = "0.0.0",
-    note = "This entire module is deprecated, and will be removed at some point. SkCanvas has full support for 4x4 matrices using SkM44"
-)]
 #![allow(deprecated)]
 use crate::prelude::*;
 use crate::{scalar, Matrix, Scalar, Vector3};
@@ -22,7 +18,6 @@ pub struct Vector4 {
 impl NativeTransmutable<SkVector4> for Vector4 {}
 
 #[test]
-#[allow(deprecated)]
 fn test_vector4_layout() {
     Vector4::test_layout()
 }
@@ -93,7 +88,6 @@ pub struct Matrix44(SkMatrix44);
 
 impl NativeTransmutable<SkMatrix44> for Matrix44 {}
 #[test]
-#[allow(deprecated)]
 fn test_matrix44_layout() {
     Matrix44::test_layout()
 }
@@ -462,7 +456,6 @@ impl Map2<(&[f64], &mut [f64])> for Matrix44 {
 }
 
 #[test]
-#[allow(deprecated)]
 fn create_identity() {
     Matrix44::new_identity();
     let _identity = Matrix44::new_identity();

--- a/skia-safe/src/core/matrix44.rs
+++ b/skia-safe/src/core/matrix44.rs
@@ -22,6 +22,7 @@ pub struct Vector4 {
 impl NativeTransmutable<SkVector4> for Vector4 {}
 
 #[test]
+#[allow(deprecated)]
 fn test_vector4_layout() {
     Vector4::test_layout()
 }
@@ -92,6 +93,7 @@ pub struct Matrix44(SkMatrix44);
 
 impl NativeTransmutable<SkMatrix44> for Matrix44 {}
 #[test]
+#[allow(deprecated)]
 fn test_matrix44_layout() {
     Matrix44::test_layout()
 }
@@ -460,6 +462,7 @@ impl Map2<(&[f64], &mut [f64])> for Matrix44 {
 }
 
 #[test]
+#[allow(deprecated)]
 fn create_identity() {
     Matrix44::new_identity();
     let _identity = Matrix44::new_identity();

--- a/skia-safe/src/core/milestone.rs
+++ b/skia-safe/src/core/milestone.rs
@@ -1,1 +1,1 @@
-pub const MILESTONE: usize = 83;
+pub const MILESTONE: usize = 84;

--- a/skia-safe/src/core/path.rs
+++ b/skia-safe/src/core/path.rs
@@ -6,7 +6,7 @@ use crate::{
     Rect, Vector,
 };
 use skia_bindings as sb;
-use skia_bindings::{SkPath, SkPathVerb, SkPath_Iter, SkPath_RawIter};
+use skia_bindings::{SkPath, SkPath_Iter, SkPath_RawIter};
 use std::marker::PhantomData;
 use std::mem::forget;
 
@@ -33,12 +33,12 @@ fn test_add_path_mode_naming() {
 
 pub use path_types::PathSegmentMask as SegmentMask;
 
-pub use path_types::PathVerb as Verb;
+pub use skia_bindings::SkPath_Verb as Verb;
 
 #[repr(C)]
 pub struct Iter<'a>(SkPath_Iter, PhantomData<&'a Handle<SkPath>>);
 
-impl<'a> NativeAccess<SkPath_Iter> for Iter<'a> {
+impl NativeAccess<SkPath_Iter> for Iter<'_> {
     fn native(&self) -> &SkPath_Iter {
         &self.0
     }
@@ -47,19 +47,19 @@ impl<'a> NativeAccess<SkPath_Iter> for Iter<'a> {
     }
 }
 
-impl<'a> Drop for Iter<'a> {
+impl Drop for Iter<'_> {
     fn drop(&mut self) {
         unsafe { sb::C_SkPath_Iter_destruct(&mut self.0) }
     }
 }
 
-impl<'a> Default for Iter<'a> {
+impl Default for Iter<'_> {
     fn default() -> Self {
         Iter(unsafe { SkPath_Iter::new() }, PhantomData)
     }
 }
 
-impl<'a> Iter<'a> {
+impl Iter<'_> {
     pub fn new(path: &Path, force_close: bool) -> Iter {
         Iter(
             unsafe { SkPath_Iter::new1(path.native(), force_close) },
@@ -98,9 +98,7 @@ impl<'a> Iterator for Iter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut points = [Point::default(); Verb::MAX_POINTS];
-        let verb = SkPathVerb::from_native(unsafe {
-            self.native_mut().next(points.native_mut().as_mut_ptr())
-        });
+        let verb = unsafe { self.native_mut().next(points.native_mut().as_mut_ptr()) };
         if verb != Verb::Done {
             Some((verb, points[0..verb.points()].into()))
         } else {
@@ -110,8 +108,13 @@ impl<'a> Iterator for Iter<'a> {
 }
 
 #[repr(C)]
+#[deprecated(
+    since = "0.0.0",
+    note = "User Iter instead, RawIter will soon be removed."
+)]
 pub struct RawIter<'a>(SkPath_RawIter, PhantomData<&'a Handle<SkPath>>);
 
+#[allow(deprecated)]
 impl<'a> NativeAccess<SkPath_RawIter> for RawIter<'a> {
     fn native(&self) -> &SkPath_RawIter {
         &self.0
@@ -121,13 +124,15 @@ impl<'a> NativeAccess<SkPath_RawIter> for RawIter<'a> {
     }
 }
 
-impl<'a> Drop for RawIter<'a> {
+#[allow(deprecated)]
+impl Drop for RawIter<'_> {
     fn drop(&mut self) {
         unsafe { sb::C_SkPath_RawIter_destruct(&mut self.0) }
     }
 }
 
-impl<'a> Default for RawIter<'a> {
+#[allow(deprecated)]
+impl Default for RawIter<'_> {
     fn default() -> Self {
         RawIter(
             construct(|ri| unsafe { sb::C_SkPath_RawIter_Construct(ri) }),
@@ -136,41 +141,43 @@ impl<'a> Default for RawIter<'a> {
     }
 }
 
-impl<'a> RawIter<'a> {
+#[allow(deprecated)]
+impl RawIter<'_> {
     pub fn new(path: &Path) -> RawIter {
         RawIter::default().set_path(path)
     }
 
     pub fn set_path(mut self, path: &Path) -> RawIter {
-        unsafe { self.0.fRawIter.setPathRef(path.native().fPathRef.fPtr) };
+        unsafe { self.native_mut().setPath(path.native()) }
         let r = RawIter(self.0, PhantomData);
         forget(self);
         r
     }
 
     pub fn peek(&self) -> Verb {
-        SkPathVerb::from_native(unsafe { sb::C_SkPath_RawIter_peek(self.native()) })
+        unsafe { sb::C_SkPath_RawIter_peek(self.native()) }
     }
 
     pub fn conic_weight(&self) -> Option<scalar> {
         #[allow(clippy::map_clone)]
         self.native()
-            .fRawIter
-            .fConicWeights
+            .fIter
+            .fWeights
             .into_option()
             .map(|cw| unsafe { *cw })
     }
 }
 
-impl<'a> Iterator for RawIter<'a> {
+#[allow(deprecated)]
+impl Iterator for RawIter<'_> {
     type Item = (Verb, Vec<Point>);
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut points = [Point::default(); Verb::MAX_POINTS];
 
-        let verb = SkPathVerb::from_native(unsafe {
+        let verb = unsafe {
             sb::C_SkPath_RawIter_next(self.native_mut(), points.native_mut().as_mut_ptr())
-        });
+        };
 
         if verb != Verb::Done {
             Some((verb, points[0..verb.points()].into()))

--- a/skia-safe/src/core/path.rs
+++ b/skia-safe/src/core/path.rs
@@ -113,7 +113,7 @@ impl<'a> Iterator for Iter<'a> {
 
 #[repr(C)]
 #[deprecated(
-    since = "0.0.0",
+    since = "0.30.0",
     note = "User Iter instead, RawIter will soon be removed."
 )]
 pub struct RawIter<'a>(SkPath_RawIter, PhantomData<&'a Handle<SkPath>>);

--- a/skia-safe/src/core/pixmap.rs
+++ b/skia-safe/src/core/pixmap.rs
@@ -229,10 +229,22 @@ impl Handle<SkPixmap> {
     }
 
     pub fn erase_4f(&self, color: impl AsRef<Color4f>, subset: Option<&IRect>) -> bool {
+        self.erase_with_colorspace(color, None, subset)
+    }
+
+    pub fn erase_with_colorspace(
+        &self,
+        color: impl AsRef<Color4f>,
+        cs: Option<&ColorSpace>,
+        subset: Option<&IRect>,
+    ) -> bool {
         let color = color.as_ref();
         unsafe {
-            self.native()
-                .erase1(color.native(), subset.native_ptr_or_null())
+            self.native().erase1(
+                color.native(),
+                cs.native_ptr_or_null_mut_force(),
+                subset.native_ptr_or_null(),
+            )
         }
     }
 }

--- a/skia-safe/src/core/scalar_.rs
+++ b/skia-safe/src/core/scalar_.rs
@@ -1,9 +1,12 @@
+use std::ops::Mul;
+
 #[allow(non_camel_case_types)]
 pub type scalar = skia_bindings::SkScalar;
 
 // TODO: wrap more core/SkScalar.h functions / macros.
 
 pub trait Scalar: Copy {
+    const ZERO: Self;
     const NEARLY_ZERO: Self;
     const ONE: Self;
     const HALF: Self;
@@ -12,7 +15,12 @@ pub trait Scalar: Copy {
     fn nearly_zero(&self, tolerance: impl Into<Option<scalar>>) -> bool;
 }
 
+pub trait Scalars {
+    fn are_finite(&self) -> bool;
+}
+
 impl Scalar for scalar {
+    const ZERO: Self = 0.0;
     const NEARLY_ZERO: Self = 1.0 / ((1 << 12) as Self);
     const ONE: Self = 1.0;
     const HALF: Self = 0.5;
@@ -27,5 +35,16 @@ impl Scalar for scalar {
         let tolerance = tolerance.into().unwrap_or(Self::NEARLY_ZERO);
         debug_assert!(tolerance >= 0.0);
         self.abs() <= tolerance
+    }
+}
+
+impl<T> Scalars for [T]
+where
+    T: Scalar,
+    T: Mul<Output = T>,
+    T: PartialEq,
+{
+    fn are_finite(&self) -> bool {
+        self.iter().fold(T::ZERO, |prod, value| prod * *value) == T::ZERO
     }
 }

--- a/skia-safe/src/core/surface.rs
+++ b/skia-safe/src/core/surface.rs
@@ -457,14 +457,19 @@ impl RCHandle<SkSurface> {
         SurfaceProps::from_native_ref(unsafe { &*sb::C_SkSurface_props(self.native()) })
     }
 
-    pub fn flush(&mut self) {
+    pub fn flush_and_submit(&mut self) {
         unsafe {
-            self.native_mut().flush();
+            self.native_mut().flushAndSubmit();
         }
     }
 
+    #[deprecated(since = "0.0.0", note = "Use flush_and_submit()")]
+    pub fn flush(&mut self) {
+        self.flush_and_submit()
+    }
+
     // TODO: flush(access, FlushInfo)
-    // TODO: flush(access, FlshFlags, semaphores)
+    // TODO: flush(access, FlushFlags, semaphores)
     // TODO: wait()
 
     pub fn characterize(&self) -> Option<SurfaceCharacterization> {

--- a/skia-safe/src/core/surface.rs
+++ b/skia-safe/src/core/surface.rs
@@ -467,7 +467,7 @@ impl RCHandle<SkSurface> {
         }
     }
 
-    #[deprecated(since = "0.0.0", note = "Use flush_and_submit()")]
+    #[deprecated(since = "0.30.0", note = "Use flush_and_submit()")]
     pub fn flush(&mut self) {
         self.flush_and_submit()
     }

--- a/skia-safe/src/core/surface.rs
+++ b/skia-safe/src/core/surface.rs
@@ -281,6 +281,10 @@ impl RCHandle<SkSurface> {
 
 #[cfg(feature = "gpu")]
 impl RCHandle<SkSurface> {
+    pub fn context(&mut self) -> Option<gpu::Context> {
+        gpu::Context::from_unshared_ptr(unsafe { self.native_mut().getContext() })
+    }
+
     pub fn get_backend_texture(
         &mut self,
         handle_access: BackendHandleAccess,

--- a/skia-safe/src/core/vertices.rs
+++ b/skia-safe/src/core/vertices.rs
@@ -1,7 +1,13 @@
 use crate::prelude::*;
 use crate::{Color, Data, Point, Rect};
 use skia_bindings as sb;
-use skia_bindings::{SkColor, SkPoint, SkVertices, SkVertices_Attribute, SkVertices_Builder};
+use skia_bindings::{
+    SkColor, SkPoint, SkVertices, SkVertices_Attribute, SkVertices_Attribute_Type,
+    SkVertices_Builder,
+};
+use std::ffi::CStr;
+use std::marker::PhantomData;
+use std::os::raw::c_char;
 use std::{ptr, slice};
 
 #[deprecated(since = "0.29.0", note = "removed without replacement")]
@@ -33,27 +39,71 @@ pub enum AttributeType {
     Byte4UNorm = sb::SkVertices_Attribute_Type::Byte4_unorm as _,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub struct Attribute {
-    pub tp: AttributeType,
+impl NativeTransmutable<SkVertices_Attribute_Type> for AttributeType {}
+#[test]
+fn test_attribute_type_layout() {
+    AttributeType::test_layout()
 }
 
-impl NativeTransmutable<SkVertices_Attribute> for Attribute {}
+pub use skia_bindings::SkVertices_Attribute_Usage as AttributeUsage;
 
+#[test]
+fn test_attribute_usage_naming() {
+    let _ = AttributeUsage::Vector;
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct Attribute<'a> {
+    pub ty: AttributeType,
+    pub usage: AttributeUsage,
+    pub marker_id: u32,
+    marker_name: *const c_char,
+    pd: PhantomData<&'a CStr>,
+}
+
+impl NativeTransmutable<SkVertices_Attribute> for Attribute<'_> {}
 #[test]
 fn test_attribute_layout() {
     Attribute::test_layout()
 }
 
-impl Default for Attribute {
+impl Default for Attribute<'_> {
     fn default() -> Self {
         Attribute::new(AttributeType::Float)
     }
 }
 
-impl Attribute {
-    pub fn new(tp: AttributeType) -> Self {
-        Self { tp }
+impl Attribute<'_> {
+    pub fn new(ty: AttributeType) -> Self {
+        Self::new_with_usage_and_marker(ty, None, None)
+    }
+
+    pub fn new_with_usage_and_marker<'a>(
+        ty: AttributeType,
+        usage: impl Into<Option<AttributeUsage>>,
+        marker_name: impl Into<Option<&'a CStr>>,
+    ) -> Attribute<'a> {
+        let marker_name = marker_name
+            .into()
+            .map(|m| m.as_ptr())
+            .unwrap_or(ptr::null());
+
+        Attribute::from_native(unsafe {
+            SkVertices_Attribute::new(
+                ty.into_native(),
+                usage.into().unwrap_or(AttributeUsage::Raw),
+                marker_name,
+            )
+        })
+    }
+
+    pub fn marker_name(&self) -> Option<&CStr> {
+        if !self.marker_name.is_null() {
+            unsafe { CStr::from_ptr(self.marker_name) }.into()
+        } else {
+            None
+        }
     }
 
     pub fn channel_count(self) -> usize {

--- a/skia-safe/src/core/vertices.rs
+++ b/skia-safe/src/core/vertices.rs
@@ -46,14 +46,13 @@ fn test_attribute_type_layout() {
 }
 
 pub use skia_bindings::SkVertices_Attribute_Usage as AttributeUsage;
-
 #[test]
 fn test_attribute_usage_naming() {
     let _ = AttributeUsage::Vector;
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, Eq, Debug)]
 pub struct Attribute<'a> {
     pub ty: AttributeType,
     pub usage: AttributeUsage,
@@ -66,6 +65,12 @@ impl NativeTransmutable<SkVertices_Attribute> for Attribute<'_> {}
 #[test]
 fn test_attribute_layout() {
     Attribute::test_layout()
+}
+
+impl PartialEq for Attribute<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.ty == other.ty && self.usage == other.usage && self.marker_id == other.marker_id
+    }
 }
 
 impl Default for Attribute<'_> {
@@ -112,6 +117,10 @@ impl Attribute<'_> {
 
     pub fn bytes_per_vertex(self) -> usize {
         unsafe { self.native().bytesPerVertex() }
+    }
+
+    pub fn is_valid(self) -> bool {
+        unsafe { self.native().isValid() }
     }
 }
 

--- a/skia-safe/src/effects/image_filters.rs
+++ b/skia-safe/src/effects/image_filters.rs
@@ -313,7 +313,7 @@ pub fn xfermode<'a>(
 }
 
 pub fn dilate<'a>(
-    (radius_x, radius_y): (i32, i32),
+    (radius_x, radius_y): (scalar, scalar),
     input: impl Into<Option<ImageFilter>>,
     crop_rect: impl Into<Option<&'a IRect>>,
 ) -> Option<ImageFilter> {
@@ -328,7 +328,7 @@ pub fn dilate<'a>(
 }
 
 pub fn erode<'a>(
-    (radius_x, radius_y): (i32, i32),
+    (radius_x, radius_y): (scalar, scalar),
     input: impl Into<Option<ImageFilter>>,
     crop_rect: impl Into<Option<&'a IRect>>,
 ) -> Option<ImageFilter> {

--- a/skia-safe/src/effects/morphology_image_filter.rs
+++ b/skia-safe/src/effects/morphology_image_filter.rs
@@ -1,12 +1,12 @@
 use crate::prelude::*;
-use crate::{image_filters, IRect};
+use crate::{image_filters, scalar, IRect};
 use skia_bindings::SkImageFilter;
 
 impl RCHandle<SkImageFilter> {
     pub fn dilate<'a>(
         self,
         crop_rect: impl Into<Option<&'a IRect>>,
-        radii: (i32, i32),
+        radii: (scalar, scalar),
     ) -> Option<Self> {
         image_filters::dilate(radii, self, crop_rect)
     }
@@ -14,7 +14,7 @@ impl RCHandle<SkImageFilter> {
     pub fn erode<'a>(
         self,
         crop_rect: impl Into<Option<&'a IRect>>,
-        radii: (i32, i32),
+        radii: (scalar, scalar),
     ) -> Option<Self> {
         image_filters::erode(radii, self, crop_rect)
     }

--- a/skia-safe/src/effects/runtime_effect.rs
+++ b/skia-safe/src/effects/runtime_effect.rs
@@ -159,8 +159,9 @@ impl RCHandle<SkRuntimeEffect> {
         unsafe { self.native().inputSize() }
     }
 
-    pub fn uniform_size(&self) -> usize {
-        unsafe { sb::C_SkRuntimeEffect_uniformSize(self.native()) }
+    #[deprecated(since = "0.0.0", note = "removed without replacement")]
+    pub fn uniform_size(&self) -> ! {
+        panic!("removed without replacement")
     }
 
     pub fn inputs(&self) -> &[Variable] {

--- a/skia-safe/src/effects/runtime_effect.rs
+++ b/skia-safe/src/effects/runtime_effect.rs
@@ -187,7 +187,7 @@ impl RCHandle<SkRuntimeEffect> {
         unsafe { self.native().inputSize() }
     }
 
-    #[deprecated(since = "0.0.0", note = "removed without replacement")]
+    #[deprecated(since = "0.30.0", note = "removed without replacement")]
     pub fn uniform_size(&self) -> ! {
         panic!("removed without replacement")
     }

--- a/skia-safe/src/gpu/backend_surface.rs
+++ b/skia-safe/src/gpu/backend_surface.rs
@@ -68,6 +68,10 @@ impl Handle<GrBackendFormat> {
 
     // texture_type() would return a private type.
 
+    pub fn channel_mask(&self) -> u32 {
+        unsafe { self.native().channelMask() }
+    }
+
     #[deprecated(since = "0.19.0", note = "use as_gl_format()")]
     #[cfg(feature = "gl")]
     pub fn gl_format(&self) -> Option<gl::Enum> {

--- a/skia-safe/src/gpu/context.rs
+++ b/skia-safe/src/gpu/context.rs
@@ -205,13 +205,25 @@ impl RCHandle<GrContext> {
 
     // TODO: wait()
 
-    pub fn flush(&mut self) -> &mut Self {
-        unsafe { sb::C_GrContext_flush(self.native_mut()) }
+    pub fn flush_and_submit(&mut self) -> &mut Self {
+        unsafe { sb::C_GrContext_flushAndSubmit(self.native_mut()) }
         self
+    }
+
+    #[deprecated(since = "0.0.0", note = "use flush_and_submit()")]
+    pub fn flush(&mut self) -> &mut Self {
+        self.flush_and_submit()
     }
 
     // TODO: flush(GrFlushInfo, ..) two variants.
     // TODO: flushAndSignalSemaphores
+
+    pub fn submit(&mut self, sync_to_cpu: impl Into<Option<bool>>) -> bool {
+        unsafe {
+            self.native_mut()
+                .submit(sync_to_cpu.into().unwrap_or(false))
+        }
+    }
 
     pub fn check_async_work_completion(&mut self) {
         unsafe { self.native_mut().checkAsyncWorkCompletion() }
@@ -258,6 +270,10 @@ impl RCHandle<GrContext> {
 
     // TODO: wrap createBackendTexture (several variants)
     //       introduced in m76, m77, and m79
+    //       extended in m84 with finishedProc and finishedContext
+
+    // TODO: wrap updateBackendTexture (several variants)
+    //       introduced in m84
 
     pub fn compressed_backend_format(&self, compression: image::CompressionType) -> BackendFormat {
         let mut backend_format = BackendFormat::default();
@@ -273,6 +289,7 @@ impl RCHandle<GrContext> {
 
     // TODO: wrap createCompressedBackendTexture (several variants)
     //       introduced in m81
+    //       extended in m84 with finishedProc and finishedContext
 
     // TODO: wrap deleteBackendTexture(),
 

--- a/skia-safe/src/gpu/context.rs
+++ b/skia-safe/src/gpu/context.rs
@@ -210,7 +210,7 @@ impl RCHandle<GrContext> {
         self
     }
 
-    #[deprecated(since = "0.0.0", note = "use flush_and_submit()")]
+    #[deprecated(since = "0.30.0", note = "use flush_and_submit()")]
     pub fn flush(&mut self) -> &mut Self {
         self.flush_and_submit()
     }

--- a/skia-safe/src/modules/paragraph/dart_types.rs
+++ b/skia-safe/src/modules/paragraph/dart_types.rs
@@ -9,6 +9,14 @@ pub use sb::skia_textlayout_RectHeightStyle as RectHeightStyle;
 pub use sb::skia_textlayout_RectWidthStyle as RectWidthStyle;
 pub use sb::skia_textlayout_TextAlign as TextAlign;
 pub use sb::skia_textlayout_TextDirection as TextDirection;
+#[test]
+fn test_reexported_enum_name_conversion() {
+    let _ = Affinity::Downstream;
+    let _ = RectHeightStyle::IncludeLineSpacingBottom;
+    let _ = RectWidthStyle::Max;
+    let _ = TextAlign::End;
+    let _ = TextDirection::LTR;
+}
 
 pub use sb::skia_textlayout_PositionWithAffinity as PositionWithAffinity;
 
@@ -33,6 +41,7 @@ pub trait RangeExtensions {
     fn shift(&mut self, d: usize);
     fn contains(&self, other: &Self) -> bool;
     fn intersects(&self, other: &Self) -> bool;
+    fn intersection(&self, other: &Self) -> Self;
     fn empty(&self) -> bool;
 }
 
@@ -54,6 +63,13 @@ impl RangeExtensions for Range<usize> {
         max(self.start, other.start) <= min(self.end, other.end)
     }
 
+    fn intersection(&self, other: &Self) -> Self {
+        Self {
+            start: max(self.start, other.start),
+            end: min(self.end, other.end),
+        }
+    }
+
     fn empty(&self) -> bool {
         self.start == EMPTY_INDEX && self.end == EMPTY_INDEX
     }
@@ -67,3 +83,15 @@ pub const EMPTY_RANGE: Range<usize> = Range {
 };
 
 pub use sb::skia_textlayout_TextBaseline as TextBaseline;
+#[test]
+fn test_text_baseline_naming() {
+    let _ = TextBaseline::Alphabetic;
+}
+
+pub use sb::skia_textlayout_TextHeightBehavior as TextHeightBehavior;
+#[test]
+fn test_text_height_behavior_naming() {
+    let _ = TextHeightBehavior::DisableFirstAscent;
+}
+
+// m84: LineMetricStyle is declared but not used in the public API yet.

--- a/skia-safe/src/modules/paragraph/paragraph_style.rs
+++ b/skia-safe/src/modules/paragraph/paragraph_style.rs
@@ -1,5 +1,6 @@
 use super::{FontFamilies, TextAlign, TextDirection, TextStyle};
 use crate::interop::{AsStr, FromStrs, SetStr};
+use crate::modules::paragraph::TextHeightBehavior;
 use crate::prelude::*;
 use crate::{interop, scalar, FontStyle};
 use skia_bindings as sb;
@@ -205,6 +206,15 @@ impl Handle<sb::skia_textlayout_ParagraphStyle> {
 
     pub fn set_height(&mut self, height: scalar) -> &mut Self {
         self.native_mut().fHeight = height;
+        self
+    }
+
+    pub fn text_height_behavior(&self) -> TextHeightBehavior {
+        self.native().fTextHeightBehavior
+    }
+
+    pub fn set_text_height_behavior(&mut self, v: TextHeightBehavior) -> &mut Self {
+        self.native_mut().fTextHeightBehavior = v;
         self
     }
 

--- a/skia-safe/src/modules/paragraph/text_style.rs
+++ b/skia-safe/src/modules/paragraph/text_style.rs
@@ -35,6 +35,12 @@ fn text_decoration_style_member_naming() {
     let _ = TextDecorationStyle::Solid;
 }
 
+pub use sb::skia_textlayout_TextDecorationMode as TextDecorationMode;
+#[test]
+fn text_decoration_mode_naming() {
+    let _ = TextDecorationMode::Gaps;
+}
+
 pub use sb::skia_textlayout_StyleType as StyleType;
 
 #[test]
@@ -46,6 +52,7 @@ fn style_type_member_naming() {
 #[derive(Copy, Clone, PartialEq, Default, Debug)]
 pub struct Decoration {
     pub ty: TextDecoration,
+    pub mode: TextDecorationMode,
     pub color: Color,
     pub style: TextDecorationStyle,
     pub thickness_multiplier: scalar,

--- a/skia-safe/src/modules/paragraph/text_style.rs
+++ b/skia-safe/src/modules/paragraph/text_style.rs
@@ -29,9 +29,8 @@ impl TextDecoration {
 }
 
 pub use sb::skia_textlayout_TextDecorationStyle as TextDecorationStyle;
-
 #[test]
-fn text_decoration_style_member_naming() {
+fn text_decoration_style_naming() {
     let _ = TextDecorationStyle::Solid;
 }
 
@@ -42,7 +41,6 @@ fn text_decoration_mode_naming() {
 }
 
 pub use sb::skia_textlayout_StyleType as StyleType;
-
 #[test]
 fn style_type_member_naming() {
     let _ = StyleType::Foreground;

--- a/skia-safe/src/utils.rs
+++ b/skia-safe/src/utils.rs
@@ -5,6 +5,9 @@ pub use _3d::*;
 mod camera;
 pub use camera::*;
 
+mod custom_typeface;
+pub use custom_typeface::*;
+
 pub mod interpolator;
 pub use interpolator::Interpolator;
 

--- a/skia-safe/src/utils/_3d.rs
+++ b/skia-safe/src/utils/_3d.rs
@@ -1,6 +1,7 @@
 //! TODO: The original Skia function names in this module are prefixed with Sk3, but we
 //!       export them without a prefix.
 //!       Should we place them into a module?
+#![allow(deprecated)]
 use crate::{Matrix44, Point, Point3, M44, V3};
 
 #[deprecated(since = "0.29.0", note = "use M44::look_at()")]
@@ -34,7 +35,6 @@ pub fn map_points(dst: &mut [Point], m4: &Matrix44, src: &[Point3]) {
 
 impl Matrix44 {
     #[deprecated(since = "0.29.0", note = "use M44::look_at()")]
-    #[allow(deprecated)]
     pub fn look_at(
         eye: impl Into<Point3>,
         center: impl Into<Point3>,
@@ -44,13 +44,11 @@ impl Matrix44 {
     }
 
     #[deprecated(since = "0.29.0", note = "use M44::perspective()")]
-    #[allow(deprecated)]
     pub fn perspective(near: f32, far: f32, angle: f32) -> Matrix44 {
         perspective(near, far, angle)
     }
 
     #[deprecated(since = "0.29.0", note = "use M44::map() or M44::Mul")]
-    #[allow(deprecated)]
     pub fn map_points(&self, src: &[Point3], dst: &mut [Point]) -> &Self {
         map_points(dst, self, src);
         self

--- a/skia-safe/src/utils/camera.rs
+++ b/skia-safe/src/utils/camera.rs
@@ -1,8 +1,13 @@
+#![allow(deprecated)]
 use crate::prelude::*;
 use crate::{scalar, Canvas, Matrix};
 use skia_bindings as sb;
 use skia_bindings::{Sk3DView, SkCamera3D, SkMatrix3D, SkPatch3D, SkPoint3D, SkUnit3D};
 
+#[deprecated(
+    since = "0.0.0",
+    note = "Skia now has support for a 4x matrix (core::M44) in core::Canvas."
+)]
 #[derive(Copy, Clone, PartialEq, Default, Debug)]
 #[repr(C)]
 pub struct Unit3D {
@@ -37,6 +42,10 @@ impl Unit3D {
     }
 }
 
+#[deprecated(
+    since = "0.0.0",
+    note = "Skia now has support for a 4x matrix (core::M44) in core::Canvas."
+)]
 #[derive(Copy, Clone, PartialEq, Default, Debug)]
 #[repr(C)]
 pub struct Point3D {
@@ -70,9 +79,17 @@ impl Point3D {
     }
 }
 
+#[deprecated(
+    since = "0.0.0",
+    note = "Skia now has support for a 4x matrix (core::M44) in core::Canvas."
+)]
 pub type Vector3D = Point3D;
 
 // note: Default is an empty matrix, and not the identity matrix, which is generated with reset()!
+#[deprecated(
+    since = "0.0.0",
+    note = "Skia now has support for a 4x matrix (core::M44) in core::Canvas."
+)]
 #[derive(Clone, PartialEq, Default, Debug)]
 #[repr(C)]
 pub struct Matrix3D {
@@ -174,6 +191,10 @@ impl Matrix3D {
     }
 }
 
+#[deprecated(
+    since = "0.0.0",
+    note = "Skia now has support for a 4x matrix (core::M44) in core::Canvas."
+)]
 #[derive(Clone, PartialEq, Debug)]
 #[repr(C)]
 pub struct Patch3D {
@@ -212,6 +233,10 @@ impl Patch3D {
     }
 }
 
+#[deprecated(
+    since = "0.0.0",
+    note = "Skia now has support for a 4x matrix (core::M44) in core::Canvas."
+)]
 #[derive(Clone, PartialEq, Debug)]
 #[repr(C)]
 pub struct Camera3D {
@@ -260,6 +285,10 @@ impl Camera3D {
 // Also note that the implementation uses interior pointers,
 // so we let Skia do the allocation.
 
+#[deprecated(
+    since = "0.0.0",
+    note = "Skia now has support for a 4x matrix (core::M44) in core::Canvas."
+)]
 pub type View3D = RefHandle<Sk3DView>;
 unsafe impl Send for View3D {}
 

--- a/skia-safe/src/utils/camera.rs
+++ b/skia-safe/src/utils/camera.rs
@@ -5,7 +5,7 @@ use skia_bindings as sb;
 use skia_bindings::{Sk3DView, SkCamera3D, SkMatrix3D, SkPatch3D, SkPoint3D, SkUnit3D};
 
 #[deprecated(
-    since = "0.0.0",
+    since = "0.30.0",
     note = "Skia now has support for a 4x matrix (core::M44) in core::Canvas."
 )]
 #[derive(Copy, Clone, PartialEq, Default, Debug)]
@@ -43,7 +43,7 @@ impl Unit3D {
 }
 
 #[deprecated(
-    since = "0.0.0",
+    since = "0.30.0",
     note = "Skia now has support for a 4x matrix (core::M44) in core::Canvas."
 )]
 #[derive(Copy, Clone, PartialEq, Default, Debug)]
@@ -80,14 +80,14 @@ impl Point3D {
 }
 
 #[deprecated(
-    since = "0.0.0",
+    since = "0.30.0",
     note = "Skia now has support for a 4x matrix (core::M44) in core::Canvas."
 )]
 pub type Vector3D = Point3D;
 
 // note: Default is an empty matrix, and not the identity matrix, which is generated with reset()!
 #[deprecated(
-    since = "0.0.0",
+    since = "0.30.0",
     note = "Skia now has support for a 4x matrix (core::M44) in core::Canvas."
 )]
 #[derive(Clone, PartialEq, Default, Debug)]
@@ -192,7 +192,7 @@ impl Matrix3D {
 }
 
 #[deprecated(
-    since = "0.0.0",
+    since = "0.30.0",
     note = "Skia now has support for a 4x matrix (core::M44) in core::Canvas."
 )]
 #[derive(Clone, PartialEq, Debug)]
@@ -234,7 +234,7 @@ impl Patch3D {
 }
 
 #[deprecated(
-    since = "0.0.0",
+    since = "0.30.0",
     note = "Skia now has support for a 4x matrix (core::M44) in core::Canvas."
 )]
 #[derive(Clone, PartialEq, Debug)]
@@ -286,7 +286,7 @@ impl Camera3D {
 // so we let Skia do the allocation.
 
 #[deprecated(
-    since = "0.0.0",
+    since = "0.30.0",
     note = "Skia now has support for a 4x matrix (core::M44) in core::Canvas."
 )]
 pub type View3D = RefHandle<Sk3DView>;

--- a/skia-safe/src/utils/custom_typeface.rs
+++ b/skia-safe/src/utils/custom_typeface.rs
@@ -1,0 +1,81 @@
+use crate::prelude::*;
+use crate::{GlyphId, Image, Paint, Path, Picture, Typeface};
+use skia_bindings as sb;
+use skia_bindings::SkCustomTypefaceBuilder;
+
+pub type CustomTypefaceBuilder = Handle<SkCustomTypefaceBuilder>;
+
+impl NativeDrop for SkCustomTypefaceBuilder {
+    fn drop(&mut self) {
+        unsafe { sb::C_SkCustomTypefaceBuilder_destruct(self) }
+    }
+}
+
+impl Handle<SkCustomTypefaceBuilder> {
+    pub fn new(num_glyphs: usize) -> Self {
+        Self::from_native(unsafe { SkCustomTypefaceBuilder::new(num_glyphs.try_into().unwrap()) })
+    }
+
+    pub fn set_glyph<'a>(
+        &mut self,
+        glyph_id: GlyphId,
+        advance: f32,
+        typeface_glyph: impl Into<TypefaceGlyph<'a>>,
+    ) {
+        unsafe {
+            match typeface_glyph.into() {
+                TypefaceGlyph::Path(path) => {
+                    self.native_mut().setGlyph(glyph_id, advance, path.native())
+                }
+                TypefaceGlyph::PathAndPaint(_path, _paint) => {
+                    unimplemented!("TypefaceGlyph::PathAndPaint is not supported yet, Skia implementation is missing (m84)")
+                }
+                TypefaceGlyph::Image { .. } => {
+                    unimplemented!("TypefaceGlyph::PathAndPaint is not supported yet, Skia implementation is missing (m84)")
+                }
+                TypefaceGlyph::Picture(_picture) => {
+                    unimplemented!("TypefaceGlyph::Picture is not supported yet, Skia implementation is missing (m84)")
+                }
+            }
+        }
+    }
+
+    pub fn detach(&mut self) -> Option<Typeface> {
+        Typeface::from_ptr(unsafe { sb::C_SkCustomTypefaceBuilder_detach(self.native_mut()) })
+    }
+}
+
+pub enum TypefaceGlyph<'a> {
+    Path(&'a Path),
+    PathAndPaint(&'a Path, &'a Paint),
+    Image { image: Image, scale: f32 },
+    Picture(Picture),
+}
+
+impl<'a> From<&'a Path> for TypefaceGlyph<'a> {
+    fn from(path: &'a Path) -> Self {
+        Self::Path(path)
+    }
+}
+
+impl<'a> From<(&'a Path, &'a Paint)> for TypefaceGlyph<'a> {
+    fn from((path, paint): (&'a Path, &'a Paint)) -> Self {
+        Self::PathAndPaint(path, paint)
+    }
+}
+
+impl From<(Image, f32)> for TypefaceGlyph<'_> {
+    fn from((image, scale): (Image, f32)) -> Self {
+        Self::Image { image, scale }
+    }
+}
+
+#[test]
+fn build_custom_typeface() {
+    let mut builder = CustomTypefaceBuilder::new(2);
+    let path = Path::new();
+    builder.set_glyph(10u16, 0.0, &path);
+    builder.set_glyph(11u16, 0.0, &path);
+    let typeface = builder.detach().unwrap();
+    assert_eq!(typeface.native().ref_counted_base()._ref_cnt(), 1);
+}


### PR DESCRIPTION
This PR updates rust-skia to support Skia's `chrome/m84` branch.

- [x] Update `README.md` ([rendered](https://github.com/pragmatrix/rust-skia/blob/m84/README.md))  
  > Most important here is to change the Skia branch name and the current Skia submodule tag at the top of the `README.md` file.
- [x] Skia can be built ([release notes](https://github.com/google/skia/blob/chrome/m84/RELEASE_NOTES.txt)).
- [x] skia-bindings.
- [x] skia-safe: Update & add new wrappers by diffing include files.  
  > Add TODOs for everything that can not be updated right now, and attempt to stay compatible with previous versions of skia-safe without trying too hard before version 1.0. Use `deprecated` attributes if needed.
  - [x] `codec/`
  - [x] `core/`
  - [x] `docs/`
  - [x] `effects/`
  - [x] `gpu/`
    - [x] `gl/`
    - [x] `mtl/`
    - [x] `vk/`
  - [x] `modules/`
    - [x] `skparagraph/`
    - [x] `skshaper/`
  - [x] `pathops/`
  - [x] `svg/`
  - [x] `utils/`
- [x] ~One week before Chrome 84 stable will be released? ([Schedule](https://www.chromestatus.com/features/schedule))
- [x] Any pending changes in the Skia `chrome/m84` branch that aren't synchronized yet?
- [x] Do the tags/hashes in `skia-bindings/Cargo.toml` under `[package.metadata]` match the submodules `depot_tools` and `skia`?
- [x] Rebase on or merge with master.
- [x] Builds with `RUSTFLAGS=-Clink-dead-code` on Windows (#318) 
- [x] Update versions of `skia-bindings/Cargo.toml` and `skia-safe/Cargo.toml` and also add the version to the new `deprecated` attributes.
- [x] Do one final review of all the changes.