### PR TITLE
If the download of binaries is forced but fails, the build script should fail

### DIFF
--- a/skia-bindings/build_support/binaries.rs
+++ b/skia-bindings/build_support/binaries.rs
@@ -118,11 +118,9 @@ pub fn key(repository_short_hash: &str, features: &[impl AsRef<str>], skia_debug
     components.join("-")
 }
 
-/// Create the download URL for the prebuilt binaries archive.
-pub fn download_url(tag: impl AsRef<str>, key: impl AsRef<str>) -> String {
-    let binding_url = cargo::env_var("SKIA_BINARIES_URL")
-        .unwrap_or_else(|| "https://github.com/rust-skia/skia-binaries/releases/download/{tag}/skia-binaries-{key}.tar.gz".to_string());
-    binding_url
+/// Prepare the final download URL for the prebuilt binaries archive.
+pub fn download_url(url_template: String, tag: impl AsRef<str>, key: impl AsRef<str>) -> String {
+    url_template
         .replace("{tag}", tag.as_ref())
         .replace("{key}", key.as_ref())
 }


### PR DESCRIPTION
.. and not try to run the full build.