### PR TITLE
Fix Rust beta 1.46 linker errors

### DIFF
--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -26,6 +26,9 @@ include = [
 	"src/impls.rs",
 	"src/lib.rs" ]
 
+[lib]
+doctest = false
+
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -437,7 +437,7 @@ impl BinariesConfiguration {
         // the system libraries.
 
         for lib in &self.built_libraries {
-            cargo::add_link_lib(format!("{}", lib));
+            cargo::add_link_lib(lib);
         }
 
         cargo::add_link_libs(&self.link_libraries);

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -437,7 +437,7 @@ impl BinariesConfiguration {
         // the system libraries.
 
         for lib in &self.built_libraries {
-            cargo::add_link_lib(format!("static={}", lib));
+            cargo::add_link_lib(format!("{}", lib));
         }
 
         cargo::add_link_libs(&self.link_libraries);

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -436,8 +436,20 @@ impl BinariesConfiguration {
         // On Linux, the order is significant, first the static libraries we built, and then
         // the system libraries.
 
+        let target = cargo::target();
+
         for lib in &self.built_libraries {
-            cargo::add_link_lib(lib);
+            // Prefixing the libraries we built with `static=` causes linker errors on Windows.
+            // https://github.com/rust-skia/rust-skia/pull/354
+            let kind_prefix = {
+                if target.is_windows() {
+                    ""
+                } else {
+                    "static="
+                }
+            };
+
+            cargo::add_link_lib(format!("{}{}", kind_prefix, lib));
         }
 
         cargo::add_link_libs(&self.link_libraries);


### PR DESCRIPTION
This PR attempts to fix the linker errors on Windows that appeared with rust beta version 1.46 when the skia-bindings package was being tested.

I assume that the underlying cause is some dead code in Skia expecting symbols that we can not provide yet. This was not a problem before, because the MSVC linker was invoked with dead code elimination up until [this PR](https://github.com/rust-lang/rust/pull/72785), which flagged them with [`/WHOLEARCHIVE`](https://docs.microsoft.com/en-us/cpp/build/reference/wholearchive-include-all-library-object-files) for the testcases.

Submitting skia.lib and skia-bindings.lib to cargo as an "unspecified library" (without a prefix) seems to mitigate the problem for now.