### PR TITLE
Chrome Milestone 85

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m85 ([pending changes][skiapending], [our changes][skiaours]).
 
-[skiapending]: https://github.com/rust-skia/skia/compare/m85-0.32.0...google:chrome/m85
-[skiaours]: https://github.com/google/skia/compare/chrome/m85...rust-skia:m85-0.32.0
+[skiapending]: https://github.com/rust-skia/skia/compare/m85-0.32.1...google:chrome/m85
+[skiaours]: https://github.com/google/skia/compare/chrome/m85...rust-skia:m85-0.32.1
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![Build Status](https://dev.azure.com/pragmatrix-github/rust-skia/_apis/build/status/rust-skia.rust-skia?branchName=master)](https://dev.azure.com/pragmatrix-github/rust-skia/_build/latest?definitionId=2&branchName=master)
 
-Skia Submodule Status: chrome/m84 ([pending changes][skiapending], [our changes][skiaours]).
+Skia Submodule Status: chrome/m85 ([pending changes][skiapending], [our changes][skiaours]).
 
-[skiapending]: https://github.com/rust-skia/skia/compare/m84-0.31.1...google:chrome/m84
-[skiaours]: https://github.com/google/skia/compare/chrome/m84...rust-skia:m84-0.31.1
+[skiapending]: https://github.com/rust-skia/skia/compare/m85-0.31.0...google:chrome/m85
+[skiaours]: https://github.com/google/skia/compare/chrome/m85...rust-skia:m85-0.31.0
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m85 ([pending changes][skiapending], [our changes][skiaours]).
 
-[skiapending]: https://github.com/rust-skia/skia/compare/m85-0.31.0...google:chrome/m85
-[skiaours]: https://github.com/google/skia/compare/chrome/m85...rust-skia:m85-0.31.0
+[skiapending]: https://github.com/rust-skia/skia/compare/m85-0.32.0...google:chrome/m85
+[skiaours]: https://github.com/google/skia/compare/chrome/m85...rust-skia:m85-0.32.0
 
 ## Goals
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m85-0.31.0"
+skia = "m85-0.32.0"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m84-0.31.1"
+skia = "m85-0.31.0"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.32.0"
+version = "0.33.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m85-0.32.0"
+skia = "m85-0.32.1"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -1061,6 +1061,8 @@ const ENUM_TABLE: &[EnumEntry] = &[
     ("Verb", rewrite::k_xxx_name),
     // m84: SkVertices::Attribute::Usage
     ("Usage", rewrite::k_xxx),
+    // m85: VkSharingMode
+    ("VkSharingMode", rewrite::vk),
 ];
 
 pub(crate) mod rewrite {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1364,18 +1364,6 @@ extern "C" SkColorFilter* C_SkColorFilter_makeComposed(const SkColorFilter* self
     return self->makeComposed(sp(inner)).release();
 }
 
-extern "C" bool C_SkColorFilter_asAColorMode(const SkColorFilter* self, SkColor* color, SkBlendMode* mode) {
-    return self->asAColorMode(color, mode);
-}
-
-extern "C" bool C_SkColorFilter_asAColorMatrix(const SkColorFilter* self, SkScalar matrix[20]) {
-    return self->asAColorMatrix(matrix);
-}
-
-extern "C" uint32_t C_SkColorFilter_getFlags(const SkColorFilter* self) {
-    return self->getFlags();
-}
-
 extern "C" SkColorFilter* C_SkColorFilter_Deserialize(const void* data, size_t length) {
     // TODO: there is no "official" Deserialize wrapper in SkColorFilter, so we
     //       are not sure if deserialization is supported at all.

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1376,6 +1376,12 @@ extern "C" uint32_t C_SkColorFilter_getFlags(const SkColorFilter* self) {
     return self->getFlags();
 }
 
+extern "C" SkColorFilter* C_SkColorFilter_Deserialize(const void* data, size_t length) {
+    // TODO: there is no "official" Deserialize wrapper in SkColorFilter, so we
+    //       are not sure if deserialization is supported at all.
+    return static_cast<SkColorFilter*>(SkFlattenable::Deserialize(SkFlattenable::kSkColorFilter_Type, data, length).release());
+}
+
 //
 // SkColorFilters
 //

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1376,10 +1376,6 @@ extern "C" uint32_t C_SkColorFilter_getFlags(const SkColorFilter* self) {
     return self->getFlags();
 }
 
-extern "C" SkColorFilter* C_SkColorFilter_Deserialize(const void* data, size_t size) {
-    return SkColorFilter::Deserialize(data, size).release();
-}
-
 //
 // SkColorFilters
 //
@@ -2247,12 +2243,6 @@ SkShader *C_SkRuntimeEffect_makeShader(SkRuntimeEffect *self, SkData *inputs, Sk
                                        const SkMatrix *localMatrix, bool isOpaque) {
     auto childrenSPs = reinterpret_cast<sk_sp<SkShader> *>(children);
     return self->makeShader(sp(inputs), childrenSPs, childCount, localMatrix, isOpaque).release();
-}
-
-SkColorFilter *
-C_SkRuntimeEffect_makeColorFilter2(SkRuntimeEffect *self, SkData *inputs, SkColorFilter **children, size_t childCount) {
-    auto childrenSPs = reinterpret_cast<sk_sp<SkColorFilter> *>(children);
-    return self->makeColorFilter(sp(inputs), childrenSPs, childCount).release();
 }
 
 SkColorFilter* C_SkRuntimeEffect_makeColorFilter(SkRuntimeEffect* self, SkData* inputs) {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -99,6 +99,7 @@
 
 #include "include/effects/SkPerlinNoiseShader.h"
 #include "include/effects/SkShaderMaskFilter.h"
+#include "include/effects/SkStrokeAndFillPathEffect.h"
 #include "include/effects/SkTableColorFilter.h"
 #include "include/effects/SkTableMaskFilter.h"
 #include "include/effects/SkTileImageFilter.h"
@@ -2282,6 +2283,14 @@ const SkRuntimeEffect::Varying* C_SkRuntimeEffect_varyings(const SkRuntimeEffect
 
 extern "C" SkMaskFilter* C_SkShaderMaskFilter_Make(SkShader* shader) {
     return SkShaderMaskFilter::Make(sp(shader)).release();
+}
+
+//
+// effects/SkStrokeAndFillPathEffect.h
+//
+
+extern "C" SkPathEffect* C_SkStrokeAndFillePathEffect_Make() {
+    return SkStrokeAndFillPathEffect::Make().release();
 }
 
 //

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -36,6 +36,7 @@
 #include "include/core/SkMaskFilter.h"
 #include "include/core/SkPaint.h"
 #include "include/core/SkPath.h"
+#include "include/core/SkPathBuilder.h"
 #include "include/core/SkPathMeasure.h"
 #include "include/core/SkPathTypes.h"
 #include "include/core/SkPicture.h"
@@ -501,6 +502,31 @@ extern "C" const SkRect* C_SkPath_getBounds(const SkPath* self) {
 
 extern "C" uint32_t C_SkPath_getSegmentMasks(const SkPath* self) {
     return self->getSegmentMasks();
+}
+
+//
+// core/SkPathBuilder.h
+//
+
+extern "C" void C_SkPathBuilder_destruct(SkPathBuilder* self) {
+    self->~SkPathBuilder();
+}
+
+extern "C" void C_SkPathBuilder_snapshot(SkPathBuilder* self, SkPath* path) {
+    *path = self->snapshot();
+}
+
+extern "C" void C_SkPathBuilder_detach(SkPathBuilder* self, SkPath* path) {
+    *path = self->detach();
+}
+
+extern "C" void C_SkPathBuilder_Make(
+    const SkPoint *points, int pointCount,
+    const uint8_t *verbs, int verbCount,
+    const SkScalar *weights, int cubicWeightCount,
+    SkPathFillType fillType, bool isVolatile, SkPath *path)
+{
+    *path = SkPathBuilder::Make(points, pointCount, verbs, verbCount, weights, cubicWeightCount, fillType, isVolatile);
 }
 
 //

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -281,6 +281,11 @@ extern "C" SkShader* C_SkImage_makeShader(const SkImage* self, SkTileMode tileMo
     return self->makeShader(tileMode1, tileMode2, localMatrix).release();
 }
 
+extern "C" SkShader *C_SkImage_makeShader2(const SkImage *self, SkTileMode tileMode1, SkTileMode tileMode2, const SkMatrix *localMatrix, SkFilterQuality filterQuality)
+{
+    return self->makeShader(tileMode1, tileMode2, localMatrix, filterQuality).release();
+}
+
 extern "C" SkData* C_SkImage_encodeToData(const SkImage* self, SkEncodedImageFormat imageFormat, int quality) {
     return self->encodeToData(imageFormat, quality).release();
 }

--- a/skia-bindings/src/gl.cpp
+++ b/skia-bindings/src/gl.cpp
@@ -136,3 +136,11 @@ extern "C" GrContext* C_GrContext_MakeGL(GrGLInterface* interface) {
 extern "C" void C_GrBackendFormat_ConstructGL(GrBackendFormat* uninitialized, GrGLenum format, GrGLenum target) {
     new(uninitialized)GrBackendFormat(GrBackendFormat::MakeGL(format, target));
 }
+
+extern "C" void C_GrBackendTexture_ConstructGL(GrBackendTexture* uninitialized, int width, int height, GrMipMapped mipMapped, const GrGLTextureInfo* glInfo) {
+    new(uninitialized)GrBackendTexture(width, height, mipMapped, *glInfo);
+}
+
+extern "C" void C_GrBackendRenderTarget_ConstructGL(GrBackendRenderTarget* uninitialized, int width, int height, int sampleCnt, int stencilBits, const GrGLFramebufferInfo* glInfo) {
+    new(uninitialized)GrBackendRenderTarget(width, height, sampleCnt, stencilBits, *glInfo);
+}

--- a/skia-bindings/src/gpu.cpp
+++ b/skia-bindings/src/gpu.cpp
@@ -45,23 +45,6 @@ extern "C" SkSurface* C_SkSurface_MakeFromBackendRenderTarget(
             surfaceProps).release();
 }
 
-extern "C" SkSurface* C_SkSurface_MakeFromBackendTextureAsRenderTarget(
-        GrContext* context,
-        const GrBackendTexture* backendTexture,
-        GrSurfaceOrigin origin,
-        int sampleCnt,
-        SkColorType colorType,
-        SkColorSpace* colorSpace,
-        const SkSurfaceProps* surfaceProps) {
-    return SkSurface::MakeFromBackendTextureAsRenderTarget(
-            context,
-            *backendTexture,
-            origin,
-            sampleCnt,
-            colorType,
-            sp(colorSpace), surfaceProps).release();
-}
-
 extern "C" SkSurface* C_SkSurface_MakeRenderTarget(
     GrContext* context,
     SkBudgeted budgeted,

--- a/skia-bindings/src/gpu.cpp
+++ b/skia-bindings/src/gpu.cpp
@@ -159,6 +159,14 @@ extern "C" bool C_GrBackendFormat_Equals(const GrBackendFormat* lhs, const GrBac
 }
 
 //
+// gpu/GrBackendSurfaceMutableState.h
+//
+
+extern "C" void C_GrBackendSurfaceMutableState_destruct(GrBackendSurfaceMutableState* self) {
+    self->~GrBackendSurfaceMutableState();
+}
+
+//
 // gpu/GrContext.h
 //
 

--- a/skia-bindings/src/metal.cpp
+++ b/skia-bindings/src/metal.cpp
@@ -61,3 +61,12 @@ extern "C" bool C_GrMtlTextureInfo_Equals(const GrMtlTextureInfo* lhs, const GrM
 extern "C" void C_GrBackendFormat_ConstructMtl(GrBackendFormat* uninitialized, GrMTLPixelFormat format) {
     new(uninitialized)GrBackendFormat(GrBackendFormat::MakeMtl(format));
 }
+
+
+extern "C" void C_GrBackendTexture_ConstructMtl(GrBackendTexture* uninitialized, int width, int height, GrMipMapped mipMapped, const GrMtlTextureInfo* mtlInfo) {
+    new(uninitialized)GrBackendTexture(width, height, mipMapped, *mtlInfo);
+}
+
+extern "C" void C_GrBackendRenderTarget_ConstructMtl(GrBackendRenderTarget* uninitialized, int width, int height, int sampleCnt, const GrMtlTextureInfo* mtlInfo) {
+    new(uninitialized)GrBackendRenderTarget(width, height, sampleCnt, *mtlInfo);
+}

--- a/skia-bindings/src/shaper.cpp
+++ b/skia-bindings/src/shaper.cpp
@@ -18,7 +18,11 @@ extern "C" SkShaper* C_SkShaper_MakeShapeDontWrapOrReorder(SkFontMgr* fontMgr) {
 }
 
 extern "C" SkShaper* C_SkShaper_MakeCoreText() {
+#ifdef SK_SHAPER_CORETEXT_AVAILABLE
     return SkShaper::MakeCoreText().release();
+#else
+    return nullptr;
+#endif
 }
 
 extern "C" SkShaper* C_SkShaper_Make(SkFontMgr* fontMgr) {

--- a/skia-bindings/src/vulkan.cpp
+++ b/skia-bindings/src/vulkan.cpp
@@ -101,3 +101,11 @@ extern "C" bool C_GrVkAlloc_Equals(const GrVkAlloc* lhs, const GrVkAlloc* rhs) {
 extern "C" bool C_GrVkYcbcrConversionInfo_Equals(const GrVkYcbcrConversionInfo* lhs, const GrVkYcbcrConversionInfo* rhs) {
     return *lhs == *rhs;
 }
+
+//
+// gpu/GrBackendSurfaceMutableState.h
+//
+
+extern "C" void C_GrBackendSurfaceMutableState_ConstructVK(GrBackendSurfaceMutableState* uninitialized, VkImageLayout layout, uint32_t queueFamilyIndex) {
+    new(uninitialized)GrBackendSurfaceMutableState(layout, queueFamilyIndex);
+}

--- a/skia-bindings/src/vulkan.cpp
+++ b/skia-bindings/src/vulkan.cpp
@@ -14,11 +14,19 @@ extern "C" void C_GrBackendFormat_ConstructVk2(GrBackendFormat* uninitialized, c
     new(uninitialized)GrBackendFormat(GrBackendFormat::MakeVk(*ycbcrInfo));
 }
 
+extern "C" void C_GrBackendTexture_ConstructVk(GrBackendTexture* uninitialized, int width, int height, const GrVkImageInfo* vkInfo) {
+    new(uninitialized)GrBackendTexture(width, height, *vkInfo);
+}
+
+extern "C" void C_GrBackendRenderTarget_ConstructVk(GrBackendRenderTarget* uninitialized, int width, int height, int sampleCnt, const GrVkImageInfo* vkInfo) {
+    new(uninitialized)GrBackendRenderTarget(width, height, sampleCnt, *vkInfo);
+}
+
 extern "C" bool C_GrBackendDrawableInfo_getVkDrawableInfo(const GrBackendDrawableInfo* self, GrVkDrawableInfo* info) {
     return self->getVkDrawableInfo(info);
 }
 
-extern "C" void C_GPU_VK_Types(GrVkExtensionFlags *, GrVkFeatureFlags *) {}
+extern "C" void C_GPU_VK_Types(GrVkExtensionFlags *, GrVkFeatureFlags *, VkBuffer *) {}
 
 // The GrVkBackendContext struct binding's length is too short
 // because of the std::function that is used in it.

--- a/skia-org/src/skpaint_overview.rs
+++ b/skia-org/src/skpaint_overview.rs
@@ -380,7 +380,7 @@ fn draw_path_2d_effect(canvas: &mut Canvas) {
         ));
     }
     path.close();
-    let matrix = &Matrix::new_scale((4.0 * scale, 4.0 * scale));
+    let matrix = &Matrix::scale((4.0 * scale, 4.0 * scale));
     let paint = &mut Paint::default();
     paint
         .set_path_effect(path_2d_path_effect::new(matrix, path))

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.32.0"
+version = "0.33.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -32,7 +32,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 
 [dependencies]
 bitflags = "1.0.4"
-skia-bindings = { version = "=0.32.0", path = "../skia-bindings" }
+skia-bindings = { version = "=0.33.0", path = "../skia-bindings" }
 lazy_static = "1.4"
 
 [dev-dependencies]

--- a/skia-safe/examples/icon/renderer.rs
+++ b/skia-safe/examples/icon/renderer.rs
@@ -331,7 +331,7 @@ fn triangle(
 }
 
 fn gradient(paint: &mut Paint, center: (f32, f32), radii: (f32, f32), colors: (Color, Color)) {
-    let mut matrix = Matrix::new_scale((1.0, radii.1 / radii.0));
+    let mut matrix = Matrix::scale((1.0, radii.1 / radii.0));
     matrix.post_translate((center.0, center.1));
     paint.set_shader(gradient_shader::radial(
         (0.0, 0.0),

--- a/skia-safe/src/core.rs
+++ b/skia-safe/src/core.rs
@@ -137,6 +137,9 @@ pub use paint::Style as PaintStyle;
 pub mod path;
 pub use path::Path;
 
+mod path_builder;
+pub use path_builder::PathBuilder;
+
 pub mod path_effect;
 pub use path_effect::PathEffect;
 

--- a/skia-safe/src/core.rs
+++ b/skia-safe/src/core.rs
@@ -53,6 +53,7 @@ pub mod document;
 pub use document::Document;
 
 pub mod draw_looper;
+#[allow(deprecated)]
 pub use draw_looper::DrawLooper;
 
 pub mod drawable;

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -2,9 +2,9 @@
 use crate::gpu;
 use crate::prelude::*;
 use crate::{
-    scalar, Bitmap, BlendMode, ClipOp, Color, Data, Font, IPoint, IRect, ISize, Image, ImageFilter,
-    ImageInfo, Matrix, Paint, Path, Picture, Point, QuickReject, RRect, Rect, Region, Shader,
-    Surface, SurfaceProps, TextBlob, TextEncoding, Vector, Vertices, M44,
+    scalar, Bitmap, BlendMode, ClipOp, Color, Color4f, Data, Font, IPoint, IRect, ISize, Image,
+    ImageFilter, ImageInfo, Matrix, Paint, Path, Picture, Point, QuickReject, RRect, Rect, Region,
+    Shader, Surface, SurfaceProps, TextBlob, TextEncoding, Vector, Vertices, M44,
 };
 use crate::{u8cpu, Drawable, Pixmap};
 use skia_bindings as sb;
@@ -582,17 +582,17 @@ impl Canvas {
 
     pub fn draw_color(
         &mut self,
-        color: impl Into<Color>,
+        color: impl Into<Color4f>,
         mode: impl Into<Option<BlendMode>>,
     ) -> &mut Self {
         unsafe {
             self.native_mut()
-                .drawColor(color.into().into_native(), mode.into().unwrap_or_default())
+                .drawColor(&color.into().into_native(), mode.into().unwrap_or_default())
         }
         self
     }
 
-    pub fn clear(&mut self, color: impl Into<Color>) -> &mut Self {
+    pub fn clear(&mut self, color: impl Into<Color4f>) -> &mut Self {
         self.draw_color(color, BlendMode::Src)
     }
 

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -9,8 +9,7 @@ use crate::{
 use crate::{u8cpu, Drawable, Pixmap};
 use skia_bindings as sb;
 use skia_bindings::{
-    SkAutoCanvasRestore, SkCanvas, SkCanvas_SaveLayerRec, SkImage, SkImageFilter, SkMatrix,
-    SkPaint, SkRect,
+    SkAutoCanvasRestore, SkCanvas, SkCanvas_SaveLayerRec, SkImageFilter, SkPaint, SkRect,
 };
 use std::convert::TryInto;
 use std::ffi::CString;
@@ -38,10 +37,6 @@ pub struct SaveLayerRec<'a> {
     bounds: Option<&'a SkRect>,
     paint: Option<&'a SkPaint>,
     backdrop: Option<&'a SkImageFilter>,
-    // experimental
-    clip_mask: Option<&'a SkImage>,
-    // experimental
-    clip_matrix: Option<&'a SkMatrix>,
     flags: SaveLayerFlags,
 }
 
@@ -58,8 +53,6 @@ impl<'a> Default for SaveLayerRec<'a> {
             bounds: None,
             paint: None,
             backdrop: None,
-            clip_mask: None,
-            clip_matrix: None,
             flags: SaveLayerFlags::empty(),
         }
     }
@@ -87,18 +80,20 @@ impl<'a> SaveLayerRec<'a> {
         }
     }
 
-    pub fn clip_mask(self, clip_mask: &'a Image) -> Self {
-        Self {
-            clip_mask: Some(clip_mask.native()),
-            ..self
-        }
+    #[deprecated(
+        since = "0.0.0",
+        note = "removed without replacement, does not set clip_mask"
+    )]
+    pub fn clip_mask(self, _clip_mask: &'a Image) -> Self {
+        self
     }
 
-    pub fn clip_matrix(self, clip_matrix: &'a Matrix) -> Self {
-        Self {
-            clip_matrix: Some(clip_matrix.native()),
-            ..self
-        }
+    #[deprecated(
+        since = "0.0.0",
+        note = "removed without replacement, does not set clip_matrix"
+    )]
+    pub fn clip_matrix(self, _clip_matrix: &'a Matrix) -> Self {
+        self
     }
 
     pub fn flags(self, flags: SaveLayerFlags) -> Self {
@@ -1178,8 +1173,8 @@ impl AutoCanvasRestore {
 #[cfg(test)]
 mod tests {
     use crate::{
-        canvas::SaveLayerRec, AlphaType, Canvas, ClipOp, Color, ColorType, ImageInfo, Matrix,
-        OwnedCanvas, Rect,
+        canvas::SaveLayerFlags, canvas::SaveLayerRec, AlphaType, Canvas, ClipOp, Color, ColorType,
+        ImageInfo, Matrix, OwnedCanvas, Rect,
     };
 
     #[test]
@@ -1220,9 +1215,9 @@ mod tests {
     fn test_save_layer_rec_lifetimes() {
         let rect = Rect::default();
         {
-            let matrix = Matrix::default();
-
-            let _rec = SaveLayerRec::default().clip_matrix(&matrix).bounds(&rect);
+            let _rec = SaveLayerRec::default()
+                .flags(SaveLayerFlags::PRESERVE_LCD_TEXT)
+                .bounds(&rect);
         }
     }
 

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -81,7 +81,7 @@ impl<'a> SaveLayerRec<'a> {
     }
 
     #[deprecated(
-        since = "0.0.0",
+        since = "0.33.0",
         note = "removed without replacement, does not set clip_mask"
     )]
     pub fn clip_mask(self, _clip_mask: &'a Image) -> Self {
@@ -89,7 +89,7 @@ impl<'a> SaveLayerRec<'a> {
     }
 
     #[deprecated(
-        since = "0.0.0",
+        since = "0.33.0",
         note = "removed without replacement, does not set clip_matrix"
     )]
     pub fn clip_matrix(self, _clip_matrix: &'a Matrix) -> Self {

--- a/skia-safe/src/core/color.rs
+++ b/skia-safe/src/core/color.rs
@@ -288,6 +288,21 @@ impl From<Color> for Color4f {
     }
 }
 
+// Add all Color::From implementations to Color4f, so that
+// function signatures can promote Into<Color> to Into<Color4f>.
+
+impl From<u32> for Color4f {
+    fn from(color: u32) -> Self {
+        Color::from(color).into()
+    }
+}
+
+impl From<RGB> for Color4f {
+    fn from(rgb: RGB) -> Self {
+        Color::from(rgb).into()
+    }
+}
+
 impl Color4f {
     pub const fn new(r: f32, g: f32, b: f32, a: f32) -> Color4f {
         Self { r, g, b, a }

--- a/skia-safe/src/core/color_filter.rs
+++ b/skia-safe/src/core/color_filter.rs
@@ -35,21 +35,24 @@ impl RCHandle<SkColorFilter> {
     pub fn to_a_color_mode(&self) -> Option<(Color, BlendMode)> {
         let mut color: Color = 0.into();
         let mut mode: BlendMode = Default::default();
-        unsafe { sb::C_SkColorFilter_asAColorMode(self.native(), color.native_mut(), &mut mode) }
+        unsafe { self.native().asAColorMode(color.native_mut(), &mut mode) }
             .if_true_some((color, mode))
     }
 
     pub fn to_a_color_matrix(&self) -> Option<[scalar; 20]> {
         let mut matrix: [scalar; 20] = Default::default();
-        unsafe { sb::C_SkColorFilter_asAColorMatrix(self.native(), matrix.as_mut_ptr()) }
-            .if_true_some(matrix)
+        unsafe { self.native().asAColorMatrix(&mut matrix[0]) }.if_true_some(matrix)
     }
 
     // TODO: appendStages()
     // TODO: program()
 
     pub fn flags(&self) -> self::Flags {
-        Flags::from_bits_truncate(unsafe { sb::C_SkColorFilter_getFlags(self.native()) })
+        Flags::from_bits_truncate(unsafe { self.native().getFlags() })
+    }
+
+    pub fn is_alpha_unchanged(&self) -> bool {
+        unsafe { self.native().isAlphaUnchanged() }
     }
 
     pub fn filter_color(&self, color: impl Into<Color>) -> Color {

--- a/skia-safe/src/core/draw_looper.rs
+++ b/skia-safe/src/core/draw_looper.rs
@@ -3,6 +3,7 @@ use crate::{scalar, BlurStyle, Color, NativeFlattenable, Paint, Rect, Vector};
 use skia_bindings as sb;
 use skia_bindings::{SkDrawLooper, SkDrawLooper_BlurShadowRec, SkFlattenable, SkRefCntBase};
 
+#[deprecated(since = "0.0.0", note = "No longer supported.")]
 pub type DrawLooper = RCHandle<SkDrawLooper>;
 
 impl NativeBase<SkRefCntBase> for SkDrawLooper {}

--- a/skia-safe/src/core/draw_looper.rs
+++ b/skia-safe/src/core/draw_looper.rs
@@ -3,7 +3,7 @@ use crate::{scalar, BlurStyle, Color, NativeFlattenable, Paint, Rect, Vector};
 use skia_bindings as sb;
 use skia_bindings::{SkDrawLooper, SkDrawLooper_BlurShadowRec, SkFlattenable, SkRefCntBase};
 
-#[deprecated(since = "0.0.0", note = "No longer supported.")]
+#[deprecated(since = "0.33.0", note = "No longer supported.")]
 pub type DrawLooper = RCHandle<SkDrawLooper>;
 
 impl NativeBase<SkRefCntBase> for SkDrawLooper {}

--- a/skia-safe/src/core/image.rs
+++ b/skia-safe/src/core/image.rs
@@ -469,8 +469,14 @@ impl RCHandle<SkImage> {
     // TODO: flush(GrContext*, GrFlushInfo&).
 
     #[cfg(feature = "gpu")]
+    pub fn flush_and_submit(&mut self, context: &mut gpu::Context) {
+        unsafe { self.native_mut().flushAndSubmit(context.native_mut()) }
+    }
+
+    #[cfg(feature = "gpu")]
+    #[deprecated(since = "0.0.0", note = "use flushAndSubmit()")]
     pub fn flush(&mut self, context: &mut gpu::Context) {
-        unsafe { self.native_mut().flush1(context.native_mut()) }
+        self.flush_and_submit(context)
     }
 
     #[cfg(feature = "gpu")]

--- a/skia-safe/src/core/image.rs
+++ b/skia-safe/src/core/image.rs
@@ -310,6 +310,7 @@ impl RCHandle<SkImage> {
         image_size: impl Into<ISize>,
         image_origin: gpu::SurfaceOrigin,
         image_color_space: impl Into<Option<ColorSpace>>,
+        // TODO: m85 introduced textureReleaseProc and releaseContext here.
     ) -> Option<Image> {
         Image::from_ptr(unsafe {
             sb::C_SkImage_MakeFromYUVATextures(
@@ -446,6 +447,27 @@ impl RCHandle<SkImage> {
                 tm1,
                 tm2,
                 local_matrix.into().native_ptr_or_null(),
+            )
+        })
+        .unwrap()
+    }
+
+    pub fn to_shader_with_quality<'a>(
+        &self,
+        tile_modes: impl Into<Option<(TileMode, TileMode)>>,
+        local_matrix: impl Into<Option<&'a Matrix>>,
+        filter_quality: FilterQuality,
+    ) -> Shader {
+        let tile_modes = tile_modes.into();
+        let tm1 = tile_modes.map(|m| m.0).unwrap_or_default();
+        let tm2 = tile_modes.map(|m| m.1).unwrap_or_default();
+        Shader::from_ptr(unsafe {
+            sb::C_SkImage_makeShader2(
+                self.native(),
+                tm1,
+                tm2,
+                local_matrix.into().native_ptr_or_null(),
+                filter_quality,
             )
         })
         .unwrap()

--- a/skia-safe/src/core/image.rs
+++ b/skia-safe/src/core/image.rs
@@ -496,7 +496,7 @@ impl RCHandle<SkImage> {
     }
 
     #[cfg(feature = "gpu")]
-    #[deprecated(since = "0.0.0", note = "use flushAndSubmit()")]
+    #[deprecated(since = "0.33.0", note = "use flushAndSubmit()")]
     pub fn flush(&mut self, context: &mut gpu::Context) {
         self.flush_and_submit(context)
     }

--- a/skia-safe/src/core/matrix.rs
+++ b/skia-safe/src/core/matrix.rs
@@ -12,12 +12,15 @@ fn test_apply_perspective_clip_naming() {
 }
 
 bitflags! {
-    pub struct TypeMask: i32 {
-        const IDENTITY = sb::SkMatrix_TypeMask_kIdentity_Mask;
-        const TRANSLATE = sb::SkMatrix_TypeMask_kTranslate_Mask;
-        const SCALE = sb::SkMatrix_TypeMask_kScale_Mask;
-        const AFFINE = sb::SkMatrix_TypeMask_kAffine_Mask;
-        const PERSPECTIVE = sb::SkMatrix_TypeMask_kPerspective_Mask;
+    // m85: On Windows the SkMatrix_TypeMask is defined as i32,
+    // but we stick to u32 (macOS / Linux), because there is no need to propagate
+    // the platform difference to the Rust side.
+    pub struct TypeMask: u32 {
+        const IDENTITY = sb::SkMatrix_TypeMask_kIdentity_Mask as _;
+        const TRANSLATE = sb::SkMatrix_TypeMask_kTranslate_Mask as _;
+        const SCALE = sb::SkMatrix_TypeMask_kScale_Mask as _;
+        const AFFINE = sb::SkMatrix_TypeMask_kAffine_Mask as _;
+        const PERSPECTIVE = sb::SkMatrix_TypeMask_kPerspective_Mask as _;
     }
 }
 
@@ -31,7 +34,7 @@ fn test_matrix_scale_to_fit_naming() {
 #[repr(C)]
 pub struct Matrix {
     mat: [scalar; 9usize],
-    type_mask: i32,
+    type_mask: u32,
 }
 
 impl NativeTransmutable<SkMatrix> for Matrix {}

--- a/skia-safe/src/core/matrix.rs
+++ b/skia-safe/src/core/matrix.rs
@@ -135,7 +135,7 @@ impl Matrix {
         }
     }
 
-    #[deprecated(since = "0.0.0", note = "use Matrix::scale()")]
+    #[deprecated(since = "0.33.0", note = "use Matrix::scale()")]
     pub fn new_scale(scale: (scalar, scalar)) -> Matrix {
         Self::scale(scale)
     }
@@ -146,7 +146,7 @@ impl Matrix {
         m
     }
 
-    #[deprecated(since = "0.0.0", note = "use Matrix::translate()")]
+    #[deprecated(since = "0.33.0", note = "use Matrix::translate()")]
     pub fn new_trans(d: impl Into<Vector>) -> Matrix {
         Self::translate(d)
     }

--- a/skia-safe/src/core/matrix.rs
+++ b/skia-safe/src/core/matrix.rs
@@ -1,3 +1,4 @@
+use super::scalar_;
 use crate::prelude::*;
 use crate::{scalar, Point, Point3, RSXform, Rect, Scalar, Size, Vector};
 use skia_bindings as sb;
@@ -13,7 +14,7 @@ fn test_apply_perspective_clip_naming() {
 
 bitflags! {
     // m85: On Windows the SkMatrix_TypeMask is defined as i32,
-    // but we stick to u32 (macOS / Linux), because there is no need to propagate
+    // but we stick to u32 (macOS / Linux), because there is no need to leak
     // the platform difference to the Rust side.
     pub struct TypeMask: u32 {
         const IDENTITY = sb::SkMatrix_TypeMask_kIdentity_Mask as _;
@@ -164,7 +165,7 @@ impl Matrix {
     }
 
     pub fn rotate_rad(rad: scalar) -> Matrix {
-        Self::rotate_deg(crate::core::scalar_::radians_to_degrees(rad))
+        Self::rotate_deg(scalar_::radians_to_degrees(rad))
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/skia-safe/src/core/milestone.rs
+++ b/skia-safe/src/core/milestone.rs
@@ -1,1 +1,1 @@
-pub const MILESTONE: usize = 84;
+pub const MILESTONE: usize = 85;

--- a/skia-safe/src/core/paint.rs
+++ b/skia-safe/src/core/paint.rs
@@ -121,6 +121,11 @@ impl Handle<SkPaint> {
         self
     }
 
+    pub fn set_stroke(&mut self, stroke: bool) -> &mut Self {
+        unsafe { self.native_mut().setStroke(stroke) }
+        self
+    }
+
     pub fn color(&self) -> Color {
         self.color4f().to_color()
     }

--- a/skia-safe/src/core/path.rs
+++ b/skia-safe/src/core/path.rs
@@ -821,6 +821,21 @@ impl Handle<SkPath> {
         unsafe { self.native().getLastPt(last_pt.native_mut()) }.if_true_some(last_pt)
     }
 
+    pub fn make_transform(
+        &mut self,
+        m: &Matrix,
+        pc: impl Into<Option<ApplyPerspectiveClip>>,
+    ) -> Path {
+        self.with_transform_with_perspective_clip(
+            &m,
+            pc.into().unwrap_or(ApplyPerspectiveClip::Yes),
+        )
+    }
+
+    pub fn make_scale(&mut self, (sx, sy): (scalar, scalar)) -> Path {
+        self.make_transform(&Matrix::scale((sx, sy)), ApplyPerspectiveClip::No)
+    }
+
     pub fn set_last_pt(&mut self, p: impl Into<Point>) -> &mut Self {
         let p = p.into();
         unsafe { self.native_mut().setLastPt(p.x, p.y) };

--- a/skia-safe/src/core/path.rs
+++ b/skia-safe/src/core/path.rs
@@ -1,5 +1,5 @@
-use crate::core::matrix::ApplyPerspectiveClip;
 use crate::interop::DynamicMemoryWStream;
+use crate::matrix::ApplyPerspectiveClip;
 use crate::prelude::*;
 use crate::{
     path_types, scalar, Data, Matrix, PathConvexityType, PathDirection, PathFillType, Point, RRect,

--- a/skia-safe/src/core/path_builder.rs
+++ b/skia-safe/src/core/path_builder.rs
@@ -1,0 +1,166 @@
+use crate::{prelude::*, scalar, Path, PathDirection, PathFillType, Point, RRect, Rect};
+use skia_bindings as sb;
+use skia_bindings::SkPathBuilder;
+
+pub type PathBuilder = Handle<SkPathBuilder>;
+
+impl NativeDrop for SkPathBuilder {
+    fn drop(&mut self) {
+        unsafe { sb::C_SkPathBuilder_destruct(self) }
+    }
+}
+
+impl PathBuilder {
+    pub fn new() -> Self {
+        Self::from_native(unsafe { SkPathBuilder::new() })
+    }
+
+    pub fn snapshot(&mut self) -> Path {
+        let mut path = Path::default();
+        unsafe { sb::C_SkPathBuilder_snapshot(self.native_mut(), path.native_mut()) };
+        path
+    }
+
+    pub fn detach(&mut self) -> Path {
+        let mut path = Path::default();
+        unsafe { sb::C_SkPathBuilder_detach(self.native_mut(), path.native_mut()) };
+        path
+    }
+
+    pub fn reset(&mut self) -> &mut Self {
+        unsafe { self.native_mut().reset() };
+        self
+    }
+
+    pub fn move_to(&mut self, pt: impl Into<Point>) -> &mut Self {
+        unsafe { self.native_mut().moveTo(pt.into().into_native()) };
+        self
+    }
+
+    pub fn line_to(&mut self, pt: impl Into<Point>) -> &mut Self {
+        unsafe { self.native_mut().lineTo(pt.into().into_native()) };
+        self
+    }
+
+    pub fn quad_to(&mut self, p1: impl Into<Point>, p2: impl Into<Point>) -> &mut Self {
+        unsafe {
+            self.native_mut()
+                .quadTo(p1.into().into_native(), p2.into().into_native())
+        };
+        self
+    }
+
+    pub fn conic_to(&mut self, p1: impl Into<Point>, p2: impl Into<Point>, w: scalar) -> &mut Self {
+        unsafe {
+            self.native_mut()
+                .conicTo(p1.into().into_native(), p2.into().into_native(), w)
+        };
+        self
+    }
+
+    pub fn cubic_to(
+        &mut self,
+        p1: impl Into<Point>,
+        p2: impl Into<Point>,
+        p3: impl Into<Point>,
+    ) -> &mut Self {
+        unsafe {
+            self.native_mut().cubicTo(
+                p1.into().into_native(),
+                p2.into().into_native(),
+                p3.into().into_native(),
+            )
+        };
+        self
+    }
+
+    pub fn close(&mut self) -> &mut Self {
+        unsafe { self.native_mut().close() };
+        self
+    }
+
+    pub fn add_rect(
+        &mut self,
+        rect: impl AsRef<Rect>,
+        dir: impl Into<Option<PathDirection>>,
+        start_index: impl Into<Option<usize>>,
+    ) -> &mut Self {
+        let dir = dir.into().unwrap_or(PathDirection::CW);
+        let start_index = start_index.into().unwrap_or(0);
+        unsafe {
+            self.native_mut()
+                .addRect(rect.as_ref().native(), dir, start_index.try_into().unwrap())
+        };
+        self
+    }
+
+    pub fn add_oval(
+        &mut self,
+        rect: impl AsRef<Rect>,
+        dir: impl Into<Option<PathDirection>>,
+        start_index: impl Into<Option<usize>>,
+    ) -> &mut Self {
+        let dir = dir.into().unwrap_or(PathDirection::CW);
+        let start_index = start_index.into().unwrap_or(0);
+        unsafe {
+            self.native_mut()
+                .addOval(rect.as_ref().native(), dir, start_index.try_into().unwrap())
+        };
+        self
+    }
+
+    pub fn add_rrect(
+        &mut self,
+        rect: impl AsRef<RRect>,
+        dir: impl Into<Option<PathDirection>>,
+        start_index: impl Into<Option<usize>>,
+    ) -> &mut Self {
+        let dir = dir.into().unwrap_or(PathDirection::CW);
+        let start_index = start_index.into().unwrap_or(0);
+        unsafe {
+            self.native_mut()
+                .addRRect(rect.as_ref().native(), dir, start_index.try_into().unwrap())
+        };
+        self
+    }
+
+    pub fn inc_reserve(&mut self, extra_pt_count: usize, extra_verb_count: usize) {
+        unsafe {
+            self.native_mut().incReserve(
+                extra_pt_count.try_into().unwrap(),
+                extra_verb_count.try_into().unwrap(),
+            )
+        }
+    }
+
+    pub fn make(
+        points: &[Point],
+        verbs: &[u8],
+        conic_weights: &[scalar],
+        fill_type: PathFillType,
+        is_volatile: impl Into<Option<bool>>,
+    ) -> Path {
+        let mut path = Path::default();
+        unsafe {
+            sb::C_SkPathBuilder_Make(
+                points.native().as_ptr(),
+                points.len().try_into().unwrap(),
+                verbs.as_ptr(),
+                verbs.len().try_into().unwrap(),
+                conic_weights.as_ptr(),
+                conic_weights.len().try_into().unwrap(),
+                fill_type,
+                is_volatile.into().unwrap_or(false),
+                path.native_mut(),
+            )
+        }
+        path
+    }
+}
+
+#[test]
+fn test_creation_snapshot_and_detach() {
+    let mut builder = PathBuilder::new();
+    let _path = builder.snapshot();
+    let _path = builder.detach();
+}

--- a/skia-safe/src/core/scalar_.rs
+++ b/skia-safe/src/core/scalar_.rs
@@ -48,3 +48,7 @@ where
         self.iter().fold(T::ZERO, |prod, value| prod * *value) == T::ZERO
     }
 }
+
+pub fn radians_to_degrees(radians: scalar) -> scalar {
+    radians * (180.0 / std::f32::consts::PI)
+}

--- a/skia-safe/src/core/surface.rs
+++ b/skia-safe/src/core/surface.rs
@@ -121,26 +121,17 @@ impl RCHandle<SkSurface> {
         })
     }
 
+    #[deprecated(since = "0.0.0", note = "removed without replacement")]
     pub fn from_backend_texture_as_render_target(
-        context: &mut gpu::Context,
-        backend_texture: &gpu::BackendTexture,
-        origin: gpu::SurfaceOrigin,
-        sample_count: impl Into<Option<usize>>,
-        color_type: crate::ColorType,
-        color_space: impl Into<Option<crate::ColorSpace>>,
-        surface_props: Option<&SurfaceProps>,
-    ) -> Option<Self> {
-        Self::from_ptr(unsafe {
-            sb::C_SkSurface_MakeFromBackendTextureAsRenderTarget(
-                context.native_mut(),
-                backend_texture.native(),
-                origin,
-                sample_count.into().unwrap_or(0).try_into().unwrap(),
-                color_type.into_native(),
-                color_space.into().into_ptr_or_null(),
-                surface_props.native_ptr_or_null(),
-            )
-        })
+        _context: &mut gpu::Context,
+        _backend_texture: &gpu::BackendTexture,
+        _origin: gpu::SurfaceOrigin,
+        _sample_count: impl Into<Option<usize>>,
+        _color_type: crate::ColorType,
+        _color_space: impl Into<Option<crate::ColorSpace>>,
+        _surface_props: Option<&SurfaceProps>,
+    ) -> ! {
+        panic!("removed without replacement")
     }
 
     #[cfg(feature = "metal")]

--- a/skia-safe/src/core/surface.rs
+++ b/skia-safe/src/core/surface.rs
@@ -463,8 +463,8 @@ impl RCHandle<SkSurface> {
         self.flush_and_submit()
     }
 
-    // TODO: flush(access, FlushInfo)
-    // TODO: flush(access, FlushFlags, semaphores)
+    // TODO: flush(BackendSurfaceAccess, FlushInfo)
+    // TODO: flush(FlushInfo, GrBackendSurfaceMutableState)
     // TODO: wait()
 
     pub fn characterize(&self) -> Option<SurfaceCharacterization> {

--- a/skia-safe/src/core/surface.rs
+++ b/skia-safe/src/core/surface.rs
@@ -121,7 +121,7 @@ impl RCHandle<SkSurface> {
         })
     }
 
-    #[deprecated(since = "0.0.0", note = "removed without replacement")]
+    #[deprecated(since = "0.33.0", note = "removed without replacement")]
     pub fn from_backend_texture_as_render_target(
         _context: &mut gpu::Context,
         _backend_texture: &gpu::BackendTexture,

--- a/skia-safe/src/effects.rs
+++ b/skia-safe/src/effects.rs
@@ -6,6 +6,8 @@ pub use _2d_path_effect::*;
 
 pub mod alpha_threshold_filter;
 pub mod arithmetic_image_filter;
+#[deprecated(since = "0.0.0", note = "No longer supported")]
+#[allow(deprecated)]
 pub mod blur_draw_looper;
 pub mod blur_image_filter;
 pub mod color_filter_image_filter;
@@ -23,6 +25,8 @@ pub mod high_contrast_filter;
 pub use high_contrast_filter::{high_contrast_config, HighContrastConfig};
 pub mod image_filters;
 pub mod image_source;
+#[deprecated(since = "0.0.0", note = "No longer supported")]
+#[allow(deprecated)]
 pub mod layer_draw_looper;
 pub mod lighting_image_filter;
 pub mod luma_color_filter;

--- a/skia-safe/src/effects.rs
+++ b/skia-safe/src/effects.rs
@@ -49,6 +49,7 @@ pub mod picture_image_filter;
 pub mod runtime_effect;
 pub use runtime_effect::RuntimeEffect;
 pub mod shader_mask_filter;
+pub mod stroke_and_fill_path_effect;
 pub mod table_color_filter;
 pub mod table_mask_filter;
 pub mod tile_image_filter;

--- a/skia-safe/src/effects.rs
+++ b/skia-safe/src/effects.rs
@@ -6,7 +6,7 @@ pub use _2d_path_effect::*;
 
 pub mod alpha_threshold_filter;
 pub mod arithmetic_image_filter;
-#[deprecated(since = "0.0.0", note = "No longer supported")]
+#[deprecated(since = "0.33.0", note = "No longer supported")]
 #[allow(deprecated)]
 pub mod blur_draw_looper;
 pub mod blur_image_filter;
@@ -25,7 +25,7 @@ pub mod high_contrast_filter;
 pub use high_contrast_filter::{high_contrast_config, HighContrastConfig};
 pub mod image_filters;
 pub mod image_source;
-#[deprecated(since = "0.0.0", note = "No longer supported")]
+#[deprecated(since = "0.33.0", note = "No longer supported")]
 #[allow(deprecated)]
 pub mod layer_draw_looper;
 pub mod lighting_image_filter;

--- a/skia-safe/src/effects/layer_draw_looper.rs
+++ b/skia-safe/src/effects/layer_draw_looper.rs
@@ -1,5 +1,6 @@
 use crate::prelude::*;
-use crate::{BlendMode, DrawLooper, Vector};
+use crate::DrawLooper;
+use crate::{BlendMode, Vector};
 use skia_bindings as sb;
 use skia_bindings::{SkLayerDrawLooper_Builder, SkLayerDrawLooper_LayerInfo, SkPaint};
 

--- a/skia-safe/src/effects/luma_color_filter.rs
+++ b/skia-safe/src/effects/luma_color_filter.rs
@@ -12,5 +12,3 @@ impl RCHandle<SkColorFilter> {
 pub fn new() -> ColorFilter {
     ColorFilter::from_ptr(unsafe { sb::C_SkLumaColorFilter_Make() }).unwrap()
 }
-
-// TODO: asFragmentProcessor()

--- a/skia-safe/src/effects/runtime_effect.rs
+++ b/skia-safe/src/effects/runtime_effect.rs
@@ -148,24 +148,13 @@ impl RCHandle<SkRuntimeEffect> {
         })
     }
 
+    #[deprecated(since = "0.0.0", note = "removed without replacement")]
     pub fn make_color_filter_with_children(
         &mut self,
-        inputs: impl Into<Data>,
-        children: impl IntoIterator<Item = ColorFilter>,
-    ) -> Option<ColorFilter> {
-        let mut children: Vec<_> = children
-            .into_iter()
-            .map(|color_filter| color_filter.into_ptr())
-            .collect();
-
-        ColorFilter::from_ptr(unsafe {
-            sb::C_SkRuntimeEffect_makeColorFilter2(
-                self.native_mut(),
-                inputs.into().into_ptr(),
-                children.as_mut_ptr(),
-                children.len(),
-            )
-        })
+        _inputs: impl Into<Data>,
+        _children: impl IntoIterator<Item = ColorFilter>,
+    ) -> ! {
+        panic!("removed without replacement")
     }
 
     pub fn make_color_filter(&mut self, inputs: impl Into<Data>) -> Option<ColorFilter> {

--- a/skia-safe/src/effects/runtime_effect.rs
+++ b/skia-safe/src/effects/runtime_effect.rs
@@ -148,7 +148,7 @@ impl RCHandle<SkRuntimeEffect> {
         })
     }
 
-    #[deprecated(since = "0.0.0", note = "removed without replacement")]
+    #[deprecated(since = "0.33.0", note = "removed without replacement")]
     pub fn make_color_filter_with_children(
         &mut self,
         _inputs: impl Into<Data>,

--- a/skia-safe/src/effects/stroke_and_fill_path_effect.rs
+++ b/skia-safe/src/effects/stroke_and_fill_path_effect.rs
@@ -1,0 +1,11 @@
+use crate::PathEffect;
+use skia_bindings as sb;
+
+pub fn new() -> PathEffect {
+    PathEffect::from_ptr(unsafe { sb::C_SkStrokeAndFillePathEffect_Make() }).unwrap()
+}
+
+#[test]
+fn test_new() {
+    let _effect = new();
+}

--- a/skia-safe/src/gpu.rs
+++ b/skia-safe/src/gpu.rs
@@ -4,6 +4,9 @@ pub use self::backend_drawable_info::*;
 mod backend_surface;
 pub use self::backend_surface::*;
 
+mod backend_surface_mutable_state;
+pub use self::backend_surface_mutable_state::*;
+
 mod context;
 pub use self::context::*;
 

--- a/skia-safe/src/gpu/backend_surface.rs
+++ b/skia-safe/src/gpu/backend_surface.rs
@@ -139,18 +139,18 @@ impl Handle<GrBackendTexture> {
         mip_mapped: super::MipMapped,
         gl_info: gl::TextureInfo,
     ) -> Self {
-        Self::from_native_if_valid(GrBackendTexture::new(
-            width,
-            height,
-            mip_mapped,
-            gl_info.native(),
-        ))
+        Self::from_native_if_valid(construct(|texture| {
+            sb::C_GrBackendTexture_ConstructGL(texture, width, height, mip_mapped, gl_info.native())
+        }))
         .unwrap()
     }
 
     #[cfg(feature = "vulkan")]
     pub unsafe fn new_vulkan((width, height): (i32, i32), vk_info: &vk::ImageInfo) -> Self {
-        Self::from_native_if_valid(GrBackendTexture::new1(width, height, vk_info.native())).unwrap()
+        Self::from_native_if_valid(construct(|texture| {
+            sb::C_GrBackendTexture_ConstructVk(texture, width, height, vk_info.native())
+        }))
+        .unwrap()
     }
 
     #[cfg(feature = "metal")]
@@ -159,12 +159,15 @@ impl Handle<GrBackendTexture> {
         mip_mapped: super::MipMapped,
         mtl_info: &mtl::TextureInfo,
     ) -> Self {
-        Self::from_native_if_valid(GrBackendTexture::new2(
-            width,
-            height,
-            mip_mapped,
-            mtl_info.native(),
-        ))
+        Self::from_native_if_valid(construct(|texture| {
+            sb::C_GrBackendTexture_ConstructMtl(
+                texture,
+                width,
+                height,
+                mip_mapped,
+                mtl_info.native(),
+            )
+        }))
         .unwrap()
     }
 
@@ -284,15 +287,16 @@ impl Handle<GrBackendRenderTarget> {
         stencil_bits: usize,
         info: gl::FramebufferInfo,
     ) -> Self {
-        Self::from_native(unsafe {
-            GrBackendRenderTarget::new(
+        Self::from_native(construct(|target| unsafe {
+            sb::C_GrBackendRenderTarget_ConstructGL(
+                target,
                 width,
                 height,
                 sample_count.into().unwrap_or(0).try_into().unwrap(),
                 stencil_bits.try_into().unwrap(),
                 info.native(),
             )
-        })
+        }))
     }
 
     #[cfg(feature = "vulkan")]
@@ -301,14 +305,15 @@ impl Handle<GrBackendRenderTarget> {
         sample_count: impl Into<Option<usize>>,
         info: &vk::ImageInfo,
     ) -> Self {
-        Self::from_native(unsafe {
-            GrBackendRenderTarget::new2(
+        Self::from_native(construct(|target| unsafe {
+            sb::C_GrBackendRenderTarget_ConstructVk(
+                target,
                 width,
                 height,
                 sample_count.into().unwrap_or(0).try_into().unwrap(),
                 info.native(),
             )
-        })
+        }))
     }
 
     #[cfg(feature = "metal")]
@@ -317,9 +322,15 @@ impl Handle<GrBackendRenderTarget> {
         sample_cnt: i32,
         mtl_info: &mtl::TextureInfo,
     ) -> Self {
-        Self::from_native(unsafe {
-            GrBackendRenderTarget::new3(width, height, sample_cnt, mtl_info.native())
-        })
+        Self::from_native(construct(|target| unsafe {
+            sb::C_GrBackendRenderTarget_ConstructMtl(
+                target,
+                width,
+                height,
+                sample_cnt,
+                mtl_info.native(),
+            )
+        }))
     }
 
     pub(crate) fn from_native_if_valid(

--- a/skia-safe/src/gpu/backend_surface.rs
+++ b/skia-safe/src/gpu/backend_surface.rs
@@ -4,7 +4,7 @@ use super::gl;
 use super::mtl;
 #[cfg(feature = "vulkan")]
 use super::vk;
-use super::BackendAPI;
+use super::{BackendAPI, BackendSurfaceMutableState};
 use crate::prelude::*;
 use crate::ISize;
 use skia_bindings as sb;
@@ -396,6 +396,10 @@ impl Handle<GrBackendRenderTarget> {
 
     pub fn backend_format(&self) -> BackendFormat {
         BackendFormat::from_native(unsafe { self.native().getBackendFormat() })
+    }
+
+    pub fn set_mutable_stat(&mut self, state: &BackendSurfaceMutableState) {
+        unsafe { self.native_mut().setMutableState(state.native()) }
     }
 
     pub fn is_protected(&self) -> bool {

--- a/skia-safe/src/gpu/backend_surface_mutable_state.rs
+++ b/skia-safe/src/gpu/backend_surface_mutable_state.rs
@@ -1,0 +1,20 @@
+use crate::prelude::*;
+use skia_bindings as sb;
+use skia_bindings::GrBackendSurfaceMutableState;
+
+pub type BackendSurfaceMutableState = Handle<GrBackendSurfaceMutableState>;
+
+impl NativeDrop for GrBackendSurfaceMutableState {
+    fn drop(&mut self) {
+        unsafe { sb::C_GrBackendSurfaceMutableState_destruct(self) }
+    }
+}
+
+impl BackendSurfaceMutableState {
+    #[cfg(feature = "vulkan")]
+    pub fn new_vk(layout: crate::gpu::vk::ImageLayout, queue_family_index: u32) -> Self {
+        Self::construct(|ptr| unsafe {
+            sb::C_GrBackendSurfaceMutableState_ConstructVK(ptr, layout, queue_family_index)
+        })
+    }
+}

--- a/skia-safe/src/gpu/context.rs
+++ b/skia-safe/src/gpu/context.rs
@@ -1,13 +1,13 @@
 #[cfg(feature = "gl")]
 use super::gl;
 #[cfg(feature = "vulkan")]
-use super::vk;
+use super::{vk, BackendRenderTarget, BackendSurfaceMutableState, BackendTexture};
 use crate::gpu::{BackendFormat, MipMapped, Renderable};
 use crate::prelude::*;
 use crate::{image, ColorType, Data, Image};
 use skia_bindings as sb;
 use skia_bindings::{GrContext, SkRefCntBase};
-use std::time::Duration;
+use std::{ptr, time::Duration};
 
 pub type Context = RCHandle<GrContext>;
 
@@ -84,6 +84,11 @@ impl RCHandle<GrContext> {
     // TODO: is_...?
     pub fn abandoned(&mut self) -> bool {
         unsafe { sb::C_GrContext_abandoned(self.native_mut()) }
+    }
+
+    // TODO: is_...?
+    pub fn oomed(&mut self) -> bool {
+        unsafe { self.native_mut().oomed() }
     }
 
     pub fn release_resources_and_abandon(&mut self) -> &mut Self {
@@ -205,24 +210,20 @@ impl RCHandle<GrContext> {
 
     // TODO: wait()
 
-    pub fn flush_and_submit(&mut self) -> &mut Self {
-        unsafe { sb::C_GrContext_flushAndSubmit(self.native_mut()) }
-        self
-    }
-
     #[deprecated(since = "0.30.0", note = "use flush_and_submit()")]
     pub fn flush(&mut self) -> &mut Self {
         self.flush_and_submit()
     }
 
-    // TODO: flush(GrFlushInfo, ..) two variants.
-    // TODO: flushAndSignalSemaphores
+    pub fn flush_and_submit(&mut self) -> &mut Self {
+        unsafe { sb::C_GrContext_flushAndSubmit(self.native_mut()) }
+        self
+    }
 
-    pub fn submit(&mut self, sync_to_cpu: impl Into<Option<bool>>) -> bool {
-        unsafe {
-            self.native_mut()
-                .submit(sync_to_cpu.into().unwrap_or(false))
-        }
+    // TODO: flush(GrFlushInfo, ..)
+
+    pub fn submit(&mut self, sync_cpu: impl Into<Option<bool>>) -> bool {
+        unsafe { self.native_mut().submit(sync_cpu.into().unwrap_or(false)) }
     }
 
     pub fn check_async_work_completion(&mut self) {
@@ -290,6 +291,38 @@ impl RCHandle<GrContext> {
     // TODO: wrap createCompressedBackendTexture (several variants)
     //       introduced in m81
     //       extended in m84 with finishedProc and finishedContext
+
+    // TODO: add variant with GpuFinishedProc / GpuFinishedContext
+    pub fn set_backend_texture_state(
+        &mut self,
+        backend_texture: &BackendTexture,
+        state: &BackendSurfaceMutableState,
+    ) -> bool {
+        unsafe {
+            self.native_mut().setBackendTextureState(
+                backend_texture.native(),
+                state.native(),
+                None,
+                ptr::null_mut(),
+            )
+        }
+    }
+
+    // TODO: add variant with GpuFinishedProc / GpuFinishedContext
+    pub fn set_backend_render_target_state(
+        &mut self,
+        target: &BackendRenderTarget,
+        state: &BackendSurfaceMutableState,
+    ) -> bool {
+        unsafe {
+            self.native_mut().setBackendRenderTargetState(
+                target.native(),
+                state.native(),
+                None,
+                ptr::null_mut(),
+            )
+        }
+    }
 
     // TODO: wrap deleteBackendTexture(),
 

--- a/skia-safe/src/gpu/vk.rs
+++ b/skia-safe/src/gpu/vk.rs
@@ -37,6 +37,7 @@ pub use sb::VkRect2D as Rect2D;
 pub use sb::VkRenderPass as RenderPass;
 pub use sb::VkSamplerYcbcrModelConversion as SamplerYcbcrModelConversion;
 pub use sb::VkSamplerYcbcrRange as SamplerYcbcrRange;
+pub use sb::VkSharingMode as SharingMode;
 
 pub const QUEUE_FAMILY_IGNORED: u32 = !0;
 

--- a/skia-safe/src/gpu/vk/types.rs
+++ b/skia-safe/src/gpu/vk/types.rs
@@ -75,7 +75,7 @@ impl Alloc {
 #[repr(C)]
 pub struct YcbcrConversionInfo {
     pub format: vk::Format,
-    pub external_format: u64,
+    pub external_format: i64,
     pub ycrbcr_model: vk::SamplerYcbcrModelConversion,
     pub ycbcr_range: vk::SamplerYcbcrRange,
     pub x_chroma_offset: vk::ChromaLocation,
@@ -117,7 +117,7 @@ impl YcbcrConversionInfo {
     #[allow(clippy::too_many_arguments)]
     pub fn new_with_format(
         format: vk::Format,
-        external_format: u64,
+        external_format: i64,
         ycrbcr_model: vk::SamplerYcbcrModelConversion,
         ycbcr_range: vk::SamplerYcbcrRange,
         x_chroma_offset: vk::ChromaLocation,
@@ -149,7 +149,7 @@ impl YcbcrConversionInfo {
         y_chroma_offset: vk::ChromaLocation,
         chroma_filter: vk::Filter,
         force_explicit_reconstruction: vk::Bool32,
-        external_format: u64,
+        external_format: i64,
         external_format_features: vk::FormatFeatureFlags,
     ) -> YcbcrConversionInfo {
         Self::new_with_format(
@@ -287,6 +287,27 @@ impl ImageInfo {
             info.format,
             info.level_count,
             info.current_queue_family,
+            info.ycbcr_conversion_info,
+            info.protected,
+            info.sharing_mode,
+        )
+    }
+
+    /// # Safety
+    /// The Vulkan `info.image` and `info.alloc` must outlive the lifetime of the ImageInfo returned.
+    pub unsafe fn from_info_with_queue_index(
+        info: &ImageInfo,
+        layout: vk::ImageLayout,
+        family_queue_index: u32,
+    ) -> Self {
+        Self::new(
+            info.image,
+            info.alloc,
+            info.tiling,
+            layout,
+            info.format,
+            info.level_count,
+            family_queue_index,
             info.ycbcr_conversion_info,
             info.protected,
             info.sharing_mode,

--- a/skia-safe/src/gpu/vk/types.rs
+++ b/skia-safe/src/gpu/vk/types.rs
@@ -260,7 +260,7 @@ impl ImageInfo {
         current_queue_family: impl Into<Option<u32>>,
         ycbcr_conversion_info: impl Into<Option<YcbcrConversionInfo>>,
         protected: impl Into<Option<Protected>>, // m77
-        sharing_mode: impl Into<Option<vk::SharingMode>>,
+        sharing_mode: impl Into<Option<vk::SharingMode>>, // m85
     ) -> Self {
         Self::new(
             image,

--- a/skia-safe/src/utils/camera.rs
+++ b/skia-safe/src/utils/camera.rs
@@ -1,195 +1,8 @@
 #![allow(deprecated)]
 use crate::prelude::*;
-use crate::{scalar, Canvas, Matrix};
+use crate::{scalar, Canvas, Matrix, M44, V3};
 use skia_bindings as sb;
-use skia_bindings::{Sk3DView, SkCamera3D, SkMatrix3D, SkPatch3D, SkPoint3D, SkUnit3D};
-
-#[deprecated(
-    since = "0.30.0",
-    note = "Skia now has support for a 4x matrix (core::M44) in core::Canvas."
-)]
-#[derive(Copy, Clone, PartialEq, Default, Debug)]
-#[repr(C)]
-pub struct Unit3D {
-    pub x: scalar,
-    pub y: scalar,
-    pub z: scalar,
-}
-
-impl NativeTransmutable<SkUnit3D> for Unit3D {}
-
-#[test]
-fn test_unit_3d_layout() {
-    Unit3D::test_layout();
-}
-
-impl Unit3D {
-    pub fn set(&mut self, x: scalar, y: scalar, z: scalar) -> &mut Self {
-        self.x = x;
-        self.y = y;
-        self.z = z;
-        self
-    }
-
-    pub fn dot(a: &Self, b: &Self) -> scalar {
-        unsafe { SkUnit3D::Dot(a.native(), b.native()) }
-    }
-
-    pub fn cross(a: &Self, b: &Self) -> Self {
-        let mut r = Self::default();
-        unsafe { SkUnit3D::Cross(a.native(), b.native(), r.native_mut()) };
-        r
-    }
-}
-
-#[deprecated(
-    since = "0.30.0",
-    note = "Skia now has support for a 4x matrix (core::M44) in core::Canvas."
-)]
-#[derive(Copy, Clone, PartialEq, Default, Debug)]
-#[repr(C)]
-pub struct Point3D {
-    pub x: scalar,
-    pub y: scalar,
-    pub z: scalar,
-}
-
-impl NativeTransmutable<SkPoint3D> for Point3D {}
-#[test]
-fn test_point_3d_layout() {
-    Point3D::test_layout();
-}
-
-impl From<(scalar, scalar, scalar)> for Point3D {
-    fn from((x, y, z): (scalar, scalar, scalar)) -> Self {
-        Point3D { x, y, z }
-    }
-}
-
-impl Point3D {
-    pub fn set(&mut self, x: scalar, y: scalar, z: scalar) -> &mut Self {
-        self.x = x;
-        self.y = y;
-        self.z = z;
-        self
-    }
-
-    pub fn normalize(&self, unit: &mut Unit3D) -> scalar {
-        unsafe { self.native().normalize(unit.native_mut()) }
-    }
-}
-
-#[deprecated(
-    since = "0.30.0",
-    note = "Skia now has support for a 4x matrix (core::M44) in core::Canvas."
-)]
-pub type Vector3D = Point3D;
-
-// note: Default is an empty matrix, and not the identity matrix, which is generated with reset()!
-#[deprecated(
-    since = "0.30.0",
-    note = "Skia now has support for a 4x matrix (core::M44) in core::Canvas."
-)]
-#[derive(Clone, PartialEq, Default, Debug)]
-#[repr(C)]
-pub struct Matrix3D {
-    pub mat: [[scalar; 4]; 3],
-}
-
-impl NativeTransmutable<SkMatrix3D> for Matrix3D {}
-#[test]
-fn test_matrix_3d_layout() {
-    Matrix3D::test_layout();
-}
-
-impl Matrix3D {
-    pub fn reset(&mut self) -> &mut Self {
-        unsafe {
-            self.native_mut().reset();
-        }
-        self
-    }
-
-    pub fn set_row(
-        &mut self,
-        row: usize,
-        a: scalar,
-        b: scalar,
-        c: scalar,
-        d: impl Into<Option<scalar>>,
-    ) -> &mut Self {
-        debug_assert!(row < self.mat.len());
-        let mat = &mut self.mat;
-        mat[row][0] = a;
-        mat[row][1] = b;
-        mat[row][2] = c;
-        mat[row][3] = d.into().unwrap_or_default();
-        self
-    }
-
-    pub fn set_rotate_x(&mut self, deg: scalar) -> &mut Self {
-        unsafe { self.native_mut().setRotateX(deg) }
-        self
-    }
-
-    pub fn set_rotate_y(&mut self, deg: scalar) -> &mut Self {
-        unsafe { self.native_mut().setRotateY(deg) }
-        self
-    }
-
-    pub fn set_rotate_z(&mut self, deg: scalar) -> &mut Self {
-        unsafe { self.native_mut().setRotateZ(deg) }
-        self
-    }
-
-    pub fn set_translate(&mut self, x: scalar, y: scalar, z: scalar) -> &mut Self {
-        unsafe { self.native_mut().setTranslate(x, y, z) }
-        self
-    }
-
-    pub fn pre_rotate_x(&mut self, deg: scalar) -> &mut Self {
-        unsafe { self.native_mut().preRotateX(deg) }
-        self
-    }
-
-    pub fn pre_rotate_y(&mut self, deg: scalar) -> &mut Self {
-        unsafe { self.native_mut().preRotateY(deg) }
-        self
-    }
-
-    pub fn pre_rotate_z(&mut self, deg: scalar) -> &mut Self {
-        unsafe { self.native_mut().preRotateZ(deg) }
-        self
-    }
-
-    pub fn pre_translate(&mut self, x: scalar, y: scalar, z: scalar) -> &mut Self {
-        unsafe { self.native_mut().preTranslate(x, y, z) }
-        self
-    }
-
-    pub fn set_concat(&mut self, a: &Self, b: &Self) -> &mut Self {
-        unsafe { self.native_mut().setConcat(a.native(), b.native()) }
-        self
-    }
-
-    pub fn map_point(&self, src: impl Into<Point3D>) -> Point3D {
-        let mut dst = Point3D::default();
-        unsafe {
-            self.native()
-                .mapPoint(src.into().native(), dst.native_mut())
-        };
-        dst
-    }
-
-    pub fn map_vector(&self, src: impl Into<Vector3D>) -> Vector3D {
-        let mut dst = Vector3D::default();
-        unsafe {
-            self.native()
-                .mapVector(src.into().native(), dst.native_mut())
-        };
-        dst
-    }
-}
+use skia_bindings::{Sk3DView, SkCamera3D, SkPatch3D};
 
 #[deprecated(
     since = "0.30.0",
@@ -198,9 +11,9 @@ impl Matrix3D {
 #[derive(Clone, PartialEq, Debug)]
 #[repr(C)]
 pub struct Patch3D {
-    pub u: Vector3D,
-    pub v: Vector3D,
-    pub origin: Point3D,
+    pub u: V3,
+    pub v: V3,
+    pub origin: V3,
 }
 
 impl NativeTransmutable<SkPatch3D> for Patch3D {}
@@ -221,13 +34,13 @@ impl Patch3D {
         self
     }
 
-    pub fn transform(&self, m: &Matrix3D) -> Self {
+    pub fn transform(&self, m: &M44) -> Self {
         let mut dst = Patch3D::default();
         unsafe { self.native().transform(m.native(), dst.native_mut()) }
         dst
     }
 
-    pub fn dot_with(&self, v: impl Into<Vector3D>) -> scalar {
+    pub fn dot_with(&self, v: impl Into<V3>) -> scalar {
         let v = v.into();
         unsafe { self.native().dotWith(v.x, v.y, v.z) }
     }
@@ -240,10 +53,10 @@ impl Patch3D {
 #[derive(Clone, PartialEq, Debug)]
 #[repr(C)]
 pub struct Camera3D {
-    pub location: Point3D,
-    pub axis: Point3D,
-    pub zenith: Point3D,
-    pub observer: Point3D,
+    pub location: V3,
+    pub axis: V3,
+    pub zenith: V3,
+    pub observer: V3,
     orientation: Matrix,
     need_to_update: bool,
 }
@@ -320,7 +133,7 @@ impl RefHandle<Sk3DView> {
         self
     }
 
-    pub fn translate(&mut self, d: impl Into<Vector3D>) -> &mut Self {
+    pub fn translate(&mut self, d: impl Into<V3>) -> &mut Self {
         let d = d.into();
         unsafe { self.native_mut().translate(d.x, d.y, d.z) }
         self
@@ -352,7 +165,7 @@ impl RefHandle<Sk3DView> {
         self
     }
 
-    pub fn dot_with_normal(&self, d: impl Into<Vector3D>) -> scalar {
+    pub fn dot_with_normal(&self, d: impl Into<V3>) -> scalar {
         let d = d.into();
         unsafe { self.native().dotWithNormal(d.x, d.y, d.z) }
     }

--- a/skia-safe/src/utils/custom_typeface.rs
+++ b/skia-safe/src/utils/custom_typeface.rs
@@ -14,8 +14,8 @@ impl NativeDrop for SkCustomTypefaceBuilder {
 }
 
 impl Handle<SkCustomTypefaceBuilder> {
-    pub fn new(num_glyphs: usize) -> Self {
-        Self::from_native(unsafe { SkCustomTypefaceBuilder::new(num_glyphs.try_into().unwrap()) })
+    pub fn new() -> Self {
+        Self::from_native(unsafe { SkCustomTypefaceBuilder::new() })
     }
 
     pub fn set_glyph<'a>(
@@ -83,7 +83,7 @@ impl From<(&Image, f32)> for TypefaceGlyph<'_> {
 
 #[test]
 fn build_custom_typeface() {
-    let mut builder = CustomTypefaceBuilder::new(2);
+    let mut builder = CustomTypefaceBuilder::new();
     let path = Path::new();
     builder.set_glyph(10u16, 0.0, &path);
     builder.set_glyph(11u16, 0.0, &path);


### PR DESCRIPTION
This PR updates rust-skia to support Skia's `chrome/m85` branch.

- [x] Update `README.md` ([rendered](https://github.com/pragmatrix/rust-skia/blob/m85/README.md))  
  > Most important here is to change the Skia branch name and the current Skia submodule tag at the top of the `README.md` file.
- [x] Skia can be built ([release notes](https://github.com/google/skia/blob/chrome/m85/RELEASE_NOTES.txt)).
- [x] skia-bindings.
- [x] skia-safe: Update & add new wrappers by diffing include files.  
  > Add TODOs for everything that can not be updated right now, and attempt to stay compatible with previous versions of skia-safe without trying too hard before version 1.0. Use `deprecated` attributes if needed.
  - [x] `codec/`
  - [x] `core/`
  - [x] `docs/`
  - [x] `effects/`
  - [x] `gpu/`
    - [x] `gl/`
    - [x] `mtl/`
    - [x] `vk/`
  - [x] `modules/`
    - [x] `skparagraph/`
    - [x] `skshaper/`
  - [x] `pathops/`
  - [x] `svg/`
  - [x] `utils/`
- [x] new: wrap SkPathBuilder
- [x] ~One week before Chrome 85 stable will be released? ([Schedule](https://www.chromestatus.com/features/schedule))
- [x] Any pending changes in the Skia `chrome/m85` branch that aren't synchronized yet?
- [x] Do the tags/hashes in `skia-bindings/Cargo.toml` under `[package.metadata]` match the submodules `depot_tools` and `skia`?
- [x] Rebase on or merge with master.
- [x] Builds with `RUSTFLAGS=-Clink-dead-code` on Windows (#318):
  ```bash
  RUSTFLAGS=-Clink-dead-code (cd skia-org && cargo build -vv --features gl,vulkan,textlayout)
  ```
- [x] Update versions of `skia-bindings/Cargo.toml` and `skia-safe/Cargo.toml` and also add the version to the new `deprecated` attributes.
- [x] Do one final review of all the changes.