### PR TITLE
Bump version to 0.31.0 and update Skia M84

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m84 ([pending changes][skiapending], [our changes][skiaours]).
 
-[skiapending]: https://github.com/rust-skia/skia/compare/m84-0.30.1...google:chrome/m84
-[skiaours]: https://github.com/google/skia/compare/chrome/m84...rust-skia:m84-0.30.1
+[skiapending]: https://github.com/rust-skia/skia/compare/m84-0.31.0...google:chrome/m84
+[skiaours]: https://github.com/google/skia/compare/chrome/m84...rust-skia:m84-0.31.0
 
 ## Goals
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.30.1"
+version = "0.31.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m84-0.30.1"
+skia = "m84-0.31.0"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1248,14 +1248,6 @@ extern "C" SkVertices* C_SkVertices_MakeCopy(
     return SkVertices::MakeCopy(mode, vertexCount, positions, texs, colors, indexCount, indices).release();
 }
 
-extern "C" SkVertices* C_SkVertices_Decode(const void* buffer, size_t length) {
-    return SkVertices::Decode(buffer, length).release();
-}
-
-extern "C" SkData* C_SkVertices_encode(const SkVertices* self) {
-    return self->encode().release();
-}
-
 //
 // SkVertices::Builder
 //

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.30.1"
+version = "0.31.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -32,7 +32,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 
 [dependencies]
 bitflags = "1.0.4"
-skia-bindings = { version = "=0.30.1", path = "../skia-bindings" }
+skia-bindings = { version = "=0.31.0", path = "../skia-bindings" }
 lazy_static = "1.4"
 
 [dev-dependencies]

--- a/skia-safe/src/core/vertices.rs
+++ b/skia-safe/src/core/vertices.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use crate::{Color, Data, Point, Rect};
+use crate::{Color, Point, Rect};
 use skia_bindings as sb;
 use skia_bindings::{
     SkColor, SkPoint, SkVertices, SkVertices_Attribute, SkVertices_Attribute_Type,
@@ -274,12 +274,14 @@ impl RCHandle<SkVertices> {
         unsafe { self.native().approximateSize() }
     }
 
-    pub fn decode(buffer: &[u8]) -> Option<Vertices> {
-        Vertices::from_ptr(unsafe { sb::C_SkVertices_Decode(buffer.as_ptr() as _, buffer.len()) })
+    #[deprecated(since = "0.31.0", note = "removed without replacement")]
+    pub fn decode(_buffer: &[u8]) -> ! {
+        panic!("removed without replacement");
     }
 
-    pub fn encode(&self) -> Data {
-        Data::from_ptr(unsafe { sb::C_SkVertices_encode(self.native()) }).unwrap()
+    #[deprecated(since = "0.31.0", note = "removed without replacement")]
+    pub fn encode(&self) -> ! {
+        panic!("removed without replacement");
     }
 }
 


### PR DESCRIPTION
The Skia branch chrome/m84 got some updates that removed two SkVertices functions and since we are planning a new release anyway, these changes should be included.
