### PR TITLE
Fix sparkle 0.1.25 incompatibility with offscreen_opengl_context

### DIFF
--- a/skia-org/Cargo.toml
+++ b/skia-org/Cargo.toml
@@ -30,7 +30,8 @@ offscreen_gl_context = { git = "https://github.com/rust-skia/rust-offscreen-rend
 # offscreen_gl_context = "0.25.1"
 # for offscreen_gl_context 0.25
 # sparkle 0.1.9 fails to compile on macOS targeting aarch64-linux-android
-sparkle = { version = "0.1.10", optional = true }
+# sparkle 0.1.25 is incompatible with offscreen_gl_context
+sparkle = { version = "=0.1.24", optional = true }
 clap = "2.33.0"
 ash = { version = "0.31", optional = true }
 # need to rename the package because of the feature with the same name.


### PR DESCRIPTION
. by pinning it to version 0.1.24 when the skia-org example executable is built.