### PR TITLE
Add cargo doc generated documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,3 +64,16 @@ clean-packages:
 wait: 
 	@echo "published a package, Waiting for crates.io to catch up before publishing the next"
 	sleep 10
+
+.PHONY: update-doc
+update-doc:
+	cargo clean
+	rm -rf rust-skia.github.io
+	git clone git@github.com:rust-skia/rust-skia.github.io.git
+	cd skia-safe && cargo doc --no-deps --lib --features gl,vulkan,d3d,textlayout
+	cp -r target/doc rust-skia.github.io/doc
+	cd rust-skia.github.io && git add --all
+	cd rust-skia.github.io && git commit -m"Auto-Update of /doc" || true
+	cd rust-skia.github.io && git push origin master	
+	rm -rf rust-skia.github.io
+

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ This project provides _up to date_ safe bindings that bridge idiomatic Rust with
 
 ## Status
 
+### Documentation
+
+Because we [can't build on docs.rs](https://docs.rs/crate/skia-safe/0.34.0/builds), the `cargo doc` output for skia-safe is manually created and uploaded to [rust-skia.github.io](https://rust-skia.github.io/doc/skia_safe).
+
+We are [planning to add function level documentation](https://github.com/rust-skia/rust-skia/issues/23) by linking to Skia's documentation through [intra doc links](https://github.com/rust-lang/rfcs/blob/master/text/1946-intra-rustdoc-links.md), which should be stabilized soon.
+
 ### Crate
 
 A prerelease crate is available from [crates.io](https://crates.io/crates/skia-safe) and adding

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -4,6 +4,7 @@ name = "skia-safe"
 description = "Safe Skia Bindings for Rust"
 homepage = "https://github.com/rust-skia/rust-skia"
 repository = "https://github.com/rust-skia/rust-skia"
+documentation = "https://rust-skia.github.io/doc/skia_safe"
 readme = "README.md"
 # 5 max
 keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -124,7 +124,7 @@ pub struct TopLayerPixels<'a> {
     pub origin: IPoint,
 }
 
-/// The canvas type that is returned when it is managed by another instance,
+/// The canvas type that is returned when it is owned by another instance,
 /// like Surface, for example. For these cases, the Canvas' reference that is
 /// returned is bound to the lifetime of the owner.
 #[repr(transparent)]
@@ -141,7 +141,7 @@ impl NativeAccess<SkCanvas> for Canvas {
 }
 
 /// A type representing a canvas that is owned and dropped
-/// when it goes out of scope _and_ is bound to a the lifetime of another
+/// when it goes out of scope _and_ is bound to the lifetime of another
 /// instance.
 /// Function resolvement is done via the Deref trait.
 #[repr(transparent)]


### PR DESCRIPTION
This PR changes the metadata of skia-safe's Cargo.toml so that the documentation points to https://rust-skia.github.io/doc/skia_safe and also explains the documentation status and why we can't use docs.rs in the readme.

Closes #412 