### PR TITLE
Prevent segfaults in the picture recorder

### DIFF
--- a/skia-safe/src/core/picture_recorder.rs
+++ b/skia-safe/src/core/picture_recorder.rs
@@ -74,3 +74,38 @@ impl Handle<SkPictureRecorder> {
         })
     }
 }
+
+#[test]
+fn good_case() {
+    let mut recorder = PictureRecorder::new();
+    let canvas = recorder.begin_recording(&Rect::new(0.0, 0.0, 100.0, 100.0), None, None);
+    canvas.clear(crate::Color::WHITE);
+    let _picture = recorder.finish_recording_as_picture(None).unwrap();
+}
+
+#[test]
+fn begin_recording_two_times() {
+    let mut recorder = PictureRecorder::new();
+    let canvas = recorder.begin_recording(&Rect::new(0.0, 0.0, 100.0, 100.0), None, None);
+    canvas.clear(crate::Color::WHITE);
+    assert!(recorder.recording_canvas().is_some());
+    let canvas = recorder.begin_recording(&Rect::new(0.0, 0.0, 100.0, 100.0), None, None);
+    canvas.clear(crate::Color::WHITE);
+    assert!(recorder.recording_canvas().is_some());
+}
+
+#[test]
+fn finishing_recording_two_times() {
+    let mut recorder = PictureRecorder::new();
+    let canvas = recorder.begin_recording(&Rect::new(0.0, 0.0, 100.0, 100.0), None, None);
+    canvas.clear(crate::Color::WHITE);
+    assert!(recorder.finish_recording_as_picture(None).is_some());
+    assert!(recorder.recording_canvas().is_none());
+    assert!(recorder.finish_recording_as_picture(None).is_none());
+}
+
+#[test]
+fn not_recording_no_canvas() {
+    let mut recorder = PictureRecorder::new();
+    assert!(recorder.recording_canvas().is_none());
+}

--- a/skia-safe/src/core/picture_recorder.rs
+++ b/skia-safe/src/core/picture_recorder.rs
@@ -20,15 +20,12 @@ impl NativeDrop for SkPictureRecorder {
     }
 }
 
-// TODO: why is the word "recording" used in all the functions, should we
-// remove it?
-
 impl Handle<SkPictureRecorder> {
     pub fn new() -> Self {
         Self::from_native(unsafe { SkPictureRecorder::new() })
     }
 
-    // TODO: beginRecording with BBoxHierarchy
+    // TODO: wrap beginRecording with BBoxHierarchy
 
     pub fn begin_recording(
         &mut self,


### PR DESCRIPTION
This MR prevents segfaults / UB in the picture recorder when 

- a `finish*` function is invoked without the recording being active.
- the `recording_canvas()` is called without an active recording session.

Closes #386 