### PR TITLE
Fix implementation of the Canvas::is_clip_rect() wrapper

### DIFF
--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -1002,7 +1002,7 @@ impl Canvas {
     }
 
     pub fn is_clip_rect(&self) -> bool {
-        unsafe { sb::C_SkCanvas_isClipEmpty(self.native()) }
+        unsafe { sb::C_SkCanvas_isClipRect(self.native()) }
     }
 
     pub fn local_to_device(&self) -> M44 {


### PR DESCRIPTION
This PR fixes one more copy&paste mistake.