### PR TITLE
Support Vulkan Extensions

### DIFF
--- a/skia-bindings/src/vulkan.cpp
+++ b/skia-bindings/src/vulkan.cpp
@@ -22,6 +22,8 @@ extern "C" void C_GPU_VK_Types(GrVkExtensionFlags *, GrVkFeatureFlags *) {}
 
 // The GrVkBackendContext struct binding's length is too short
 // because of the std::function that is used in it.
+// TODO: verify if this is actually true for the latest bindings (it doesn't seem so, because all skia-bindings testcases work and 
+// GrVkBackendContext seems to be generated).
 
 typedef PFN_vkVoidFunction (*GetProcFn)(const char* name, VkInstance instance, VkDevice device);
 typedef const void* (*GetProcFnVoidPtr)(const char* name, VkInstance instance, VkDevice device);
@@ -62,6 +64,14 @@ extern "C" void C_GrVkBackendContext_Delete(void* vkBackendContext) {
         delete bc->fVkExtensions;
     }
     delete bc;
+}
+
+extern "C" void C_GrVkBackendContext_setProtectedContext(GrVkBackendContext *self, GrProtected protectedContext) {
+    self->fProtectedContext = protectedContext;
+}
+
+extern "C" void C_GrVkBackendContext_setMaxAPIVersion(GrVkBackendContext *self, uint32_t maxAPIVersion) {
+    self->fMaxAPIVersion = maxAPIVersion;
 }
 
 extern "C" GrContext* C_GrContext_MakeVulkan(const GrVkBackendContext* vkBackendContext) {

--- a/skia-safe/src/gpu/vk.rs
+++ b/skia-safe/src/gpu/vk.rs
@@ -1,4 +1,5 @@
 use skia_bindings as sb;
+use std::ops::Deref;
 use std::ptr;
 
 mod backend_context;
@@ -108,5 +109,46 @@ impl From<NullHandle> for RenderPass {
 impl From<NullHandle> for u64 {
     fn from(_: NullHandle) -> Self {
         0
+    }
+}
+
+#[repr(transparent)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub struct Version(u32);
+
+impl Version {
+    pub fn new(major: usize, minor: usize, patch: usize) -> Self {
+        ((((major & 0x3ff) << 22) | ((minor & 0x3ff) << 12) | (patch & 0xfff)) as u32).into()
+    }
+
+    pub fn major(&self) -> usize {
+        (self.deref() >> 22) as _
+    }
+
+    pub fn minor(&self) -> usize {
+        ((self.deref() >> 12) & 0x3ff) as _
+    }
+
+    pub fn patch(&self) -> usize {
+        ((self.deref()) & 0xfff) as _
+    }
+}
+
+impl From<u32> for Version {
+    fn from(v: u32) -> Self {
+        Self(v)
+    }
+}
+
+impl From<(usize, usize, usize)> for Version {
+    fn from((major, minor, patch): (usize, usize, usize)) -> Self {
+        Self::new(major, minor, patch)
+    }
+}
+
+impl Deref for Version {
+    type Target = u32;
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }

--- a/skia-safe/src/gpu/vk/backend_context.rs
+++ b/skia-safe/src/gpu/vk/backend_context.rs
@@ -1,5 +1,7 @@
 use super::{Device, GetProc, GetProcOf, Instance, PhysicalDevice, Queue};
 use crate::prelude::*;
+use ffi::CString;
+use raw::c_char;
 use skia_bindings as sb;
 use skia_bindings::{GrVkExtensionFlags, GrVkFeatureFlags};
 use std::cell::RefCell;
@@ -55,7 +57,7 @@ impl<'a> Drop for BackendContext<'a> {
 // TODO: may support Clone (note the original structure holds a smartpointer!)
 // TODO: think about making this safe in respect to the lifetime of the handles
 //       it refers to.
-impl<'a> BackendContext<'a> {
+impl BackendContext<'_> {
     /// # Safety
     /// `instance`, `physical_device`, `device`, and `queue` must outlive the `BackendContext`
     /// returned.
@@ -66,17 +68,63 @@ impl<'a> BackendContext<'a> {
         (queue, queue_index): (Queue, usize),
         get_proc: &impl GetProc,
     ) -> BackendContext {
-        BackendContext {
-            native: sb::C_GrVkBackendContext_New(
-                instance as _,
-                physical_device as _,
-                device as _,
-                queue as _,
-                queue_index.try_into().unwrap(),
-                Some(global_get_proc),
-            ),
+        Self::new_with_extensions(
+            instance,
+            physical_device,
+            device,
+            (queue, queue_index),
             get_proc,
-        }
+            &[],
+            &[],
+        )
+    }
+
+    /// # Safety
+    /// `instance`, `physical_device`, `device`, and `queue` must outlive the `BackendContext`
+    /// returned.
+    pub unsafe fn new_with_extensions<'a>(
+        instance: Instance,
+        physical_device: PhysicalDevice,
+        device: Device,
+        (queue, queue_index): (Queue, usize),
+        get_proc: &'a impl GetProc,
+        instance_extensions: &[&str],
+        device_extensions: &[&str],
+    ) -> BackendContext<'a> {
+        // pin the extensions string in memory and provide pointers to the NewWithExtension function,
+        // but there is no need to retain them, because because the implementations copies these strings, too.
+        let instance_extensions: Vec<CString> = instance_extensions
+            .iter()
+            .map(|str| CString::new(*str).unwrap())
+            .collect();
+        let instance_extensions: Vec<*const c_char> =
+            instance_extensions.iter().map(|cs| cs.as_ptr()).collect();
+        let device_extensions: Vec<CString> = device_extensions
+            .iter()
+            .map(|str| CString::new(*str).unwrap())
+            .collect();
+        let device_extensions: Vec<*const c_char> =
+            device_extensions.iter().map(|cs| cs.as_ptr()).collect();
+
+        let resolver = Self::begin_resolving_proc(get_proc);
+        let native = sb::C_GrVkBackendContext_New(
+            instance as _,
+            physical_device as _,
+            device as _,
+            queue as _,
+            queue_index.try_into().unwrap(),
+            Some(global_get_proc),
+            instance_extensions.as_ptr(),
+            instance_extensions.len(),
+            device_extensions.as_ptr(),
+            device_extensions.len(),
+        );
+        drop(resolver);
+        BackendContext { native, get_proc }
+    }
+
+    pub(crate) unsafe fn begin_resolving(&self) -> impl Drop {
+        Self::begin_resolving_proc(self.get_proc)
     }
 
     // The idea here is to set up a thread local variable with the GetProc function trait
@@ -86,12 +134,9 @@ impl<'a> BackendContext<'a> {
     // of relying on a global extern "C" function.
     // TODO: This is a mess, highly unsafe, and needs to be simplified / rewritten
     //       by someone who understands Rust better.
-
-    pub(crate) unsafe fn begin_resolving(&self) -> impl Drop {
-        THREAD_LOCAL_GET_PROC.with(|get_proc| {
-            let get_proc_trait_object: &dyn GetProc = self.get_proc;
-            *get_proc.borrow_mut() = Some(mem::transmute(get_proc_trait_object))
-        });
+    unsafe fn begin_resolving_proc(get_proc_trait_object: &dyn GetProc) -> impl Drop {
+        THREAD_LOCAL_GET_PROC
+            .with(|get_proc| *get_proc.borrow_mut() = Some(mem::transmute(get_proc_trait_object)));
 
         EndResolving {}
     }

--- a/skia-safe/src/gpu/vk/backend_context.rs
+++ b/skia-safe/src/gpu/vk/backend_context.rs
@@ -1,10 +1,12 @@
-use super::{Device, GetProc, GetProcOf, Instance, PhysicalDevice, Queue};
+use super::{Device, GetProc, GetProcOf, Instance, PhysicalDevice, Queue, Version};
+use crate::gpu;
 use crate::prelude::*;
 use ffi::CString;
 use raw::c_char;
 use skia_bindings as sb;
 use skia_bindings::{GrVkExtensionFlags, GrVkFeatureFlags};
 use std::cell::RefCell;
+use std::ops::Deref;
 use std::os::raw;
 use std::{ffi, mem};
 
@@ -121,6 +123,18 @@ impl BackendContext<'_> {
         );
         drop(resolver);
         BackendContext { native, get_proc }
+    }
+
+    pub fn set_protected_context(&mut self, protected_context: gpu::Protected) -> &mut Self {
+        unsafe { sb::C_GrVkBackendContext_setProtectedContext(self.native as _, protected_context) }
+        self
+    }
+
+    pub fn set_max_api_version(&mut self, version: impl Into<Version>) -> &mut Self {
+        unsafe {
+            sb::C_GrVkBackendContext_setMaxAPIVersion(self.native as _, *version.into().deref())
+        }
+        self
     }
 
     pub(crate) unsafe fn begin_resolving(&self) -> impl Drop {


### PR DESCRIPTION
This PR adds a new function to `vk::BackendContext` that supports the creation with an explicit set of Vulkan extensions. It also adds the possibility to set a protected context and the maximum API version.