### PR TITLE
Don't link skia-bindings two times in a full build

### DIFF
--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -678,6 +678,8 @@ fn bindgen_gen(build: &FinalBuildConfiguration, current_dir: &Path, output_direc
     }
 
     println!("COMPILING BINDINGS: {:?}", build.binding_sources);
+    // we add skia-bindings later on.
+    cc_build.cargo_metadata(false);
     cc_build.compile(lib::SKIA_BINDINGS);
 
     println!("GENERATING BINDINGS");


### PR DESCRIPTION
Although not causing an error so far, skia-bindings was added to list of linker libraries twice if a full build was invoked, once by the invocation of cc and once by our build_support. This PR disables the cargo metadata submission caused by cc.