### PR TITLE
HOTFIX 0.32.1 Downgrade minimum bindgen requirement and reenable semver.

### DIFF
--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.32.0"
+version = "0.32.1"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -49,9 +49,7 @@ shaper = ["textlayout"]
 
 [build-dependencies]
 cc = "1.0.37"
-# we'd like to reference specific bindgen versions here, because the generated
-# bindings are platform dependent and critical to this project.
-bindgen = "=0.54.1"
+bindgen = "0.54.0"
 # For enum variant name replacements.
 regex = "1.2.1"
 heck = "0.3.1"

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.32.0"
+version = "0.32.1"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -32,7 +32,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 
 [dependencies]
 bitflags = "1.0.4"
-skia-bindings = { version = "=0.32.0", path = "../skia-bindings" }
+skia-bindings = { version = "=0.32.1", path = "../skia-bindings" }
 lazy_static = "1.4"
 
 [dev-dependencies]


### PR DESCRIPTION
Bindgen version 0.54.1 [got yanked](https://github.com/rust-lang/rust-bindgen/commit/6653d0c0ae5a5c2e134adf3362bd2df93fbcf722) and we use it as a pinned dependency in skia-bindings, this PR removes the constraint.