### PR TITLE
Update Skia and integrate iwyu fixes for VS 2019 16.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m84 ([pending changes][skiapending], [our changes][skiaours]).
 
-[skiapending]: https://github.com/rust-skia/skia/compare/m84-0.31.0...google:chrome/m84
-[skiaours]: https://github.com/google/skia/compare/chrome/m84...rust-skia:m84-0.31.0
+[skiapending]: https://github.com/rust-skia/skia/compare/m84-0.31.1...google:chrome/m84
+[skiaours]: https://github.com/google/skia/compare/chrome/m84...rust-skia:m84-0.31.1
 
 ## Goals
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.31.0"
+version = "0.31.1"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m84-0.31.0"
+skia = "m84-0.31.1"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.31.0"
+version = "0.31.1"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -32,7 +32,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 
 [dependencies]
 bitflags = "1.0.4"
-skia-bindings = { version = "=0.31.0", path = "../skia-bindings" }
+skia-bindings = { version = "=0.31.1", path = "../skia-bindings" }
 lazy_static = "1.4"
 
 [dev-dependencies]


### PR DESCRIPTION
Visual Studio 16.7 STL's update breaks backward compatibility in Skia by not implicitly including some headers in parts of the SDL, this causes various compilation errors after an update.

This PR cherry picks https://github.com/google/skia/commit/0d6f81593b1fa222e8e4afb56cc961ce8c9be375 and updates Skia to the latest chrome/m84 branch.