### PR TITLE
API to shape non-Rust implemented RunHandlers

### DIFF
--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -362,8 +362,8 @@ mod run_handler {
                     Point::from_native_ref_mut(&mut *buffer.positions),
                     glyph_count,
                 ),
-                offsets: offsets,
-                clusters: clusters,
+                offsets,
+                clusters,
                 point: Point::from_native(buffer.point),
             }
         }


### PR DESCRIPTION
Up until now, the Shaper's `shape*` functions supported only run handlers that had the Rust trait `RunHandler` implemented, which prevented the use of the `TextBlobBuilderRunHandler` for example.

This PR adds a set of new functions named `shape_native*` that support run handlers implementing a new trait named `AsNativeRunHandler`.

**Update:** The the `shape` and `shape_native` functions got unified by adding another trait that support boths, the creation of a new run handlers and accessing the underlying Skia run handler through `AsNativeRunHandler`.