### PR TITLE
Support WEBP image encoding formats.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m85 ([pending changes][skiapending], [our changes][skiaours]).
 
-[skiapending]: https://github.com/rust-skia/skia/compare/m85-0.32.2...google:chrome/m85
-[skiaours]: https://github.com/google/skia/compare/chrome/m85...rust-skia:m85-0.32.2
+[skiapending]: https://github.com/rust-skia/skia/compare/m85-0.34.2...google:chrome/m85
+[skiaours]: https://github.com/google/skia/compare/chrome/m85...rust-skia:m85-0.34.2
 
 ## Goals
 

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -52,16 +52,16 @@ jobs:
       ${{ if eq(parameters.deployRelease, 'False') }}:
         stable-all-features:
           toolchain: stable
-          features: 'gl,vulkan,textlayout'
+          features: 'gl,vulkan,textlayout,webp'
           exampleArgs: '--driver cpu --driver pdf --driver svg'
         stable-all-features-debug:
           toolchain: stable
-          features: 'gl,vulkan,textlayout'
+          features: 'gl,vulkan,textlayout,webp'
           exampleArgs: ''
           skia_debug: '1'
         beta-all-features:
           toolchain: beta
-          features: 'gl,vulkan,textlayout'
+          features: 'gl,vulkan,textlayout,webp'
           exampleArgs: ''
 
   variables:

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.34.1"
+version = "0.34.2"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m85-0.34.1"
+skia = "m85-0.34.2"
 depot_tools = "a110bf6"
 
 [features]
@@ -42,6 +42,9 @@ vulkan = []
 metal = []
 d3d = []
 textlayout = []
+webp = ["webp-encode", "webp-decode"]
+webp-encode = []
+webp-decode = []
 # deprecated since 0.25.0
 svg = []
 shaper = ["textlayout"]

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -169,7 +169,7 @@ impl FinalBuildConfiguration {
             }
 
             let mut args: Vec<(&str, String)> = vec![
-                ("is_official_build", no_if(build.skia_debug)),
+                ("is_official_build", yes_if(!build.skia_debug)),
                 ("is_debug", yes_if(build.skia_debug)),
                 ("skia_enable_gpu", yes_if(features.gpu())),
                 ("skia_use_gl", yes_if(features.gl)),
@@ -358,9 +358,6 @@ fn yes_if(y: bool) -> String {
     } else {
         no()
     }
-}
-fn no_if(no: bool) -> String {
-    yes_if(!no)
 }
 
 /// The configuration of the resulting binaries.

--- a/skia-org/Cargo.toml
+++ b/skia-org/Cargo.toml
@@ -22,6 +22,7 @@ vulkan = ["ash", "skia-safe/vulkan"]
 metal = ["metal-rs", "foreign-types", "cocoa", "objc", "skia-safe/metal"]
 d3d = ["skia-safe/d3d", "winapi", "wio"]
 textlayout = ["skia-safe/textlayout"]
+webp = ["skia-safe/webp"]
 
 [dependencies]
 skia-safe = { path = "../skia-safe" }

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.34.1"
+version = "0.34.2"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -26,6 +26,10 @@ vulkan = ["gpu", "skia-bindings/vulkan"]
 metal = ["gpu", "skia-bindings/metal"]
 d3d = ["gpu", "winapi", "wio", "skia-bindings/d3d"]
 textlayout = ["skia-bindings/textlayout"]
+webp = ["webp-encode", "webp-decode"]
+webp-encode = ["skia-bindings/webp-encode"]
+webp-decode = ["skia-bindings/webp-decode"]
+
 # implied only, do not use
 gpu = []
 # deprecated since 0.25.0, forwarded to skia-bindings with the intent to show warnings while build.rs is running
@@ -35,7 +39,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 [dependencies]
 bitflags = "1.2"
 lazy_static = "1.4"
-skia-bindings = { version = "=0.34.1", path = "../skia-bindings" }
+skia-bindings = { version = "=0.34.2", path = "../skia-bindings" }
 # for d3d types
 winapi = { version = "0.3.9", features = ["d3d12", "dxgi"], optional = true }
 # for ComPtr

--- a/skia-safe/README.md
+++ b/skia-safe/README.md
@@ -40,6 +40,8 @@ By default, full builds and prebuilt binaries of all platforms support the follo
 
 [^1]: skia-safe versions before 0.34.1 had no support for decoding GIF images.
 
+In addition to that, support for the WEBP image format can be enabled through the features `webp-encode`, `webp-decode`, and `webp` explained below.
+
 ## Features
 
 Skia-safe supports the following features that can be configured [via cargo](https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section):
@@ -79,6 +81,10 @@ The skshaper module can be accessed through `skia_safe::Shaper` and the Rust bi
 On **Windows**, the file `icudtl.dat` must be available in your executable's directory. To provide the data file, either copy it from the build's output directory (shown when skia-bindings is compiled with `cargo build -vv | grep "ninja: Entering directory"`), or - if your executable directory is writable - invoke the function `skia_safe::icu::init()` before using the `skia_safe::Shaper` object or the `skia_safe::textlayout` module. 
 
 Simple examples of the skshaper and skparagraph module bindings can be found [in the skia-org example command line application](https://github.com/rust-skia/rust-skia/blob/master/skia-org/src/).
+
+### `webp-encode`, `webp-decode`, `webp`
+
+`webp-encode` enables support for encoding Skia bitmaps and images to the [WEBP](https://en.wikipedia.org/wiki/WebP) image format, and `web-decode` enables support for decoding WEBP to Skia bitmaps and images. The `webp` feature can be used as a shorthand to enable the `webp-encode` and `webp-decode` features.
 
 ## Multithreading
 

--- a/skia-safe/tests/codec.rs
+++ b/skia-safe/tests/codec.rs
@@ -2,11 +2,11 @@
 use skia_safe::{codec, Bitmap, Data, EncodedImageFormat};
 
 /// The supported encoders.
-const SUPPORTED_ENCODERS: &[EncodedImageFormat] =
+const STANDARD_ENCODERS: &[EncodedImageFormat] =
     &[EncodedImageFormat::JPEG, EncodedImageFormat::PNG];
 
 /// The supported decoders.
-const SUPPORTED_DECODERS: &[EncodedImageFormat] = &[
+const STANDARD_DECODERS: &[EncodedImageFormat] = &[
     EncodedImageFormat::BMP,
     EncodedImageFormat::GIF,
     EncodedImageFormat::ICO,
@@ -15,8 +15,22 @@ const SUPPORTED_DECODERS: &[EncodedImageFormat] = &[
     EncodedImageFormat::WBMP,
 ];
 
+fn supported_encoders() -> Vec<EncodedImageFormat> {
+    let mut r = STANDARD_ENCODERS.to_vec();
+    #[cfg(feature = "webp-encode")]
+    r.push(EncodedImageFormat::WEBP);
+    r
+}
+
+fn supported_decoders() -> Vec<EncodedImageFormat> {
+    let mut r = STANDARD_DECODERS.to_vec();
+    #[cfg(feature = "webp-decode")]
+    r.push(EncodedImageFormat::WEBP);
+    r
+}
+
 #[test]
-fn encode() {
+fn test_supported_encoders() {
     const DIM: i32 = 16;
 
     let mut bitmap = Bitmap::new();
@@ -28,12 +42,12 @@ fn encode() {
         .filter(|format| bitmap.encode(*format, 100).is_some())
         .collect();
 
-    assert_eq!(&supported, &SUPPORTED_ENCODERS);
+    assert_eq!(supported, supported_encoders());
 }
 
 #[test]
-fn decode() {
-    let formats_supported: Vec<EncodedImageFormat> = DECODER_TESTS
+fn test_supported_decoders() {
+    let supported: Vec<EncodedImageFormat> = DECODER_TESTS
         .iter()
         .filter(|(format, bytes)| {
             let data = Data::new_copy(bytes);
@@ -46,7 +60,7 @@ fn decode() {
         .map(|(format, _bytes)| *format)
         .collect();
 
-    assert_eq!(&formats_supported, &SUPPORTED_DECODERS);
+    assert_eq!(supported, supported_decoders());
 }
 
 type DecoderTest = (EncodedImageFormat, &'static [u8]);


### PR DESCRIPTION
This PR introduces three new features in skia-bindings and skia-safe: `webp`, `webp-encode` and `webp-decode`, which enable WEBP image format encoding and/or decoding.