### PR TITLE
Make Pixmap::new() implementation actually use the arguments

### DIFF
--- a/skia-safe/src/core/pixmap.rs
+++ b/skia-safe/src/core/pixmap.rs
@@ -41,9 +41,9 @@ impl Handle<SkPixmap> {
         assert!(pixels.len() >= height * row_bytes);
 
         let pm = Pixmap::from_native(SkPixmap {
-            fPixels: ptr::null(),
-            fRowBytes: 0,
-            fInfo: ImageInfo::new_unknown(None).native().clone(),
+            fPixels: pixels.as_ptr() as _,
+            fRowBytes: row_bytes,
+            fInfo: info.native().clone(),
         });
         pm.borrows(pixels)
     }


### PR DESCRIPTION
Just recognized that the `Pixmap::new()` implementation wasn't actually creating a `Pixmap` with the provided format and pixels, but a Pixmap with an unknown format and no pixels at all. Must be a copy & paste error. This PR fixes that.