### PR TITLE
Don't use impl AsMut anymore in functions that expect mutable Canvas.

### DIFF
--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.33.1"
+version = "0.34.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -175,7 +175,7 @@ impl<'lt> Default for OwnedCanvas<'lt> {
 }
 
 #[deprecated(
-    since = "0.0.0",
+    since = "0.34.0",
     note = "Use `&mut canvas` to pass an exclusive reference."
 )]
 impl AsMut<Canvas> for Canvas {
@@ -185,7 +185,7 @@ impl AsMut<Canvas> for Canvas {
 }
 
 #[deprecated(
-    since = "0.0.0",
+    since = "0.34.0",
     note = "Use `&mut canvas` to pass an exclusive reference."
 )]
 impl<'lt> AsMut<Canvas> for OwnedCanvas<'lt> {

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -174,15 +174,20 @@ impl<'lt> Default for OwnedCanvas<'lt> {
     }
 }
 
-// We implement AsMut for Canvas & OwnedCanvas
-// to simplify a number of API calls.
-// TODO: Should we support AsRef, too?
+#[deprecated(
+    since = "0.0.0",
+    note = "Use `&mut canvas` to pass an exclusive reference."
+)]
 impl AsMut<Canvas> for Canvas {
     fn as_mut(&mut self) -> &mut Canvas {
         self
     }
 }
 
+#[deprecated(
+    since = "0.0.0",
+    note = "Use `&mut canvas` to pass an exclusive reference."
+)]
 impl<'lt> AsMut<Canvas> for OwnedCanvas<'lt> {
     fn as_mut(&mut self) -> &mut Canvas {
         self.deref_mut()
@@ -1159,8 +1164,6 @@ pub enum AutoCanvasRestore {}
 
 impl AutoCanvasRestore {
     // TODO: rename to save(), add a method to Canvas, perhaps named auto_restored()?
-    // Note: Can't use AsMut here for the canvas, because it would break
-    //       the lifetime bound.
     pub fn guard(canvas: &mut Canvas, do_save: bool) -> AutoRestoredCanvas {
         let restore = construct(|acr| unsafe {
             sb::C_SkAutoCanvasRestore_Construct(acr, canvas.native_mut(), do_save)

--- a/skia-safe/src/core/picture.rs
+++ b/skia-safe/src/core/picture.rs
@@ -29,8 +29,8 @@ impl RCHandle<SkPicture> {
 
     // TODO: AbortCallback and the function that use it.
 
-    pub fn playback(&self, mut canvas: impl AsMut<Canvas>) {
-        unsafe { sb::C_SkPicture_playback(self.native(), canvas.as_mut().native_mut()) }
+    pub fn playback(&self, canvas: &mut Canvas) {
+        unsafe { sb::C_SkPicture_playback(self.native(), canvas.native_mut()) }
     }
 
     pub fn cull_rect(&self) -> Rect {

--- a/skia-safe/src/core/surface.rs
+++ b/skia-safe/src/core/surface.rs
@@ -374,16 +374,11 @@ impl RCHandle<SkSurface> {
         })
     }
 
-    pub fn draw(
-        &mut self,
-        mut canvas: impl AsMut<Canvas>,
-        size: impl Into<Size>,
-        paint: Option<&Paint>,
-    ) {
+    pub fn draw(&mut self, canvas: &mut Canvas, size: impl Into<Size>, paint: Option<&Paint>) {
         let size = size.into();
         unsafe {
             self.native_mut().draw(
-                canvas.as_mut().native_mut(),
+                canvas.native_mut(),
                 size.width,
                 size.height,
                 paint.native_ptr_or_null(),
@@ -520,29 +515,23 @@ fn test_raster_direct() {
 }
 
 #[test]
-fn test_drawing_as_mut_ergonomics() {
+fn test_drawing_owned_as_exclusive_ref_ergonomics() {
     let mut surface = Surface::new_raster_n32_premul((16, 16)).unwrap();
 
     // option1:
-    // - An _owned_ canvas can be drawn by transferring ownership.
-    {
-        let canvas = Canvas::new(ISize::new(16, 16), None).unwrap();
-        surface.draw(canvas, (10.0, 10.0), None);
-    }
-
-    // option2:
-    // - An &mut canvas can be drawn.
-
+    // - An &mut canvas can be drawn to.
     {
         let mut canvas = Canvas::new(ISize::new(16, 16), None).unwrap();
+        surface.draw(&mut canvas, (5.0, 5.0), None);
         surface.draw(&mut canvas, (10.0, 10.0), None);
     }
 
-    // option3:
-    // - A canvas from another surface can be drawn.
+    // option2:
+    // - A canvas from another surface can be drawn to.
     {
         let mut surface2 = Surface::new_raster_n32_premul((16, 16)).unwrap();
         let canvas = surface2.canvas();
+        surface.draw(canvas, (5.0, 5.0), None);
         surface.draw(canvas, (10.0, 10.0), None);
     }
 }

--- a/skia-safe/src/utils/camera.rs
+++ b/skia-safe/src/utils/camera.rs
@@ -160,8 +160,8 @@ impl RefHandle<Sk3DView> {
         m
     }
 
-    pub fn apply_to_canvas(&self, mut canvas: impl AsMut<Canvas>) -> &Self {
-        unsafe { self.native().applyToCanvas(canvas.as_mut().native_mut()) }
+    pub fn apply_to_canvas(&self, canvas: &mut Canvas) -> &Self {
+        unsafe { self.native().applyToCanvas(canvas.native_mut()) }
         self
     }
 
@@ -180,8 +180,6 @@ fn test_canvas_passing_syntax() {
     let view = View3D::default();
     // as mutable reference
     view.apply_to_canvas(&mut null_canvas);
-    // moved
-    view.apply_to_canvas(null_canvas);
 
     // and one with a mutable reference to a shared Canvas:
     let mut surface = Surface::new_raster_n32_premul((100, 100)).unwrap();

--- a/skia-safe/src/utils/shadow_utils.rs
+++ b/skia-safe/src/utils/shadow_utils.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 use crate::{scalar, Canvas, Color, Path, Point3};
-use core::borrow::BorrowMut;
 use skia_bindings as sb;
 use skia_bindings::SkShadowUtils;
 
@@ -14,7 +13,7 @@ bitflags! {
 
 #[allow(clippy::too_many_arguments)]
 pub fn draw_shadow(
-    mut canvas: impl AsMut<Canvas>,
+    canvas: &mut Canvas,
     path: &Path,
     z_plane_params: impl Into<Point3>,
     light_pos: impl Into<Point3>,
@@ -25,7 +24,7 @@ pub fn draw_shadow(
 ) {
     unsafe {
         SkShadowUtils::DrawShadow(
-            canvas.as_mut().native_mut(),
+            canvas.native_mut(),
             path.native(),
             z_plane_params.into().native(),
             light_pos.into().native(),
@@ -50,7 +49,7 @@ impl Canvas {
         flags: impl Into<Option<ShadowFlags>>,
     ) -> &mut Self {
         draw_shadow(
-            self.borrow_mut(),
+            self,
             path,
             z_plane_params,
             light_pos,

--- a/skia-safe/src/utils/text_utils.rs
+++ b/skia-safe/src/utils/text_utils.rs
@@ -10,7 +10,7 @@ fn test_align_layout() {
 }
 
 pub fn draw_str(
-    mut canvas: impl AsMut<Canvas>,
+    canvas: &mut Canvas,
     text: impl AsRef<str>,
     p: impl Into<Point>,
     font: &Font,
@@ -21,7 +21,7 @@ pub fn draw_str(
     let p = p.into();
     unsafe {
         SkTextUtils::Draw(
-            canvas.as_mut().native_mut(),
+            canvas.native_mut(),
             text.as_ptr() as _,
             text.len(),
             TextEncoding::UTF8.into_native(),


### PR DESCRIPTION
Given that it is very confusing (#398) and it actually does not even make sense to take ownership in the case of an `OwnedCanvas`, this PR removes all `impl AsMut<>` parameter signatures.

This change is breaking backwards compatibility, but hopefully only so for some rarely used edge cases.

I am keeping and deprecating the `AsMut<>` trait implementation for `&mut Canvas` as `OwnedCanvas`, so that uses of `.as_mut()` will compile after updating to the version that will contain this change.

@Kethku Would you mind to look at the changes and see if they resonate with what you would expect from the APIs that are  related to the Canvas type? Thanks!
