### PR TITLE
M85: Support Skia's Direct3D backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project (skia-bindings)
 
 include_directories(skia-bindings/skia)
 
-add_compile_definitions(SK_SHAPER_HARFBUZZ_AVAILABLE, SK_VULKAN, SK_XML, SK_METAL)
+add_compile_definitions(SK_SHAPER_HARFBUZZ_AVAILABLE, SK_VULKAN, SK_XML, SK_METAL, SK_DIRECT3D)
 
 add_library(skiabindings
         skia-bindings/src/bindings.cpp
@@ -16,4 +16,5 @@ add_library(skiabindings
         skia-bindings/src/svg.cpp
         skia-bindings/src/vulkan.cpp
         skia-bindings/src/metal.cpp
+        skia-bindings/src/d3d.cpp
         )

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m85 ([pending changes][skiapending], [our changes][skiaours]).
 
-[skiapending]: https://github.com/rust-skia/skia/compare/m85-0.32.1...google:chrome/m85
-[skiaours]: https://github.com/google/skia/compare/chrome/m85...rust-skia:m85-0.32.1
+[skiapending]: https://github.com/rust-skia/skia/compare/m85-0.32.2...google:chrome/m85
+[skiaours]: https://github.com/google/skia/compare/chrome/m85...rust-skia:m85-0.32.2
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Skia Submodule Status: chrome/m85 ([pending changes][skiapending], [our changes]
 
 ## Goals
 
-This project attempts to provide _up to date_ safe bindings that bridge idiomatic Rust with Skia's C++ API on all major desktop and mobile platforms, including GPU rendering support for [Vulkan](https://en.wikipedia.org/wiki/Vulkan_(API)), [Metal](https://en.wikipedia.org/wiki/Metal_(API)), and [OpenGL](https://en.wikipedia.org/wiki/OpenGL).
+This project provides _up to date_ safe bindings that bridge idiomatic Rust with Skia's C++ API on desktop and mobile platforms, including GPU rendering backends for [Vulkan](https://en.wikipedia.org/wiki/Vulkan_(API)), [Metal](https://en.wikipedia.org/wiki/Metal_(API)), [OpenGL](https://en.wikipedia.org/wiki/OpenGL), and [Direct3D](https://en.wikipedia.org/wiki/Direct3D).
 
 ## Status
 
@@ -248,7 +248,7 @@ cargo run -- --help
 
 ### gl-window
 
-An example that opens an OpenGL Window and draws a line with skia-safe (contributed by [@nornagon](https://github.com/nornagon)).
+An example that opens an OpenGL Window and draws the rust-skia icon with skia-safe (contributed by [@nornagon](https://github.com/nornagon)).
 
 ```bash
 (cd skia-safe && cargo run --example gl-window --features "gl")

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -145,6 +145,8 @@ jobs:
       releaseBinaries: ${{ parameters.deployRelease }}
       ${{ if and(eq(parameters.platform, 'macOS'), eq(parameters.deployRelease, 'False')) }}:
         features: '$(features),metal'
+      ${{ if and(eq(parameters.platform, 'Windows'), eq(parameters.deployRelease, 'False')) }}:
+        features: '$(features),d3d'
 
   - ${{ if eq(parameters.platform, 'macOS') }}:
     - template: 'azure-pipelines-build-target.yml'

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m85-0.32.1"
+skia = "m85-0.32.2"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -40,6 +40,7 @@ default = []
 gl = []
 vulkan = []
 metal = []
+d3d = []
 textlayout = []
 # deprecated since 0.25.0
 svg = []

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -1079,6 +1079,8 @@ const ENUM_TABLE: &[EnumEntry] = &[
     ("Verb", rewrite::k_xxx_name),
     // m84: SkVertices::Attribute::Usage
     ("Usage", rewrite::k_xxx),
+    ("GrSemaphoresSubmitted", rewrite::k_xxx),
+    ("BackendSurfaceAccess", rewrite::k_xxx),
     // m85: VkSharingMode
     ("VkSharingMode", rewrite::vk),
 ];

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -311,6 +311,9 @@ impl FinalBuildConfiguration {
             if features.metal {
                 sources.push("src/metal.cpp".into());
             }
+            if features.d3d {
+                sources.push("src/d3d.cpp".into());
+            }
             if features.gpu() {
                 sources.push("src/gpu.cpp".into());
             }

--- a/skia-bindings/src/d3d.cpp
+++ b/skia-bindings/src/d3d.cpp
@@ -1,0 +1,47 @@
+#include "bindings.h"
+
+// for VSCode
+// TODO: remove that and add proper CMake support for VSCode
+#ifndef SK_DIRECT3D
+    #define SK_DIRECT3D
+#endif
+
+#include "include/gpu/GrBackendSurface.h"
+#include "include/gpu/GrContext.h"
+#include "include/gpu/d3d/GrD3DBackendContext.h"
+
+//
+// gpu/d3d
+//
+
+extern "C" void C_IUnknown_AddRef(IUnknown* self) {
+    self->AddRef();
+}
+
+extern "C" void C_IUnknown_Release(IUnknown* self) {
+    self->Release();
+}
+
+//
+// gpu/GrBackendSurface.h
+//
+
+extern "C" void C_GrBackendFormat_ConstructDxgi(GrBackendFormat* uninitialized, DXGI_FORMAT format) {
+    new(uninitialized)GrBackendFormat(GrBackendFormat::MakeDxgi(format));
+}
+
+extern "C" void C_GrBackendTexture_ConstructD3D(GrBackendTexture* uninitialized, int width, int height, const GrD3DTextureResourceInfo* resourceInfo) {
+    new(uninitialized)GrBackendTexture(width, height, *resourceInfo);
+}
+
+extern "C" void C_GrBackendRenderTarget_ConstructD3D(GrBackendRenderTarget* uninitialized, int width, int height, int sampleCnt, const GrD3DTextureResourceInfo* resourceInfo) {
+    new(uninitialized)GrBackendRenderTarget(width, height, sampleCnt, *resourceInfo);
+}
+
+//
+// gpu/GrContext.h
+//
+
+extern "C" GrContext* C_GrContext_MakeDirect3D(const GrD3DBackendContext* backendContext) {
+    return GrContext::MakeDirect3D(*backendContext).release();
+}

--- a/skia-bindings/src/d3d.cpp
+++ b/skia-bindings/src/d3d.cpp
@@ -11,18 +11,6 @@
 #include "include/gpu/d3d/GrD3DBackendContext.h"
 
 //
-// gpu/d3d
-//
-
-extern "C" void C_IUnknown_AddRef(IUnknown* self) {
-    self->AddRef();
-}
-
-extern "C" void C_IUnknown_Release(IUnknown* self) {
-    self->Release();
-}
-
-//
 // gpu/GrBackendSurface.h
 //
 

--- a/skia-bindings/src/impls.rs
+++ b/skia-bindings/src/impls.rs
@@ -121,18 +121,8 @@ impl From<crate::GrGLFormat> for crate::GrGLenum {
 }
 
 #[cfg(feature = "d3d")]
-/// This marker trait that makes it possible to use the cp smartpointer for D3D types.
-pub unsafe trait AsIUnknown {}
-
-#[cfg(feature = "d3d")]
 mod d3d {
-    use super::AsIUnknown;
     use std::marker::PhantomData;
-
-    unsafe impl AsIUnknown for crate::IDXGIAdapter1 {}
-    unsafe impl AsIUnknown for crate::ID3D12Device {}
-    unsafe impl AsIUnknown for crate::ID3D12CommandQueue {}
-    unsafe impl AsIUnknown for crate::ID3D12Resource {}
 
     impl<T> Default for crate::gr_cp<T> {
         fn default() -> Self {

--- a/skia-bindings/src/impls.rs
+++ b/skia-bindings/src/impls.rs
@@ -119,3 +119,40 @@ impl From<crate::GrGLFormat> for crate::GrGLenum {
         unsafe { crate::C_GrGLFormatToEnum(format) }
     }
 }
+
+#[cfg(feature = "d3d")]
+/// This marker trait that makes it possible to use the cp smartpointer for D3D types.
+pub unsafe trait AsIUnknown {}
+
+#[cfg(feature = "d3d")]
+mod d3d {
+    use super::AsIUnknown;
+    use std::marker::PhantomData;
+
+    unsafe impl AsIUnknown for crate::IDXGIAdapter1 {}
+    unsafe impl AsIUnknown for crate::ID3D12Device {}
+    unsafe impl AsIUnknown for crate::ID3D12CommandQueue {}
+    unsafe impl AsIUnknown for crate::ID3D12Resource {}
+
+    impl<T> Default for crate::gr_cp<T> {
+        fn default() -> Self {
+            Self {
+                fObject: std::ptr::null_mut(),
+                _phantom_0: PhantomData,
+            }
+        }
+    }
+
+    impl Default for crate::GrD3DTextureResourceInfo {
+        fn default() -> Self {
+            Self {
+                fResource: Default::default(),
+                fResourceState: crate::D3D12_RESOURCE_STATES::D3D12_RESOURCE_STATE_COMMON,
+                fFormat: crate::DXGI_FORMAT::DXGI_FORMAT_UNKNOWN,
+                fLevelCount: 0,
+                fSampleQualityLevel: 0,
+                fProtected: crate::GrProtected::No,
+            }
+        }
+    }
+}

--- a/skia-bindings/src/metal.cpp
+++ b/skia-bindings/src/metal.cpp
@@ -1,4 +1,5 @@
 #include "bindings.h"
+
 #include "include/core/SkSurface.h"
 #include "include/gpu/GrContext.h"
 

--- a/skia-org/Cargo.toml
+++ b/skia-org/Cargo.toml
@@ -20,7 +20,7 @@ default = []
 gl = ["offscreen_gl_context", "sparkle", "skia-safe/gl"]
 vulkan = ["ash", "skia-safe/vulkan"]
 metal = ["metal-rs", "foreign-types", "cocoa", "objc", "skia-safe/metal"]
-d3d = ["skia-safe/d3d"]
+d3d = ["skia-safe/d3d", "winapi", "wio"]
 textlayout = ["skia-safe/textlayout"]
 
 [dependencies]
@@ -42,3 +42,6 @@ foreign-types = { version = "0.3", optional = true }
 # ... for that NSAutoReleasePool to be able to free metal devices.
 cocoa = { version = "0.23", optional = true }
 objc = { version = "0.2.4", optional = true }
+# d3d
+winapi = { version = "0.3.9", optional = true, features = ["d3d12", "dxgi"] }
+wio = { version = "0.2.2", optional = true }

--- a/skia-org/Cargo.toml
+++ b/skia-org/Cargo.toml
@@ -20,6 +20,7 @@ default = []
 gl = ["offscreen_gl_context", "sparkle", "skia-safe/gl"]
 vulkan = ["ash", "skia-safe/vulkan"]
 metal = ["metal-rs", "foreign-types", "cocoa", "objc", "skia-safe/metal"]
+d3d = ["skia-safe/d3d"]
 textlayout = ["skia-safe/textlayout"]
 
 [dependencies]

--- a/skia-org/src/drivers.rs
+++ b/skia-org/src/drivers.rs
@@ -17,6 +17,10 @@ pub use svg::SVG;
 pub mod vulkan;
 #[cfg(feature = "vulkan")]
 pub use vulkan::Vulkan;
+#[cfg(feature = "d3d")]
+pub mod d3d;
+#[cfg(feature = "d3d")]
+pub use d3d::D3D;
 
 pub trait DrawingDriver {
     const NAME: &'static str;

--- a/skia-org/src/drivers/d3d.rs
+++ b/skia-org/src/drivers/d3d.rs
@@ -1,0 +1,127 @@
+use crate::artifact;
+use crate::drivers::DrawingDriver;
+use skia_safe::{
+    gpu,
+    gpu::{d3d, d3d::cp, Protected},
+    Budgeted, Canvas, ImageInfo, Surface,
+};
+use std::path::Path;
+use std::ptr;
+use winapi::{
+    shared::{
+        dxgi::{CreateDXGIFactory1, IDXGIAdapter1, IDXGIFactory1},
+        winerror::S_OK,
+    },
+    um::{
+        d3d12::{
+            D3D12CreateDevice, ID3D12CommandQueue, ID3D12Device, D3D12_COMMAND_LIST_TYPE_DIRECT,
+            D3D12_COMMAND_QUEUE_DESC, D3D12_COMMAND_QUEUE_FLAG_NONE,
+            D3D12_COMMAND_QUEUE_PRIORITY_NORMAL,
+        },
+        d3dcommon::D3D_FEATURE_LEVEL_12_0,
+    },
+    Interface,
+};
+use wio::com::ComPtr;
+
+pub struct D3D {
+    context: gpu::Context,
+}
+
+impl DrawingDriver for D3D {
+    const NAME: &'static str = "d3d";
+
+    fn new() -> Self {
+        let factory = {
+            let mut factory: *mut IDXGIFactory1 = ptr::null_mut();
+            let r = unsafe {
+                CreateDXGIFactory1(&IDXGIFactory1::uuidof(), &mut factory as *mut _ as _)
+            };
+            if r != S_OK {
+                panic!("failed to create DXGI factory");
+            }
+            unsafe { ComPtr::from_raw(factory) }
+        };
+
+        let adapter = {
+            let mut adapter: *mut IDXGIAdapter1 = ptr::null_mut();
+            let r = unsafe { factory.EnumAdapters1(0, &mut adapter as *mut _ as _) };
+            if r != S_OK {
+                panic!("failed to create DXGI adapter");
+            }
+            unsafe { ComPtr::from_raw(adapter) }
+        };
+
+        let device = {
+            let mut device: *mut ID3D12Device = ptr::null_mut();
+            let r = unsafe {
+                D3D12CreateDevice(
+                    ptr::null_mut(),
+                    D3D_FEATURE_LEVEL_12_0,
+                    &ID3D12Device::uuidof(),
+                    &mut device as *mut _ as _,
+                )
+            };
+            if r != S_OK {
+                panic!("failed to create D3D device")
+            }
+            unsafe { ComPtr::from_raw(device) }
+        };
+
+        let queue = {
+            let mut queue: *mut ID3D12CommandQueue = ptr::null_mut();
+            let desc = D3D12_COMMAND_QUEUE_DESC {
+                Type: D3D12_COMMAND_LIST_TYPE_DIRECT,
+                Priority: D3D12_COMMAND_QUEUE_PRIORITY_NORMAL as _,
+                Flags: D3D12_COMMAND_QUEUE_FLAG_NONE,
+                NodeMask: 0,
+            };
+            let r = unsafe {
+                device.CreateCommandQueue(
+                    &desc,
+                    &ID3D12CommandQueue::uuidof(),
+                    &mut queue as *mut _ as _,
+                )
+            };
+            if r != S_OK {
+                panic!("failed to create D3D device")
+            }
+            unsafe { ComPtr::from_raw(queue) }
+        };
+
+        let backend_context = d3d::BackendContext {
+            adapter: cp::from_ptr(adapter.into_raw() as _),
+            device: cp::from_ptr(device.into_raw() as _),
+            queue: cp::from_ptr(queue.into_raw() as _),
+            protected_context: Protected::No,
+        };
+
+        let context = unsafe { gpu::Context::new_d3d(&backend_context) }.unwrap();
+        Self { context }
+    }
+
+    fn draw_image(
+        &mut self,
+        (width, height): (i32, i32),
+        path: &Path,
+        name: &str,
+        func: impl Fn(&mut Canvas),
+    ) {
+        let image_info = ImageInfo::new_n32_premul((width * 2, height * 2), None);
+        let mut surface = Surface::new_render_target(
+            &mut self.context,
+            Budgeted::Yes,
+            &image_info,
+            None,
+            gpu::SurfaceOrigin::BottomLeft,
+            None,
+            false,
+        )
+        .unwrap();
+
+        artifact::draw_image_on_surface(&mut surface, path, name, func);
+    }
+    fn draw_image_256(&mut self, path: &Path, name: &str, func: impl Fn(&mut Canvas)) {
+        self.draw_image((256, 256), path, name, func)
+    }
+}

--- a/skia-org/src/drivers/d3d.rs
+++ b/skia-org/src/drivers/d3d.rs
@@ -18,7 +18,7 @@ use winapi::{
             D3D12_COMMAND_QUEUE_DESC, D3D12_COMMAND_QUEUE_FLAG_NONE,
             D3D12_COMMAND_QUEUE_PRIORITY_NORMAL,
         },
-        d3dcommon::D3D_FEATURE_LEVEL_12_0,
+        d3dcommon::D3D_FEATURE_LEVEL_11_0,
     },
     Interface,
 };
@@ -56,8 +56,8 @@ impl DrawingDriver for D3D {
             let mut device: *mut ID3D12Device = ptr::null_mut();
             let r = unsafe {
                 D3D12CreateDevice(
-                    ptr::null_mut(),
-                    D3D_FEATURE_LEVEL_12_0,
+                    adapter.as_raw() as _,
+                    D3D_FEATURE_LEVEL_11_0,
                     &ID3D12Device::uuidof(),
                     &mut device as *mut _ as _,
                 )

--- a/skia-org/src/drivers/d3d.rs
+++ b/skia-org/src/drivers/d3d.rs
@@ -2,7 +2,7 @@ use crate::artifact;
 use crate::drivers::DrawingDriver;
 use skia_safe::{
     gpu,
-    gpu::{d3d, d3d::cp, Protected},
+    gpu::{d3d, Protected},
     Budgeted, Canvas, ImageInfo, Surface,
 };
 use std::path::Path;
@@ -56,9 +56,9 @@ impl DrawingDriver for D3D {
         };
 
         let backend_context = d3d::BackendContext {
-            adapter: cp::from_ptr(adapter.into_raw() as _),
-            device: cp::from_ptr(device.into_raw() as _),
-            queue: cp::from_ptr(queue.into_raw() as _),
+            adapter,
+            device,
+            queue,
             protected_context: Protected::No,
         };
 

--- a/skia-org/src/main.rs
+++ b/skia-org/src/main.rs
@@ -142,10 +142,10 @@ fn main() {
         skpaint_overview::draw(driver, &out_path);
 
         #[cfg(feature = "textlayout")]
-        skshaper_example::draw(driver, &out_path);
-
-        #[cfg(feature = "textlayout")]
-        skparagraph_example::draw(driver, &out_path);
+        {
+            skshaper_example::draw(driver, &out_path);
+            skparagraph_example::draw(driver, &out_path);
+        }
     }
 }
 

--- a/skia-org/src/main.rs
+++ b/skia-org/src/main.rs
@@ -125,6 +125,15 @@ fn main() {
         }
     }
 
+    #[cfg(feature = "d3d")]
+    {
+        use drivers::d3d::D3D;
+
+        if drivers.contains(&D3D::NAME) {
+            draw_all(&mut D3D::new(), &out_path)
+        }
+    }
+
     fn draw_all<Driver: DrawingDriver>(driver: &mut Driver, out_path: &Path) {
         let out_path = out_path.join(Driver::NAME);
 
@@ -150,6 +159,9 @@ fn get_available_drivers() -> Vec<&'static str> {
     }
     if cfg!(feature = "metal") {
         drivers.push("metal")
+    }
+    if cfg!(feature = "d3d") {
+        drivers.push("d3d")
     }
     drivers
 }

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -23,6 +23,7 @@ default = []
 gl = ["gpu", "skia-bindings/gl"]
 vulkan = ["gpu", "skia-bindings/vulkan"]
 metal = ["gpu", "skia-bindings/metal"]
+d3d = ["gpu", "skia-bindings/d3d"]
 textlayout = ["skia-bindings/textlayout"]
 # implied only, do not use
 gpu = []

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -23,7 +23,7 @@ default = []
 gl = ["gpu", "skia-bindings/gl"]
 vulkan = ["gpu", "skia-bindings/vulkan"]
 metal = ["gpu", "skia-bindings/metal"]
-d3d = ["gpu", "skia-bindings/d3d"]
+d3d = ["gpu", "winapi", "wio", "skia-bindings/d3d"]
 textlayout = ["skia-bindings/textlayout"]
 # implied only, do not use
 gpu = []
@@ -35,6 +35,10 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 bitflags = "1.0.4"
 skia-bindings = { version = "=0.33.0", path = "../skia-bindings" }
 lazy_static = "1.4"
+# for d3d types
+winapi = { version = "0.3.9", features = ["d3d12", "dxgi"], optional = true }
+# for ComPtr
+wio = { version = "0.2.2", optional = true }
 
 [dev-dependencies]
 serial_test = "0.4"

--- a/skia-safe/README.md
+++ b/skia-safe/README.md
@@ -25,6 +25,8 @@ Skia-safe wraps most parts of the public Skia C++ APIs:
   - [x] Vulkan
   - [x] OpenGL
   - [x] Metal
+  - [x] Direct3D
+  - [ ] WebGPU [Dawn](https://dawn.googlesource.com/dawn/)
 
 Wrappers for functions that take callbacks and virtual classes are not supported right now. While we think they should be wrapped, the use cases related seem to be rather special, so we postponed that for now.
 
@@ -53,6 +55,10 @@ Note that Vulkan drivers need to be available. On Windows, they are most likely 
 ### `metal`
 
 Support for Metal on macOS and iOS targets can be enabled by adding the feature `metal`.
+
+### `d3d`
+
+The Direct3D backend can be enabled for Windows targets by adding the feature `d3d`.
 
 ### `textlayout`
 

--- a/skia-safe/src/core/surface.rs
+++ b/skia-safe/src/core/surface.rs
@@ -21,6 +21,12 @@ fn test_surface_backend_handle_access_naming() {
     let _ = BackendHandleAccess::FlushWrite;
 }
 
+pub use skia_bindings::SkSurface_BackendSurfaceAccess as BackendSurfaceAccess;
+#[test]
+fn test_surface_backend_surface_access_naming() {
+    let _ = BackendSurfaceAccess::Present;
+}
+
 pub type Surface = RCHandle<SkSurface>;
 
 impl NativeRefCountedBase for SkSurface {
@@ -459,11 +465,20 @@ impl RCHandle<SkSurface> {
     }
 
     #[deprecated(since = "0.30.0", note = "Use flush_and_submit()")]
+    // when removed, replace it with flush_with_access() and deprecate it.
     pub fn flush(&mut self) {
         self.flush_and_submit()
     }
 
-    // TODO: flush(BackendSurfaceAccess, FlushInfo)
+    #[cfg(feature = "gpu")]
+    pub fn flush_with_access_info(
+        &mut self,
+        access: BackendSurfaceAccess,
+        info: &gpu::FlushInfo,
+    ) -> gpu::SemaphoresSubmitted {
+        unsafe { self.native_mut().flush(access, info.native()) }
+    }
+
     // TODO: flush(FlushInfo, GrBackendSurfaceMutableState)
     // TODO: wait()
 

--- a/skia-safe/src/gpu.rs
+++ b/skia-safe/src/gpu.rs
@@ -21,3 +21,6 @@ pub mod vk;
 
 #[cfg(feature = "metal")]
 pub mod mtl;
+
+#[cfg(feature = "d3d")]
+pub mod d3d;

--- a/skia-safe/src/gpu/backend_surface.rs
+++ b/skia-safe/src/gpu/backend_surface.rs
@@ -63,7 +63,9 @@ impl Handle<GrBackendFormat> {
 
     #[cfg(feature = "d3d")]
     pub fn new_dxgi(format: d3d::DXGI_FORMAT) -> Self {
-        Self::construct(|bf| unsafe { sb::C_GrBackendFormat_ConstructDxgi(bf, format) })
+        Self::construct(|bf| unsafe {
+            sb::C_GrBackendFormat_ConstructDxgi(bf, format.into_native())
+        })
     }
 
     #[deprecated(since = "0.19.0", note = "use backend()")]
@@ -114,8 +116,8 @@ impl Handle<GrBackendFormat> {
 
     #[cfg(feature = "d3d")]
     pub fn as_dxgi_format(&self) -> Option<d3d::DXGI_FORMAT> {
-        let mut f = d3d::DXGI_FORMAT::DXGI_FORMAT_UNKNOWN;
-        unsafe { self.native().asDxgiFormat(&mut f) }.if_true_some(f)
+        let mut f = sb::DXGI_FORMAT::DXGI_FORMAT_UNKNOWN;
+        unsafe { self.native().asDxgiFormat(&mut f) }.if_true_some(d3d::DXGI_FORMAT::from_native(f))
     }
 
     pub fn to_texture_2d(&self) -> Option<Self> {

--- a/skia-safe/src/gpu/backend_surface.rs
+++ b/skia-safe/src/gpu/backend_surface.rs
@@ -269,10 +269,13 @@ impl Handle<GrBackendTexture> {
     #[cfg(feature = "d3d")]
     pub fn d3d_texture_resource_info(&self) -> Option<d3d::TextureResourceInfo> {
         unsafe {
-            let mut resource_info = sb::GrD3DTextureResourceInfo::default();
+            let mut info = sb::GrD3DTextureResourceInfo::default();
             self.native()
-                .getD3DTextureResourceInfo(&mut resource_info)
-                .if_true_then_some(|| d3d::TextureResourceInfo::from_native(resource_info))
+                .getD3DTextureResourceInfo(&mut info)
+                .if_true_then_some(|| {
+                    assert!(!info.fResource.fObject.is_null());
+                    d3d::TextureResourceInfo::from_native(info)
+                })
         }
     }
 
@@ -455,8 +458,10 @@ impl Handle<GrBackendRenderTarget> {
     #[cfg(feature = "d3d")]
     pub fn d3d_texture_resource_info(&self) -> Option<d3d::TextureResourceInfo> {
         let mut info = sb::GrD3DTextureResourceInfo::default();
-        unsafe { self.native().getD3DTextureResourceInfo(&mut info) }
-            .if_true_then_some(|| d3d::TextureResourceInfo::from_native(info))
+        unsafe { self.native().getD3DTextureResourceInfo(&mut info) }.if_true_then_some(|| {
+            assert!(!info.fResource.fObject.is_null());
+            d3d::TextureResourceInfo::from_native(info)
+        })
     }
 
     #[cfg(feature = "d3d")]

--- a/skia-safe/src/gpu/context.rs
+++ b/skia-safe/src/gpu/context.rs
@@ -62,8 +62,8 @@ impl RCHandle<GrContext> {
 
     // TODO: support variant with GrContextOptions
     #[cfg(feature = "d3d")]
-    pub fn new_d3d(backend_context: &d3d::BackendContext) -> Option<Context> {
-        unsafe { Context::from_ptr(sb::C_GrContext_MakeDirect3D(backend_context.native())) }
+    pub unsafe fn new_d3d(backend_context: &d3d::BackendContext) -> Option<Context> {
+        Context::from_ptr(sb::C_GrContext_MakeDirect3D(backend_context.native()))
     }
 
     // TODO: threadSafeProxy()

--- a/skia-safe/src/gpu/context.rs
+++ b/skia-safe/src/gpu/context.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "d3d")]
+use super::d3d;
 #[cfg(feature = "gl")]
 use super::gl;
 #[cfg(feature = "vulkan")]
@@ -56,6 +58,12 @@ impl RCHandle<GrContext> {
         queue: *mut std::ffi::c_void,
     ) -> Option<Context> {
         Context::from_ptr(sb::C_GrContext_MakeMetal(device, queue))
+    }
+
+    // TODO: support variant with GrContextOptions
+    #[cfg(feature = "d3d")]
+    pub fn new_d3d(backend_context: &d3d::BackendContext) -> Option<Context> {
+        unsafe { Context::from_ptr(sb::C_GrContext_MakeDirect3D(backend_context.native())) }
     }
 
     // TODO: threadSafeProxy()

--- a/skia-safe/src/gpu/context.rs
+++ b/skia-safe/src/gpu/context.rs
@@ -2,7 +2,7 @@
 use super::d3d;
 #[cfg(feature = "gl")]
 use super::gl;
-#[cfg(feature = "vk")]
+#[cfg(feature = "vulkan")]
 use super::vk;
 use super::{BackendRenderTarget, BackendSurfaceMutableState, BackendTexture};
 use crate::gpu::{BackendFormat, MipMapped, Renderable};

--- a/skia-safe/src/gpu/context.rs
+++ b/skia-safe/src/gpu/context.rs
@@ -2,8 +2,9 @@
 use super::d3d;
 #[cfg(feature = "gl")]
 use super::gl;
-#[cfg(feature = "vulkan")]
-use super::{vk, BackendRenderTarget, BackendSurfaceMutableState, BackendTexture};
+#[cfg(feature = "vk")]
+use super::vk;
+use super::{BackendRenderTarget, BackendSurfaceMutableState, BackendTexture};
 use crate::gpu::{BackendFormat, MipMapped, Renderable};
 use crate::prelude::*;
 use crate::{image, ColorType, Data, Image};

--- a/skia-safe/src/gpu/d3d.rs
+++ b/skia-safe/src/gpu/d3d.rs
@@ -1,4 +1,3 @@
-use crate::prelude::*;
 use skia_bindings as sb;
 
 mod backend_context;
@@ -17,36 +16,3 @@ pub use sb::ID3D12Resource;
 pub use sb::IDXGIAdapter1;
 pub use sb::D3D12_RESOURCE_STATES;
 pub use sb::DXGI_FORMAT;
-
-#[repr(transparent)]
-#[allow(non_camel_case_types)]
-pub struct cp<T: AsIUnknown>(*mut T);
-
-impl<T: AsIUnknown> NativeTransmutable<skia_bindings::gr_cp<T>> for cp<T> {}
-#[test]
-fn test_cp_layout() {
-    cp::<ID3D12Device>::test_layout();
-}
-
-impl<T: AsIUnknown> Drop for cp<T> {
-    fn drop(&mut self) {
-        unsafe { sb::C_IUnknown_Release(self.0 as _) }
-    }
-}
-
-impl<T: AsIUnknown> Clone for cp<T> {
-    fn clone(&self) -> Self {
-        Self::new(self.0)
-    }
-}
-
-impl<T: AsIUnknown> cp<T> {
-    /// Creates a new smart pointer for D3D types.
-    ///
-    /// Asserts if ptr is `null`, increases the reference count.
-    pub fn new(ptr: *mut T) -> Self {
-        assert!(!ptr.is_null());
-        unsafe { sb::C_IUnknown_AddRef(ptr as _) };
-        cp(ptr)
-    }
-}

--- a/skia-safe/src/gpu/d3d.rs
+++ b/skia-safe/src/gpu/d3d.rs
@@ -1,0 +1,52 @@
+use crate::prelude::*;
+use skia_bindings as sb;
+
+mod backend_context;
+pub use backend_context::*;
+
+mod types;
+pub use types::*;
+
+// re-export D3D types we use
+
+pub use sb::AsIUnknown;
+pub use sb::GrD3DResourceStateEnum as ResourceStateEnum;
+pub use sb::ID3D12CommandQueue;
+pub use sb::ID3D12Device;
+pub use sb::ID3D12Resource;
+pub use sb::IDXGIAdapter1;
+pub use sb::D3D12_RESOURCE_STATES;
+pub use sb::DXGI_FORMAT;
+
+#[repr(transparent)]
+#[allow(non_camel_case_types)]
+pub struct cp<T: AsIUnknown>(*mut T);
+
+impl<T: AsIUnknown> NativeTransmutable<skia_bindings::gr_cp<T>> for cp<T> {}
+#[test]
+fn test_cp_layout() {
+    cp::<ID3D12Device>::test_layout();
+}
+
+impl<T: AsIUnknown> Drop for cp<T> {
+    fn drop(&mut self) {
+        unsafe { sb::C_IUnknown_Release(self.0 as _) }
+    }
+}
+
+impl<T: AsIUnknown> Clone for cp<T> {
+    fn clone(&self) -> Self {
+        Self::new(self.0)
+    }
+}
+
+impl<T: AsIUnknown> cp<T> {
+    /// Creates a new smart pointer for D3D types.
+    ///
+    /// Asserts if ptr is `null`, increases the reference count.
+    pub fn new(ptr: *mut T) -> Self {
+        assert!(!ptr.is_null());
+        unsafe { sb::C_IUnknown_AddRef(ptr as _) };
+        cp(ptr)
+    }
+}

--- a/skia-safe/src/gpu/d3d.rs
+++ b/skia-safe/src/gpu/d3d.rs
@@ -1,4 +1,6 @@
+use crate::prelude::*;
 use skia_bindings as sb;
+use winapi::{shared::dxgi, shared::dxgiformat, um::d3d12};
 
 mod backend_context;
 pub use backend_context::*;
@@ -8,11 +10,17 @@ pub use types::*;
 
 // re-export D3D types we use
 
-pub use sb::AsIUnknown;
 pub use sb::GrD3DResourceStateEnum as ResourceStateEnum;
-pub use sb::ID3D12CommandQueue;
-pub use sb::ID3D12Device;
-pub use sb::ID3D12Resource;
-pub use sb::IDXGIAdapter1;
-pub use sb::D3D12_RESOURCE_STATES;
-pub use sb::DXGI_FORMAT;
+
+pub use d3d12::ID3D12CommandQueue;
+pub use d3d12::ID3D12Device;
+pub use d3d12::ID3D12Resource;
+pub use d3d12::D3D12_RESOURCE_STATES;
+pub use dxgi::IDXGIAdapter1;
+pub use dxgiformat::DXGI_FORMAT;
+
+impl NativeTransmutable<sb::DXGI_FORMAT> for dxgiformat::DXGI_FORMAT {}
+#[test]
+fn test_dxgi_format_layout() {
+    dxgiformat::DXGI_FORMAT::test_layout();
+}

--- a/skia-safe/src/gpu/d3d/backend_context.rs
+++ b/skia-safe/src/gpu/d3d/backend_context.rs
@@ -1,0 +1,20 @@
+use super::cp;
+use super::{ID3D12CommandQueue, ID3D12Device, IDXGIAdapter1};
+use crate::gpu;
+use crate::prelude::*;
+use skia_bindings::GrD3DBackendContext;
+
+#[repr(C)]
+#[derive(Clone)]
+pub struct BackendContext {
+    pub adapter: cp<IDXGIAdapter1>,
+    pub device: cp<ID3D12Device>,
+    pub queue: cp<ID3D12CommandQueue>,
+    pub protected_context: gpu::Protected,
+}
+
+impl NativeTransmutable<GrD3DBackendContext> for BackendContext {}
+#[test]
+fn test_backend_context_layout() {
+    BackendContext::test_layout();
+}

--- a/skia-safe/src/gpu/d3d/types.rs
+++ b/skia-safe/src/gpu/d3d/types.rs
@@ -1,7 +1,41 @@
-use super::{cp, ID3D12Resource, D3D12_RESOURCE_STATES, DXGI_FORMAT};
+use super::{ID3D12Resource, D3D12_RESOURCE_STATES, DXGI_FORMAT};
 use crate::gpu;
 use crate::prelude::*;
-use skia_bindings::GrD3DTextureResourceInfo;
+use skia_bindings as sb;
+use skia_bindings::{AsIUnknown, GrD3DTextureResourceInfo};
+
+#[repr(transparent)]
+#[allow(non_camel_case_types)]
+pub struct cp<T: AsIUnknown>(*mut T);
+
+impl<T: AsIUnknown> NativeTransmutable<skia_bindings::gr_cp<T>> for cp<T> {}
+#[test]
+fn test_cp_layout() {
+    cp::<super::ID3D12Device>::test_layout();
+}
+
+impl<T: AsIUnknown> Drop for cp<T> {
+    fn drop(&mut self) {
+        unsafe { sb::C_IUnknown_Release(self.0 as _) }
+    }
+}
+
+impl<T: AsIUnknown> Clone for cp<T> {
+    fn clone(&self) -> Self {
+        Self::new(self.0)
+    }
+}
+
+impl<T: AsIUnknown> cp<T> {
+    /// Creates a new smart pointer for D3D types.
+    ///
+    /// Asserts if ptr is `null`, increases the reference count.
+    pub fn new(ptr: *mut T) -> Self {
+        assert!(!ptr.is_null());
+        unsafe { sb::C_IUnknown_AddRef(ptr as _) };
+        cp(ptr)
+    }
+}
 
 #[repr(C)]
 #[derive(Clone)]

--- a/skia-safe/src/gpu/d3d/types.rs
+++ b/skia-safe/src/gpu/d3d/types.rs
@@ -1,0 +1,21 @@
+use super::{cp, ID3D12Resource, D3D12_RESOURCE_STATES, DXGI_FORMAT};
+use crate::gpu;
+use crate::prelude::*;
+use skia_bindings::GrD3DTextureResourceInfo;
+
+#[repr(C)]
+#[derive(Clone)]
+pub struct TextureResourceInfo {
+    pub resource: cp<ID3D12Resource>,
+    pub resource_state: D3D12_RESOURCE_STATES,
+    pub format: DXGI_FORMAT,
+    pub level_count: u32,
+    pub sample_quality_level: std::os::raw::c_uint,
+    pub protected: gpu::Protected,
+}
+
+impl NativeTransmutable<GrD3DTextureResourceInfo> for TextureResourceInfo {}
+#[test]
+fn test_texture_resource_info_layout() {
+    TextureResourceInfo::test_layout();
+}

--- a/skia-safe/src/gpu/d3d/types.rs
+++ b/skia-safe/src/gpu/d3d/types.rs
@@ -2,59 +2,59 @@ use super::{ID3D12Resource, D3D12_RESOURCE_STATES, DXGI_FORMAT};
 use crate::gpu;
 use crate::prelude::*;
 use skia_bindings as sb;
-use skia_bindings::{AsIUnknown, GrD3DTextureResourceInfo};
+use skia_bindings::GrD3DTextureResourceInfo;
 use std::ptr;
 
 #[repr(transparent)]
 #[allow(non_camel_case_types)]
-pub struct cp<T: AsIUnknown>(*mut T);
+pub struct cp<T>(*mut T);
 
-pub fn safe_com_add_ref<T: AsIUnknown>(obj: *mut T) -> *mut T {
+pub fn safe_com_add_ref<T>(obj: *mut T) -> *mut T {
     if !obj.is_null() {
         unsafe { sb::C_IUnknown_AddRef(obj as _) }
     }
     obj
 }
 
-pub fn safe_com_release<T: AsIUnknown>(obj: *mut T) {
+pub fn safe_com_release<T>(obj: *mut T) {
     if !obj.is_null() {
         unsafe { sb::C_IUnknown_Release(obj as _) }
     }
 }
 
-impl<T: AsIUnknown> NativeTransmutable<skia_bindings::gr_cp<T>> for cp<T> {}
+impl<T> NativeTransmutable<skia_bindings::gr_cp<T>> for cp<T> {}
 #[test]
 fn test_cp_layout() {
     cp::<super::ID3D12Device>::test_layout();
 }
 
-impl<T: AsIUnknown> Drop for cp<T> {
+impl<T> Drop for cp<T> {
     fn drop(&mut self) {
         safe_com_release(self.0);
     }
 }
 
-impl<T: AsIUnknown> Clone for cp<T> {
+impl<T> Clone for cp<T> {
     fn clone(&self) -> Self {
         Self::from_ptr(safe_com_add_ref(self.0))
     }
 }
 
-impl<T: AsIUnknown> Default for cp<T> {
+impl<T> Default for cp<T> {
     fn default() -> Self {
         Self::from_ptr(ptr::null_mut())
     }
 }
 
-impl<T: AsIUnknown> PartialEq for cp<T> {
+impl<T> PartialEq for cp<T> {
     fn eq(&self, other: &Self) -> bool {
         self.0 == other.0
     }
 }
 
-impl<T: AsIUnknown> Eq for cp<T> {}
+impl<T> Eq for cp<T> {}
 
-impl<T: AsIUnknown> cp<T> {
+impl<T> cp<T> {
     pub fn from_ptr(ptr: *mut T) -> Self {
         cp(ptr)
     }

--- a/skia-safe/src/gpu/d3d/types.rs
+++ b/skia-safe/src/gpu/d3d/types.rs
@@ -1,24 +1,21 @@
 use super::{ID3D12Resource, D3D12_RESOURCE_STATES, DXGI_FORMAT};
 use crate::gpu;
 use crate::prelude::*;
-use skia_bindings as sb;
 use skia_bindings::GrD3DTextureResourceInfo;
-use std::ptr;
+use winapi::um::unknwnbase::IUnknown;
 
-#[repr(transparent)]
-#[allow(non_camel_case_types)]
-pub struct cp<T>(*mut T);
+pub use wio::com::ComPtr as cp;
 
-pub fn safe_com_add_ref<T>(obj: *mut T) -> *mut T {
-    if !obj.is_null() {
-        unsafe { sb::C_IUnknown_AddRef(obj as _) }
+pub fn safe_com_add_ref<T: winapi::Interface>(ptr: *mut T) -> *mut T {
+    if !ptr.is_null() {
+        unsafe { (*(ptr as *mut IUnknown)).AddRef() };
     }
-    obj
+    ptr
 }
 
-pub fn safe_com_release<T>(obj: *mut T) {
-    if !obj.is_null() {
-        unsafe { sb::C_IUnknown_Release(obj as _) }
+pub fn safe_com_release<T: winapi::Interface>(ptr: *mut T) {
+    if !ptr.is_null() {
+        unsafe { (*(ptr as *mut IUnknown)).Release() };
     }
 }
 
@@ -28,60 +25,7 @@ fn test_cp_layout() {
     cp::<super::ID3D12Device>::test_layout();
 }
 
-impl<T> Drop for cp<T> {
-    fn drop(&mut self) {
-        safe_com_release(self.0);
-    }
-}
-
-impl<T> Clone for cp<T> {
-    fn clone(&self) -> Self {
-        Self::from_ptr(safe_com_add_ref(self.0))
-    }
-}
-
-impl<T> Default for cp<T> {
-    fn default() -> Self {
-        Self::from_ptr(ptr::null_mut())
-    }
-}
-
-impl<T> PartialEq for cp<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-
-impl<T> Eq for cp<T> {}
-
-impl<T> cp<T> {
-    pub fn from_ptr(ptr: *mut T) -> Self {
-        cp(ptr)
-    }
-
-    pub fn get(&self) -> *mut T {
-        self.0
-    }
-
-    pub fn reset(&mut self, object: *mut T) {
-        let old = self.0;
-        self.0 = object;
-        safe_com_release(old);
-    }
-
-    pub fn retain(&mut self, object: *mut T) {
-        if self.0 != object {
-            self.reset(safe_com_add_ref(object))
-        }
-    }
-
-    #[must_use]
-    pub fn release(&mut self) -> *mut T {
-        let obj = self.0;
-        self.0 = ptr::null_mut();
-        obj
-    }
-}
+// TODO: add remaining cp functions to ComPtr via traits (get, reset, retain).
 
 #[repr(C)]
 #[derive(Clone)]

--- a/skia-safe/src/gpu/types.rs
+++ b/skia-safe/src/gpu/types.rs
@@ -1,3 +1,7 @@
+use crate::prelude::*;
+use skia_bindings as sb;
+use std::ptr;
+
 pub use skia_bindings::GrBackendApi as BackendAPI;
 #[test]
 fn test_backend_api_layout() {
@@ -35,3 +39,59 @@ fn test_surface_origin_naming() {
 }
 
 // Note: BackendState is in gl/types.rs/
+
+bitflags! {
+    pub struct FlushFlags: i32 {
+        const NONE = sb::GrFlushFlags_kNone_GrFlushFlags;
+        const SYNC_CPU = sb::GrFlushFlags_kSyncCpu_GrFlushFlag;
+    }
+}
+
+#[allow(dead_code)]
+pub struct FlushInfo {
+    pub flags: FlushFlags,
+    // TODO: wrap access to the following fields in a safe way:
+    num_semaphores: std::os::raw::c_int,
+    signal_semaphores: *mut sb::GrBackendSemaphore,
+    finished_proc: sb::GrGpuFinishedProc,
+    finished_context: sb::GrGpuFinishedContext,
+    submitted_proc: sb::GrGpuSubmittedProc,
+    submitted_context: sb::GrGpuSubmittedContext,
+}
+
+impl Default for FlushInfo {
+    fn default() -> Self {
+        Self {
+            flags: FlushFlags::NONE,
+            num_semaphores: 0,
+            signal_semaphores: ptr::null_mut(),
+            finished_proc: None,
+            finished_context: ptr::null_mut(),
+            submitted_proc: None,
+            submitted_context: ptr::null_mut(),
+        }
+    }
+}
+
+impl From<FlushFlags> for FlushInfo {
+    fn from(flags: FlushFlags) -> Self {
+        Self {
+            flags,
+            ..Default::default()
+        }
+    }
+}
+
+impl NativeTransmutable<sb::GrFlushInfo> for FlushInfo {}
+#[test]
+fn test_flush_info_layout() {
+    FlushInfo::test_layout();
+}
+
+pub use sb::GrSemaphoresSubmitted as SemaphoresSubmitted;
+#[test]
+fn test_semaphores_submitted_naming() {
+    let _ = SemaphoresSubmitted::Yes;
+}
+
+// TODO: wrap GrPrepareForExternalIORequests

--- a/skia-safe/src/gpu/types.rs
+++ b/skia-safe/src/gpu/types.rs
@@ -40,10 +40,11 @@ fn test_surface_origin_naming() {
 
 // Note: BackendState is in gl/types.rs/
 
+// i32 on Windows, u32 on macOS, so we'd prefer to mal it to unsigned type in Rust.
 bitflags! {
-    pub struct FlushFlags: i32 {
-        const NONE = sb::GrFlushFlags_kNone_GrFlushFlags;
-        const SYNC_CPU = sb::GrFlushFlags_kSyncCpu_GrFlushFlag;
+    pub struct FlushFlags: u32 {
+        const NONE = sb::GrFlushFlags_kNone_GrFlushFlags as _;
+        const SYNC_CPU = sb::GrFlushFlags_kSyncCpu_GrFlushFlag as _;
     }
 }
 

--- a/skia-safe/src/prelude.rs
+++ b/skia-safe/src/prelude.rs
@@ -664,12 +664,18 @@ pub trait NativeTransmutable<NT: Sized>: Sized {
 
     /// Copies the native value to an equivalent Rust value.
     fn from_native(nt: NT) -> Self {
-        unsafe { mem::transmute_copy::<NT, Self>(&nt) }
+        let r = unsafe { mem::transmute_copy::<NT, Self>(&nt) };
+        // don't drop, the Rust type takes over.
+        mem::forget(nt);
+        r
     }
 
     /// Copies the rust type to an equivalent instance of the native type.
     fn into_native(self) -> NT {
-        unsafe { mem::transmute_copy::<Self, NT>(&self) }
+        let r = unsafe { mem::transmute_copy::<Self, NT>(&self) };
+        // don't drop, the native type takes over.
+        mem::forget(self);
+        r
     }
 
     /// Provides access to the Rust value through a


### PR DESCRIPTION
This PR is a humble attempt to support Skia's Direct3D backend. Like metal support, no binaries are planned.

- [x] skia-bindings builds.
- [x] Builds on CI
- [x] Add a minimum set of wrappers
- [x] Support D3D backend in skia-org
- [x] Wait for M85 to land in master and then replace the commits with the branch m85-d3d.
- [x] Fix Skia tag / version (temporarily uses the development only tag m84-d3d).
- [x] Update documentation