### PR TITLE
add Data::new_bytes to create without copy

### DIFF
--- a/skia-safe/src/core/data.rs
+++ b/skia-safe/src/core/data.rs
@@ -70,9 +70,8 @@ impl RCHandle<SkData> {
     /// Constructs Data from a given byte slice without copying it.
     ///
     /// Users must make sure that the underlying slice will outlive the lifetime of the Data.
-    pub fn new_bytes(data: &[u8]) -> Self {
-        Data::from_ptr(unsafe { sb::C_SkData_MakeWithoutCopy(data.as_ptr() as _, data.len()) })
-            .unwrap()
+    pub unsafe fn new_bytes(data: &[u8]) -> Self {
+        Data::from_ptr(sb::C_SkData_MakeWithoutCopy(data.as_ptr() as _, data.len())).unwrap()
     }
 
     pub unsafe fn new_uninitialized(length: usize) -> Data {

--- a/skia-safe/src/core/data.rs
+++ b/skia-safe/src/core/data.rs
@@ -67,6 +67,14 @@ impl RCHandle<SkData> {
             .unwrap()
     }
 
+    /// Constructs Data from a given byte slice without copying it.
+    ///
+    /// Users must make sure that the underlying slice will outlive the lifetime of the Data.
+    pub fn new_bytes(data: &[u8]) -> Self {
+        Data::from_ptr(unsafe { sb::C_SkData_MakeWithoutCopy(data.as_ptr() as _, data.len()) })
+            .unwrap()
+    }
+
     pub unsafe fn new_uninitialized(length: usize) -> Data {
         Data::from_ptr(sb::C_SkData_MakeUninitialized(length)).unwrap()
     }


### PR DESCRIPTION
It would be nice to be able to create Data without copy. Should `new_bytes` be marked `unsafe`?