### PR TITLE
Chrome Milestone 87

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ _Notes:_
 
 ### For iOS
 
-Compilation to iOS is supported on macOS targeting the iOS simulator (`--target x86_64-apple-ios`) and 64 bit ARM devices (`--target aarch64-apple-ios`).
+Compilation to iOS is supported on macOS targeting the iOS simulator (`--target x86_64-apple-ios`) and 64 bit ARM devices (`--target aarch64-apple-ios`). The ARM64**e** architecture is [not supported yet](https://github.com/rust-lang/rust/issues/73628).
 
 ### Skia
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m87 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m87-0.36.0...google:chrome/m87
-[skia-ours]: https://github.com/google/skia/compare/chrome/m87...rust-skia:m87-0.36.0
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m87-0.36.1...google:chrome/m87
+[skia-ours]: https://github.com/google/skia/compare/chrome/m87...rust-skia:m87-0.36.1
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m87 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m87-0.35.1...google:chrome/m87
-[skia-ours]: https://github.com/google/skia/compare/chrome/m87...rust-skia:m87-0.35.1
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m87-0.36.0...google:chrome/m87
+[skia-ours]: https://github.com/google/skia/compare/chrome/m87...rust-skia:m87-0.36.0
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![Build Status](https://dev.azure.com/pragmatrix-github/rust-skia/_apis/build/status/rust-skia.rust-skia?branchName=master)](https://dev.azure.com/pragmatrix-github/rust-skia/_build/latest?definitionId=2&branchName=master)
 
-Skia Submodule Status: chrome/m86 ([upstream changes][skia-upstream], [our changes][skia-ours]).
+Skia Submodule Status: chrome/m87 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m86-0.35.0...google:chrome/m86
-[skia-ours]: https://github.com/google/skia/compare/chrome/m86...rust-skia:m86-0.35.0
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m87-0.35.1...google:chrome/m87
+[skia-ours]: https://github.com/google/skia/compare/chrome/m87...rust-skia:m87-0.35.1
 
 ## Goals
 

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -81,11 +81,11 @@ jobs:
     container: ${{ parameters.container }}
 
   steps:
-  - ${{ if eq(parameters.platform, 'macOS') }}:
-    # macOS
-    - bash: |
-        echo "##vso[task.setvariable variable=PATH;]/usr/local/opt/llvm/bin:$PATH"
-      displayName: Set path to clang / llvm-config
+  # - ${{ if eq(parameters.platform, 'macOS') }}:
+  #   # macOS
+  #   - bash: |
+  #       echo "##vso[task.setvariable variable=PATH;]/usr/local/opt/llvm/bin:$PATH"
+  #     displayName: Set path to clang / llvm-config
 
   - ${{ if eq(parameters.platform, 'Windows') }}:
     # Windows.

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -82,8 +82,7 @@ jobs:
 
   steps:
   - ${{ if eq(parameters.platform, 'macOS') }}:
-    # macOS preinstall LLVM conflicts with clang's LLVM, 
-    # which we require now to build iOS/arm64e targets
+    # Uninstall LLVM to prevent conflicts with Apple's clang. 
     - bash: |
         brew uninstall llvm
       displayName: 'Uninstall LLVM'

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -81,11 +81,12 @@ jobs:
     container: ${{ parameters.container }}
 
   steps:
-  # - ${{ if eq(parameters.platform, 'macOS') }}:
-  #   # macOS
-  #   - bash: |
-  #       echo "##vso[task.setvariable variable=PATH;]/usr/local/opt/llvm/bin:$PATH"
-  #     displayName: Set path to clang / llvm-config
+  - ${{ if eq(parameters.platform, 'macOS') }}:
+    # macOS preinstall LLVM conflicts with clang's LLVM, 
+    # which we require now to build iOS/arm64e targets
+    - bash: |
+        brew uninstall llvm
+      displayName: 'Uninstall LLVM'
 
   - ${{ if eq(parameters.platform, 'Windows') }}:
     # Windows.

--- a/patch/all-features-macos.patch
+++ b/patch/all-features-macos.patch
@@ -7,7 +7,7 @@ index 87e7ea7..df4903a 100644
  
  [features]
 -default = []
-+default = ["gl", "vulkan", "d3d", "textlayout", "webp"]
++default = ["gl", "vulkan", "metal", "textlayout", "webp"]
  gl = []
  vulkan = []
  metal = []
@@ -20,7 +20,7 @@ index 5a33403..2e93fee 100644
  
  [features]
 -default = []
-+default = ["gl", "vulkan", "d3d", "textlayout", "webp"]
++default = ["gl", "vulkan", "metal", "textlayout", "webp"]
  gl = ["offscreen_gl_context", "sparkle", "skia-safe/gl"]
  vulkan = ["ash", "skia-safe/vulkan"]
  metal = ["metal-rs", "foreign-types", "cocoa", "objc", "skia-safe/metal"]
@@ -33,7 +33,7 @@ index 37877ff..3ed3950 100644
  
  [features]
 -default = []
-+default = ["gl", "vulkan", "d3d", "textlayout", "webp"]
++default = ["gl", "vulkan", "metal", "textlayout", "webp"]
  gl = ["gpu", "skia-bindings/gl"]
  vulkan = ["gpu", "skia-bindings/vulkan"]
  metal = ["gpu", "skia-bindings/metal"]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m87-0.36.0"
+skia = "m87-0.36.1"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m86-0.35.1"
+skia = "m87-0.36.0"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m86-0.35.0"
+skia = "m86-0.35.1"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.35.1"
+version = "0.36.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -921,6 +921,9 @@ const OPAQUE_TYPES: &[&str] = &[
     // m86:
     "GrRecordingContext",
     "GrDirectContext",
+    // m87:
+    "GrD3DAlloc",
+    "GrD3DMemoryAllocator",
 ];
 
 const BLACKLISTED_TYPES: &[&str] = &[

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -1086,6 +1086,7 @@ const ENUM_TABLE: &[EnumEntry] = &[
     ("TextDirection", rewrite::k_xxx_uppercase),
     ("TextBaseline", rewrite::k_xxx),
     ("TextHeightBehavior", rewrite::k_xxx),
+    ("DrawOptions", rewrite::k_xxx),
     //
     // TextStyle.h
     //

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -660,6 +660,7 @@ fn generate_bindings(build: &FinalBuildConfiguration, output_directory: &Path) {
         .raw_line("pub enum SkVerticesPriv {}")
         .blacklist_type("SkVerticesPriv")
         .blacklist_function("SkVertices_priv.*")
+        .blacklist_function("std::bitset_flip")
         // Vulkan reexports that got swallowed by making them opaque.
         // (these can not be whitelisted by a extern "C" function)
         .whitelist_type("VkPhysicalDeviceFeatures")

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -660,7 +660,7 @@ fn generate_bindings(build: &FinalBuildConfiguration, output_directory: &Path) {
         .raw_line("pub enum SkVerticesPriv {}")
         .blacklist_type("SkVerticesPriv")
         .blacklist_function("SkVertices_priv.*")
-        .blacklist_function("std::bitset_flip")
+        .blacklist_function("std::bitset_flip.*")
         // Vulkan reexports that got swallowed by making them opaque.
         // (these can not be whitelisted by a extern "C" function)
         .whitelist_type("VkPhysicalDeviceFeatures")

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -418,6 +418,8 @@ impl BinariesConfiguration {
                 }
                 if features.metal {
                     link_libraries.push("framework=Metal");
+                    // MetalKit was added in m87 BUILD.gn.
+                    link_libraries.push("framework=MetalKit");
                     link_libraries.push("framework=Foundation");
                 }
             }

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -324,6 +324,10 @@ extern "C" SkImage* C_SkImage_makeSubset(const SkImage* self, const SkIRect* sub
     return self->makeSubset(*subset, direct).release();
 }
 
+extern "C" SkImage* C_SkImage_withDefaultMipmaps(const SkImage* self) {
+    return self->withDefaultMipmaps().release();
+}
+
 extern "C" SkImage* C_SkImage_makeNonTextureImage(const SkImage* self) {
     return self->makeNonTextureImage().release();
 }
@@ -486,6 +490,11 @@ extern "C" void C_SkPath_Oval(SkPath* uninitialized,
     new(uninitialized) SkPath(SkPath::Oval(r, dir));
 }
 
+extern "C" void C_SkPath_OvalWithStartIndex(SkPath* uninitialized,
+    const SkRect& r, SkPathDirection dir, unsigned startIndex) {
+    new(uninitialized) SkPath(SkPath::Oval(r, dir, startIndex));
+}
+
 extern "C" void C_SkPath_Circle(SkPath* uninitialized,
     SkScalar x, SkScalar y, SkScalar r, SkPathDirection dir) {
     new(uninitialized) SkPath(SkPath::Circle(x, y, r, dir));
@@ -494,6 +503,11 @@ extern "C" void C_SkPath_Circle(SkPath* uninitialized,
 extern "C" void C_SkPath_RRect(SkPath* uninitialized,
     const SkRRect& rr, SkPathDirection dir) {
     new(uninitialized) SkPath(SkPath::RRect(rr, dir));
+}
+
+extern "C" void C_SkPath_RRectWithStartIndex(SkPath* uninitialized,
+    const SkRRect& r, SkPathDirection dir, unsigned startIndex) {
+    new(uninitialized) SkPath(SkPath::RRect(r, dir, startIndex));
 }
 
 extern "C" void C_SkPath_Polygon(SkPath* uninitialized,
@@ -575,11 +589,29 @@ extern "C" uint32_t C_SkPath_getSegmentMasks(const SkPath* self) {
 // core/SkPathBuilder.h
 //
 
+extern "C" void C_SkPathBuilder_Construct(SkPathBuilder* uninitialized) {
+    new(uninitialized) SkPathBuilder();
+}
+
+/* m87: Implementation is missing.
+extern "C" void C_SkPathBuilder_Construct2(SkPathBuilder* uninitialized, SkPathFillType fillType) {
+    new(uninitialized) SkPathBuilder(fillType);
+}
+*/
+
+extern "C" void C_SkPathBuilder_Construct3(SkPathBuilder* uninitialized, const SkPath& path) {
+    new(uninitialized) SkPathBuilder(path);
+}
+
+extern "C" void C_SkPathBuilder_CopyConstruct(SkPathBuilder* uninitialized, const SkPathBuilder& pathBuilder) {
+    new(uninitialized) SkPathBuilder(pathBuilder);
+}
+
 extern "C" void C_SkPathBuilder_destruct(SkPathBuilder* self) {
     self->~SkPathBuilder();
 }
 
-extern "C" void C_SkPathBuilder_snapshot(SkPathBuilder* self, SkPath* path) {
+extern "C" void C_SkPathBuilder_snapshot(const SkPathBuilder* self, SkPath* path) {
     *path = self->snapshot();
 }
 
@@ -1025,6 +1057,10 @@ extern "C" void C_SkRRect_setOval(SkRRect* self, const SkRect* oval) {
     self->setOval(*oval);
 }
 
+extern "C" void C_SkRRect_dumpToString(const SkRRect* self, bool asHex, SkString* str) {
+    *str = self->dumpToString(asHex);
+}
+
 extern "C" bool C_SkRRect_Equals(const SkRRect* lhs, const SkRRect* rhs) {
     return *lhs == *rhs;
 }
@@ -1394,6 +1430,10 @@ extern "C" SkVertices* C_SkVertices_Builder_detach(SkVertices::Builder* builder)
 // SkPictureRecorder
 //
 
+extern "C" void C_SkPictureRecorder_Construct(SkPictureRecorder *uninitialized) {
+    new(uninitialized) SkPictureRecorder();
+}
+
 extern "C" void C_SkPictureRecorder_destruct(SkPictureRecorder *self) {
     self->~SkPictureRecorder();
 }
@@ -1527,6 +1567,10 @@ extern "C" SkColorFilter* C_SkColorFilters_Matrix(const SkColorMatrix* colorMatr
 
 extern "C" SkColorFilter* C_SkColorFilters_MatrixRowMajor(const SkScalar array[20]) {
     return SkColorFilters::Matrix(array).release();
+}
+
+extern "C" SkColorFilter* C_SkColorFilters_HSLAMatrixOfColorMatrix(const SkColorMatrix& colorMatrix) {
+    return SkColorFilters::HSLAMatrix(colorMatrix).release();
 }
 
 extern "C" SkColorFilter* C_SkColorFilters_HSLAMatrix(const float rowMajor[20]) {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -543,6 +543,10 @@ extern "C" SkPathFillType C_SkPath_getFillType(const SkPath* self) {
     return self->getFillType();
 }
 
+extern "C" bool C_SkPath_isConvex(const SkPath* self) {
+    return self->isConvex();
+}
+
 extern "C" bool C_SkPath_isEmpty(const SkPath* self) {
     return self->isEmpty();
 }

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -543,14 +543,6 @@ extern "C" SkPathFillType C_SkPath_getFillType(const SkPath* self) {
     return self->getFillType();
 }
 
-extern "C" SkPathConvexityType C_SkPath_getConvexityType(const SkPath* self) {
-    return self->getConvexityType();
-}
-
-extern "C" SkPathConvexityType C_SkPath_getConvexityTypeOrUnknown(const SkPath* self) {
-    return self->getConvexityTypeOrUnknown();
-}
-
 extern "C" bool C_SkPath_isEmpty(const SkPath* self) {
     return self->isEmpty();
 }
@@ -604,7 +596,7 @@ extern "C" void C_SkPathMeasure_destruct(const SkPathMeasure* self) {
 //
 
 extern "C" void
-C_SkPathTypes_Types(SkPathFillType *, SkPathConvexityType *, SkPathDirection *, SkPathSegmentMask *, SkPathVerb *) {}
+C_SkPathTypes_Types(SkPathFillType *, SkPathDirection *, SkPathSegmentMask *, SkPathVerb *) {}
 
 //
 // core/SkCanvas.h
@@ -2412,10 +2404,6 @@ SkColorFilter* C_SkRuntimeEffect_makeColorFilter(SkRuntimeEffect* self, SkData* 
 
 const SkString *C_SkRuntimeEffect_source(const SkRuntimeEffect *self) {
     return &self->source();
-}
-
-uint32_t C_SkRuntimeEffect_hash(const SkRuntimeEffect *self) {
-    return self->hash();
 }
 
 const SkRuntimeEffect::Uniform* C_SkRuntimeEffect_uniforms(const SkRuntimeEffect* self, size_t* count) {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -603,6 +603,10 @@ extern "C" void C_SkPathBuilder_Construct3(SkPathBuilder* uninitialized, const S
     new(uninitialized) SkPathBuilder(path);
 }
 
+extern "C" SkRect C_SkPathBuilder_computeBounds(const SkPathBuilder* self) {
+    return self->computeBounds();
+}
+
 extern "C" void C_SkPathBuilder_CopyConstruct(SkPathBuilder* uninitialized, const SkPathBuilder& pathBuilder) {
     new(uninitialized) SkPathBuilder(pathBuilder);
 }

--- a/skia-bindings/src/d3d.cpp
+++ b/skia-bindings/src/d3d.cpp
@@ -12,6 +12,14 @@
 #include "include/gpu/d3d/GrD3DBackendContext.h"
 
 //
+// gpu/d3d/GrD3DTypes.h
+//
+
+extern "C" void C_GrD3DTextureResourceInfo_Construct(GrD3DTextureResourceInfo* uninitialized) {
+    new(uninitialized) GrD3DTextureResourceInfo();
+}
+
+//
 // gpu/GrBackendSurface.h
 //
 
@@ -23,8 +31,8 @@ extern "C" void C_GrBackendTexture_ConstructD3D(GrBackendTexture* uninitialized,
     new(uninitialized)GrBackendTexture(width, height, *resourceInfo);
 }
 
-extern "C" void C_GrBackendRenderTarget_ConstructD3D(GrBackendRenderTarget* uninitialized, int width, int height, int sampleCnt, const GrD3DTextureResourceInfo* resourceInfo) {
-    new(uninitialized)GrBackendRenderTarget(width, height, sampleCnt, *resourceInfo);
+extern "C" void C_GrBackendRenderTarget_ConstructD3D(GrBackendRenderTarget* uninitialized, int width, int height, const GrD3DTextureResourceInfo* resourceInfo) {
+    new(uninitialized)GrBackendRenderTarget(width, height, *resourceInfo);
 }
 
 //

--- a/skia-bindings/src/gpu.cpp
+++ b/skia-bindings/src/gpu.cpp
@@ -72,16 +72,6 @@ extern "C" SkSurface* C_SkSurface_MakeRenderTarget2(
             budgeted).release();
 }
 
-extern "C" SkSurface *C_SkSurface_MakeFromBackendTexture2(
-        GrContext *context,
-        const SkSurfaceCharacterization &characterization,
-        const GrBackendTexture *backendTexture) {
-    return SkSurface::MakeFromBackendTexture(
-            context,
-            characterization,
-            *backendTexture).release();
-}
-
 extern "C" void C_SkSurface_getBackendTexture(
         SkSurface* self,
         SkSurface::BackendHandleAccess handleAccess,
@@ -282,8 +272,8 @@ extern "C" GrBackendApi C_GrBackendDrawableInfo_backend(const GrBackendDrawableI
 // core/SkCanvas.h
 //
 
-extern "C" GrContext* C_SkCanvas_getGrContext(SkCanvas* self) {
-    return self->getGrContext();
+extern "C" GrRecordingContext* C_SkCanvas_recordingContext(SkCanvas* self) {
+    return self->recordingContext();
 }
 
 //

--- a/skia-bindings/src/impls.rs
+++ b/skia-bindings/src/impls.rs
@@ -135,13 +135,10 @@ mod d3d {
 
     impl Default for crate::GrD3DTextureResourceInfo {
         fn default() -> Self {
-            Self {
-                fResource: Default::default(),
-                fResourceState: crate::D3D12_RESOURCE_STATES::D3D12_RESOURCE_STATE_COMMON,
-                fFormat: crate::DXGI_FORMAT::DXGI_FORMAT_UNKNOWN,
-                fLevelCount: 0,
-                fSampleQualityPattern: 0,
-                fProtected: crate::GrProtected::No,
+            let mut instance = std::mem::MaybeUninit::uninit();
+            unsafe {
+                crate::C_GrD3DTextureResourceInfo_Construct(instance.as_mut_ptr());
+                instance.assume_init()
             }
         }
     }

--- a/skia-bindings/src/metal.cpp
+++ b/skia-bindings/src/metal.cpp
@@ -8,7 +8,7 @@
 // core/SkSurface.h
 //
 
-extern "C" SkSurface *C_SkSurface_MakeFromCAMetalLayer(GrContext *context,
+extern "C" SkSurface *C_SkSurface_MakeFromCAMetalLayer(GrRecordingContext *context,
                                                        GrMTLHandle layer,
                                                        GrSurfaceOrigin origin,
                                                        int sampleCnt,
@@ -20,7 +20,7 @@ extern "C" SkSurface *C_SkSurface_MakeFromCAMetalLayer(GrContext *context,
                                            drawable).release();
 }
 
-extern "C" SkSurface *C_SkSurface_MakeFromMTKView(GrContext *context,
+extern "C" SkSurface *C_SkSurface_MakeFromMTKView(GrRecordingContext *context,
                                                   GrMTLHandle mtkView,
                                                   GrSurfaceOrigin origin,
                                                   int sampleCnt,

--- a/skia-bindings/src/paragraph.cpp
+++ b/skia-bindings/src/paragraph.cpp
@@ -146,16 +146,16 @@ extern "C" {
 }
 
 extern "C" {
-    void C_ParagraphStyle_Construct(ParagraphStyle* uninitialized) {
-        new(uninitialized) ParagraphStyle();
+    ParagraphStyle* C_ParagraphStyle_New() {
+        return new ParagraphStyle();
     }
 
-    void C_ParagraphStyle_CopyConstruct(ParagraphStyle* uninitialized, const ParagraphStyle* other) {
-        new(uninitialized) ParagraphStyle(*other);
+    ParagraphStyle* C_ParagraphStyle_NewCopy(const ParagraphStyle* other) {
+        return new ParagraphStyle(*other);
     }
 
-    void C_ParagraphStyle_destruct(ParagraphStyle* self) {
-        self->~ParagraphStyle();
+    void C_ParagraphStyle_delete(ParagraphStyle* self) {
+        delete self;
     }
 
     bool C_ParagraphStyle_Equals(const ParagraphStyle* left, const ParagraphStyle* right) {

--- a/skia-bindings/src/paragraph.cpp
+++ b/skia-bindings/src/paragraph.cpp
@@ -118,6 +118,10 @@ extern "C" {
 //
 
 extern "C" {
+    void C_StrutStyle_Construct(StrutStyle* uninitialized) {
+        new(uninitialized) StrutStyle();
+    }
+
     void C_StrutStyle_CopyConstruct(StrutStyle* uninitialized, const StrutStyle* other) {
         new(uninitialized) StrutStyle(*other);
     }
@@ -142,6 +146,10 @@ extern "C" {
 }
 
 extern "C" {
+    void C_ParagraphStyle_Construct(ParagraphStyle* uninitialized) {
+        new(uninitialized) ParagraphStyle();
+    }
+
     void C_ParagraphStyle_CopyConstruct(ParagraphStyle* uninitialized, const ParagraphStyle* other) {
         new(uninitialized) ParagraphStyle(*other);
     }
@@ -152,6 +160,10 @@ extern "C" {
 
     bool C_ParagraphStyle_Equals(const ParagraphStyle* left, const ParagraphStyle* right) {
         return *left == *right;
+    }
+
+    bool C_ParagraphStyle_ellipsized(const ParagraphStyle* self) {
+        return self->ellipsized();
     }
 }
 

--- a/skia-bindings/src/vulkan.cpp
+++ b/skia-bindings/src/vulkan.cpp
@@ -100,10 +100,6 @@ extern "C" GrDirectContext* C_GrDirectContext_MakeVulkan(
 // GrVkTypes.h
 //
 
-extern "C" void C_GrVkAlloc_Construct(GrVkAlloc* uninitialized, VkDeviceMemory memory, VkDeviceSize offset, VkDeviceSize size, uint32_t flags) {
-    new (uninitialized) GrVkAlloc(memory, offset, size, flags);
-}
-
 extern "C" bool C_GrVkAlloc_Equals(const GrVkAlloc* lhs, const GrVkAlloc* rhs) {
     return *lhs == *rhs;
 }

--- a/skia-bindings/src/vulkan.cpp
+++ b/skia-bindings/src/vulkan.cpp
@@ -112,6 +112,10 @@ extern "C" bool C_GrVkYcbcrConversionInfo_Equals(const GrVkYcbcrConversionInfo* 
 // gpu/GrBackendSurfaceMutableState.h
 //
 
+extern "C" void C_GrBackendSurfaceMutableState_Construct(GrBackendSurfaceMutableState* uninitialized) {
+    new(uninitialized)GrBackendSurfaceMutableState();
+}
+
 extern "C" void C_GrBackendSurfaceMutableState_ConstructVK(GrBackendSurfaceMutableState* uninitialized, VkImageLayout layout, uint32_t queueFamilyIndex) {
     new(uninitialized)GrBackendSurfaceMutableState(layout, queueFamilyIndex);
 }

--- a/skia-org/src/drivers/d3d.rs
+++ b/skia-org/src/drivers/d3d.rs
@@ -59,6 +59,7 @@ impl DrawingDriver for D3D {
             adapter,
             device,
             queue,
+            memory_allocator: None,
             protected_context: Protected::No,
         };
 

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.35.1"
+version = "0.36.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -39,7 +39,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 [dependencies]
 bitflags = "1.2"
 lazy_static = "1.4"
-skia-bindings = { version = "=0.35.1", path = "../skia-bindings" }
+skia-bindings = { version = "=0.36.0", path = "../skia-bindings" }
 # for d3d types
 winapi = { version = "0.3.9", features = ["d3d12", "dxgi"], optional = true }
 # for ComPtr

--- a/skia-safe/src/codec/_codec.rs
+++ b/skia-safe/src/codec/_codec.rs
@@ -147,8 +147,8 @@ impl RCHandle<SkCodec> {
         }
     }
 
-    // TODO: queryYUV8
-    // TODO: getYUV8Planes
+    // TODO: queryYUVAInfo
+    // TODO: getYUVAPlanes
     // TODO: startIncrementalDecode
     // TODO: incrementalDecode
     // TODO: startScanlineDecode

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -302,7 +302,7 @@ impl Canvas {
     // TODO: test ref count consistency assuming it is not increased in the native part.
     #[deprecated(
         since = "0.0.0",
-        note = "Removed, only recording_context() is support."
+        note = "Removed, only recording_context() is supported."
     )]
     #[cfg(feature = "gpu")]
     pub fn gpu_context(&mut self) -> ! {

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -301,7 +301,7 @@ impl Canvas {
 
     // TODO: test ref count consistency assuming it is not increased in the native part.
     #[deprecated(
-        since = "0.0.0",
+        since = "0.36.0",
         note = "Removed, only recording_context() is supported."
     )]
     #[cfg(feature = "gpu")]

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -300,9 +300,20 @@ impl Canvas {
     }
 
     // TODO: test ref count consistency assuming it is not increased in the native part.
+    #[deprecated(
+        since = "0.0.0",
+        note = "Removed, only recording_context() is support."
+    )]
     #[cfg(feature = "gpu")]
-    pub fn gpu_context(&mut self) -> Option<gpu::Context> {
-        gpu::Context::from_unshared_ptr(unsafe { sb::C_SkCanvas_getGrContext(self.native_mut()) })
+    pub fn gpu_context(&mut self) -> ! {
+        panic!("Removed");
+    }
+
+    #[cfg(feature = "gpu")]
+    pub fn recording_context(&mut self) -> Option<gpu::RecordingContext> {
+        gpu::RecordingContext::from_unshared_ptr(unsafe {
+            sb::C_SkCanvas_recordingContext(self.native_mut())
+        })
     }
 
     /// # Safety

--- a/skia-safe/src/core/color_filter.rs
+++ b/skia-safe/src/core/color_filter.rs
@@ -110,6 +110,13 @@ pub mod color_filters {
             .unwrap()
     }
 
+    pub fn hsla_matrix_of_color_matrix(color_matrix: &ColorMatrix) -> ColorFilter {
+        ColorFilter::from_ptr(unsafe {
+            sb::C_SkColorFilters_HSLAMatrixOfColorMatrix(color_matrix.native())
+        })
+        .unwrap()
+    }
+
     pub fn hsla_matrix(row_major: &[f32; 20]) -> ColorFilter {
         ColorFilter::from_ptr(unsafe { sb::C_SkColorFilters_HSLAMatrix(row_major.as_ptr()) })
             .unwrap()

--- a/skia-safe/src/core/image.rs
+++ b/skia-safe/src/core/image.rs
@@ -595,6 +595,38 @@ impl RCHandle<SkImage> {
 
         unsafe {
             self.native().readPixels(
+                ptr::null_mut(),
+                dst_info.native(),
+                pixels.as_mut_ptr() as _,
+                dst_row_bytes,
+                src.x,
+                src.y,
+                caching_hint,
+            )
+        }
+    }
+
+    #[cfg(feature = "gpu")]
+    pub fn read_pixels_with_context<'a, P>(
+        &self,
+        context: impl Into<Option<&'a mut gpu::DirectContext>>,
+        dst_info: &ImageInfo,
+        pixels: &mut [P],
+        dst_row_bytes: usize,
+        src: impl Into<IPoint>,
+        caching_hint: CachingHint,
+    ) -> bool {
+        if pixels.elements_size_of()
+            != (usize::try_from(dst_info.height()).unwrap() * dst_row_bytes)
+        {
+            return false;
+        }
+
+        let src = src.into();
+
+        unsafe {
+            self.native().readPixels(
+                context.into().native_ptr_or_null_mut(),
                 dst_info.native(),
                 pixels.as_mut_ptr() as _,
                 dst_row_bytes,

--- a/skia-safe/src/core/image.rs
+++ b/skia-safe/src/core/image.rs
@@ -577,6 +577,59 @@ impl RCHandle<SkImage> {
         .map(|texture| (texture, origin))
     }
 
+    #[cfg(feature = "gpu")]
+    pub fn read_pixels_with_context<'a, P>(
+        &self,
+        context: impl Into<Option<&'a mut gpu::DirectContext>>,
+        dst_info: &ImageInfo,
+        pixels: &mut [P],
+        dst_row_bytes: usize,
+        src: impl Into<IPoint>,
+        caching_hint: CachingHint,
+    ) -> bool {
+        if pixels.elements_size_of()
+            != (usize::try_from(dst_info.height()).unwrap() * dst_row_bytes)
+        {
+            return false;
+        }
+
+        let src = src.into();
+
+        unsafe {
+            self.native().readPixels(
+                context.into().native_ptr_or_null_mut(),
+                dst_info.native(),
+                pixels.as_mut_ptr() as _,
+                dst_row_bytes,
+                src.x,
+                src.y,
+                caching_hint,
+            )
+        }
+    }
+
+    #[cfg(feature = "gpu")]
+    pub fn read_pixels_to_pixmap_with_context<'a>(
+        &self,
+        context: impl Into<Option<&'a mut gpu::DirectContext>>,
+        dst: &Pixmap,
+        src: impl Into<IPoint>,
+        caching_hint: CachingHint,
+    ) -> bool {
+        let src = src.into();
+
+        unsafe {
+            self.native().readPixels1(
+                context.into().native_ptr_or_null_mut(),
+                dst.native(),
+                src.x,
+                src.y,
+                caching_hint,
+            )
+        }
+    }
+
+    // _not_ deprecated, because we support separate functions in `gpu` feature builds.
     pub fn read_pixels<P>(
         &self,
         dst_info: &ImageInfo,
@@ -607,34 +660,16 @@ impl RCHandle<SkImage> {
     }
 
     #[cfg(feature = "gpu")]
-    pub fn read_pixels_with_context<'a, P>(
+    pub unsafe fn read_pixels_to_pixmap(
         &self,
-        context: impl Into<Option<&'a mut gpu::DirectContext>>,
-        dst_info: &ImageInfo,
-        pixels: &mut [P],
-        dst_row_bytes: usize,
+        dst: &Pixmap,
         src: impl Into<IPoint>,
         caching_hint: CachingHint,
     ) -> bool {
-        if pixels.elements_size_of()
-            != (usize::try_from(dst_info.height()).unwrap() * dst_row_bytes)
-        {
-            return false;
-        }
-
         let src = src.into();
 
-        unsafe {
-            self.native().readPixels(
-                context.into().native_ptr_or_null_mut(),
-                dst_info.native(),
-                pixels.as_mut_ptr() as _,
-                dst_row_bytes,
-                src.x,
-                src.y,
-                caching_hint,
-            )
-        }
+        self.native()
+            .readPixels1(ptr::null_mut(), dst.native(), src.x, src.y, caching_hint)
     }
 
     // TODO:
@@ -698,7 +733,9 @@ impl RCHandle<SkImage> {
         unsafe { self.native().hasMipmaps() }
     }
 
-    // TODO: withMipmaps()
+    pub fn with_default_mipmaps(&self) -> Option<Image> {
+        Image::from_ptr(unsafe { sb::C_SkImage_withDefaultMipmaps(self.native()) })
+    }
 
     #[cfg(feature = "gpu")]
     pub fn new_texture_image(

--- a/skia-safe/src/core/image_generator.rs
+++ b/skia-safe/src/core/image_generator.rs
@@ -54,7 +54,7 @@ impl RefHandle<SkImageGenerator> {
 
     // TODO: m86: get_pixels(&Pixmap)
 
-    #[deprecated(since = "0.0.0", note = "Use get_yuva_info()")]
+    #[deprecated(since = "0.36.0", note = "Use get_yuva_info()")]
     pub fn query_yuva8(
         &self,
     ) -> Option<(
@@ -75,7 +75,7 @@ impl RefHandle<SkImageGenerator> {
         .if_true_some((size_info, indices, cs))
     }
 
-    #[deprecated(since = "0.0.0", note = "Use get_yuva_planes()")]
+    #[deprecated(since = "0.36.0", note = "Use get_yuva_planes()")]
     pub fn get_yuva8_planes(
         &mut self,
         size_info: &YUVASizeInfo,

--- a/skia-safe/src/core/image_generator.rs
+++ b/skia-safe/src/core/image_generator.rs
@@ -54,6 +54,7 @@ impl RefHandle<SkImageGenerator> {
 
     // TODO: m86: get_pixels(&Pixmap)
 
+    #[deprecated(since = "0.0.0", note = "Use get_yuva_info()")]
     pub fn query_yuva8(
         &self,
     ) -> Option<(
@@ -74,6 +75,7 @@ impl RefHandle<SkImageGenerator> {
         .if_true_some((size_info, indices, cs))
     }
 
+    #[deprecated(since = "0.0.0", note = "Use get_yuva_planes()")]
     pub fn get_yuva8_planes(
         &mut self,
         size_info: &YUVASizeInfo,

--- a/skia-safe/src/core/matrix.rs
+++ b/skia-safe/src/core/matrix.rs
@@ -164,6 +164,12 @@ impl Matrix {
         m
     }
 
+    pub fn rotate_deg_pivot(deg: scalar, pivot: impl Into<Point>) -> Matrix {
+        let mut m = Matrix::new();
+        m.set_rotate(deg, pivot.into());
+        m
+    }
+
     pub fn rotate_rad(rad: scalar) -> Matrix {
         Self::rotate_deg(scalar_::radians_to_degrees(rad))
     }
@@ -221,6 +227,12 @@ impl Matrix {
 
     pub fn preserves_right_angles(&self) -> bool {
         unsafe { self.native().preservesRightAngles(scalar::NEARLY_ZERO) }
+    }
+
+    pub fn rc(&self, r: usize, c: usize) -> scalar {
+        assert!(r <= 2);
+        assert!(c <= 2);
+        self[r * 3 + c]
     }
 
     pub fn scale_x(&self) -> scalar {

--- a/skia-safe/src/core/milestone.rs
+++ b/skia-safe/src/core/milestone.rs
@@ -1,1 +1,1 @@
-pub const MILESTONE: usize = 86;
+pub const MILESTONE: usize = 87;

--- a/skia-safe/src/core/path.rs
+++ b/skia-safe/src/core/path.rs
@@ -246,6 +246,21 @@ impl Handle<SkPath> {
         })
     }
 
+    pub fn oval_with_start_index(
+        oval: impl AsRef<Rect>,
+        dir: PathDirection,
+        start_index: usize,
+    ) -> Self {
+        Self::construct(|path| unsafe {
+            sb::C_SkPath_OvalWithStartIndex(
+                path,
+                oval.as_ref().native(),
+                dir,
+                start_index.try_into().unwrap(),
+            )
+        })
+    }
+
     pub fn circle(
         center: impl Into<Point>,
         radius: scalar,
@@ -269,6 +284,21 @@ impl Handle<SkPath> {
                 path,
                 rect.as_ref().native(),
                 dir.into().unwrap_or(PathDirection::CW),
+            )
+        })
+    }
+
+    pub fn rrect_with_start_index(
+        rect: impl AsRef<RRect>,
+        dir: PathDirection,
+        start_index: usize,
+    ) -> Self {
+        Self::construct(|path| unsafe {
+            sb::C_SkPath_RRectWithStartIndex(
+                path,
+                rect.as_ref().native(),
+                dir,
+                start_index.try_into().unwrap(),
             )
         })
     }

--- a/skia-safe/src/core/path.rs
+++ b/skia-safe/src/core/path.rs
@@ -361,12 +361,12 @@ impl Handle<SkPath> {
         self
     }
 
-    #[deprecated(since = "0.0.0", note = "Removed, use is_convex()")]
+    #[deprecated(since = "0.36.0", note = "Removed, use is_convex()")]
     pub fn convexity_type(&self) -> ! {
         panic!("Removed")
     }
 
-    #[deprecated(since = "0.0.0", note = "Removed, use is_convex()")]
+    #[deprecated(since = "0.36.0", note = "Removed, use is_convex()")]
     pub fn convexity_type_or_unknown(&self) -> ! {
         panic!("Removed")
     }

--- a/skia-safe/src/core/path.rs
+++ b/skia-safe/src/core/path.rs
@@ -2,8 +2,7 @@ use crate::interop::DynamicMemoryWStream;
 use crate::matrix::ApplyPerspectiveClip;
 use crate::prelude::*;
 use crate::{
-    path_types, scalar, Data, Matrix, PathConvexityType, PathDirection, PathFillType, Point, RRect,
-    Rect, Vector,
+    path_types, scalar, Data, Matrix, PathDirection, PathFillType, Point, RRect, Rect, Vector,
 };
 use skia_bindings as sb;
 use skia_bindings::{SkPath, SkPath_Iter, SkPath_RawIter};
@@ -15,9 +14,6 @@ pub use path_types::PathDirection as Direction;
 
 #[deprecated(since = "0.25.0", note = "use PathFillType")]
 pub use path_types::PathFillType as FillType;
-
-#[deprecated(since = "0.25.0", note = "use PathConvexityType")]
-pub use path_types::PathConvexityType as Convexity;
 
 pub use skia_bindings::SkPath_ArcSize as ArcSize;
 #[test]
@@ -335,36 +331,18 @@ impl Handle<SkPath> {
         self
     }
 
-    pub fn convexity_type(&self) -> PathConvexityType {
-        unsafe { sb::C_SkPath_getConvexityType(self.native()) }
+    #[deprecated(since = "0.0.0", note = "Removed, use is_convex()")]
+    pub fn convexity_type(&self) -> ! {
+        panic!("Removed")
     }
 
-    pub fn convexity_type_or_unknown(&self) -> PathConvexityType {
-        unsafe { sb::C_SkPath_getConvexityTypeOrUnknown(self.native()) }
-    }
-
-    pub fn set_convexity_type(&mut self, convexity: PathConvexityType) -> &mut Self {
-        unsafe { self.native_mut().setConvexityType(convexity) }
-        self
+    #[deprecated(since = "0.0.0", note = "Removed, use is_convex()")]
+    pub fn convexity_type_or_unknown(&self) -> ! {
+        panic!("Removed")
     }
 
     pub fn is_convex(&self) -> bool {
-        self.convexity_type() == PathConvexityType::Convex
-    }
-
-    #[deprecated(since = "0.25.0", note = "use convexity_type()")]
-    pub fn convexity(&self) -> PathConvexityType {
-        self.convexity_type()
-    }
-
-    #[deprecated(since = "0.25.0", note = "use convexity_type_or_unknown()")]
-    pub fn convexity_or_unknown(&self) -> PathConvexityType {
-        self.convexity_type_or_unknown()
-    }
-
-    #[deprecated(since = "0.25.0", note = "use set_convexity_type()")]
-    pub fn set_convexity(&mut self, convexity: PathConvexityType) -> &mut Self {
-        self.set_convexity_type(convexity)
+        unsafe { sb::C_SkPath_isConvex(self.native()) }
     }
 
     pub fn is_oval(&self) -> Option<Rect> {

--- a/skia-safe/src/core/path_builder.rs
+++ b/skia-safe/src/core/path_builder.rs
@@ -1,6 +1,7 @@
-use crate::{prelude::*, scalar, Path, PathDirection, PathFillType, Point, RRect, Rect};
+use crate::{prelude::*, scalar, Path, PathDirection, PathFillType, Point, RRect, Rect, Vector};
 use skia_bindings as sb;
 use skia_bindings::SkPathBuilder;
+use std::mem;
 
 pub use skia_bindings::SkPathBuilder_ArcSize as ArcSize;
 #[test]
@@ -18,14 +19,38 @@ impl NativeDrop for SkPathBuilder {
     }
 }
 
+impl Clone for PathBuilder {
+    fn clone(&self) -> Self {
+        Self::construct(|pb| unsafe { sb::C_SkPathBuilder_CopyConstruct(pb, self.native()) })
+    }
+}
+
 impl PathBuilder {
     pub fn new() -> Self {
-        Self::from_native_c(unsafe { SkPathBuilder::new() })
+        Self::construct(|pb| unsafe { sb::C_SkPathBuilder_Construct(pb) })
     }
 
-    pub fn snapshot(&mut self) -> Path {
+    /* m87: No Implementation.
+    pub fn new_fill_type(fill_type: PathFillType) -> Self {
+        Self::construct(|pb| unsafe { sb::C_SkPathBuilder_Construct2(pb, fill_type) })
+    }
+    */
+
+    pub fn new_path(path: &Path) -> Self {
+        Self::construct(|pb| unsafe { sb::C_SkPathBuilder_Construct3(pb, path.native()) })
+    }
+
+    pub fn fill_type(&self) -> PathFillType {
+        self.native().fFillType
+    }
+
+    pub fn compute_bounds(&self) -> Rect {
+        Rect::from_native(unsafe { self.native().computeBounds() })
+    }
+
+    pub fn snapshot(&self) -> Path {
         let mut path = Path::default();
-        unsafe { sb::C_SkPathBuilder_snapshot(self.native_mut(), path.native_mut()) }
+        unsafe { sb::C_SkPathBuilder_snapshot(self.native(), path.native_mut()) }
         path
     }
 
@@ -101,6 +126,14 @@ impl PathBuilder {
     pub fn close(&mut self) -> &mut Self {
         unsafe {
             self.native_mut().close();
+        }
+        self
+    }
+
+    pub fn polyline_to(&mut self, points: &[Point]) -> &mut Self {
+        unsafe {
+            self.native_mut()
+                .polylineTo(points.native().as_ptr(), points.len().try_into().unwrap());
         }
         self
     }
@@ -298,6 +331,20 @@ impl PathBuilder {
                 extra_verb_count.try_into().unwrap(),
             )
         }
+    }
+
+    pub fn offset(&mut self, d: impl Into<Vector>) -> &mut Self {
+        let d = d.into();
+        unsafe {
+            self.native_mut().offset(d.x, d.y);
+        }
+        self
+    }
+
+    pub fn toggle_inverse_fill_type(&mut self) -> &mut Self {
+        let n = self.native_mut();
+        n.fFillType = unsafe { mem::transmute(n.fFillType as i32 ^ 2) };
+        self
     }
 
     #[deprecated(since = "0.35.0", note = "Removed without replacement")]

--- a/skia-safe/src/core/path_builder.rs
+++ b/skia-safe/src/core/path_builder.rs
@@ -45,7 +45,7 @@ impl PathBuilder {
     }
 
     pub fn compute_bounds(&self) -> Rect {
-        Rect::from_native(unsafe { self.native().computeBounds() })
+        Rect::from_native_c(unsafe { sb::C_SkPathBuilder_computeBounds(self.native()) })
     }
 
     pub fn snapshot(&self) -> Path {

--- a/skia-safe/src/core/path_types.rs
+++ b/skia-safe/src/core/path_types.rs
@@ -8,12 +8,6 @@ pub fn test_fill_type_naming() {
     let _ = PathFillType::InverseEvenOdd;
 }
 
-pub use skia_bindings::SkPathConvexityType as PathConvexityType;
-#[test]
-fn test_convexity_type_naming() {
-    let _ = PathConvexityType::Concave;
-}
-
 pub use skia_bindings::SkPathDirection as PathDirection;
 #[test]
 fn test_direction_naming() {

--- a/skia-safe/src/core/picture_recorder.rs
+++ b/skia-safe/src/core/picture_recorder.rs
@@ -16,10 +16,10 @@ impl NativeDrop for SkPictureRecorder {
 
 impl Handle<SkPictureRecorder> {
     pub fn new() -> Self {
-        Self::from_native_c(unsafe { SkPictureRecorder::new() })
+        Self::construct(|pr| unsafe { sb::C_SkPictureRecorder_Construct(pr) })
     }
 
-    // TODO: wrap beginRecording with BBoxHierarchy
+    // TODO: beginRecording with BBoxHierarchy
 
     pub fn begin_recording(
         &mut self,

--- a/skia-safe/src/core/picture_recorder.rs
+++ b/skia-safe/src/core/picture_recorder.rs
@@ -4,12 +4,6 @@ use skia_bindings as sb;
 use skia_bindings::{SkPictureRecorder, SkRect};
 use std::ptr;
 
-bitflags! {
-    pub struct RecordFlags: u32 {
-        const PLAYBACK_DRAW_PICTURE = sb::SkPictureRecorder_RecordFlags_kPlaybackDrawPicture_RecordFlag as _;
-    }
-}
-
 pub type PictureRecorder = Handle<SkPictureRecorder>;
 
 impl NativeDrop for SkPictureRecorder {
@@ -31,16 +25,11 @@ impl Handle<SkPictureRecorder> {
         &mut self,
         bounds: impl AsRef<Rect>,
         mut bbh_factory: Option<&mut BBHFactory>,
-        record_flags: impl Into<Option<RecordFlags>>,
     ) -> &mut Canvas {
         let canvas_ref = unsafe {
             &mut *self.native_mut().beginRecording1(
                 bounds.as_ref().native(),
                 bbh_factory.native_ptr_or_null_mut(),
-                record_flags
-                    .into()
-                    .unwrap_or_else(RecordFlags::empty)
-                    .bits(),
             )
         };
 
@@ -78,7 +67,7 @@ impl Handle<SkPictureRecorder> {
 #[test]
 fn good_case() {
     let mut recorder = PictureRecorder::new();
-    let canvas = recorder.begin_recording(&Rect::new(0.0, 0.0, 100.0, 100.0), None, None);
+    let canvas = recorder.begin_recording(&Rect::new(0.0, 0.0, 100.0, 100.0), None);
     canvas.clear(crate::Color::WHITE);
     let _picture = recorder.finish_recording_as_picture(None).unwrap();
 }
@@ -86,10 +75,10 @@ fn good_case() {
 #[test]
 fn begin_recording_two_times() {
     let mut recorder = PictureRecorder::new();
-    let canvas = recorder.begin_recording(&Rect::new(0.0, 0.0, 100.0, 100.0), None, None);
+    let canvas = recorder.begin_recording(&Rect::new(0.0, 0.0, 100.0, 100.0), None);
     canvas.clear(crate::Color::WHITE);
     assert!(recorder.recording_canvas().is_some());
-    let canvas = recorder.begin_recording(&Rect::new(0.0, 0.0, 100.0, 100.0), None, None);
+    let canvas = recorder.begin_recording(&Rect::new(0.0, 0.0, 100.0, 100.0), None);
     canvas.clear(crate::Color::WHITE);
     assert!(recorder.recording_canvas().is_some());
 }
@@ -97,7 +86,7 @@ fn begin_recording_two_times() {
 #[test]
 fn finishing_recording_two_times() {
     let mut recorder = PictureRecorder::new();
-    let canvas = recorder.begin_recording(&Rect::new(0.0, 0.0, 100.0, 100.0), None, None);
+    let canvas = recorder.begin_recording(&Rect::new(0.0, 0.0, 100.0, 100.0), None);
     canvas.clear(crate::Color::WHITE);
     assert!(recorder.finish_recording_as_picture(None).is_some());
     assert!(recorder.recording_canvas().is_none());

--- a/skia-safe/src/core/rrect.rs
+++ b/skia-safe/src/core/rrect.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use crate::{scalar, Matrix, Rect, Vector};
+use crate::{interop, scalar, Matrix, Rect, Vector};
 use skia_bindings as sb;
 use skia_bindings::SkRRect;
 use std::{mem, ptr};
@@ -263,6 +263,12 @@ impl RRect {
 
     pub fn dump(&self, as_hex: impl Into<Option<bool>>) {
         unsafe { self.native().dump(as_hex.into().unwrap_or_default()) }
+    }
+
+    pub fn dump_to_string(&self, as_hex: bool) -> String {
+        let mut str = interop::String::default();
+        unsafe { sb::C_SkRRect_dumpToString(self.native(), as_hex, str.native_mut()) }
+        str.to_string()
     }
 
     pub fn dump_hex(&self) {

--- a/skia-safe/src/core/surface.rs
+++ b/skia-safe/src/core/surface.rs
@@ -168,7 +168,7 @@ impl RCHandle<SkSurface> {
     }
 
     #[cfg(feature = "metal")]
-    #[deprecated(since = "0.0.0", note = "use from_mtk_view()")]
+    #[deprecated(since = "0.36.0", note = "use from_mtk_view()")]
     pub fn from_ca_mtk_view(
         context: &mut gpu::Context,
         mtk_view: gpu::mtl::Handle,
@@ -247,7 +247,7 @@ impl RCHandle<SkSurface> {
         })
     }
 
-    #[deprecated(since = "0.0.0", note = "Removed without replacement")]
+    #[deprecated(since = "0.36.0", note = "Removed without replacement")]
     pub fn from_backend_texture_with_caracterization(
         _context: &mut gpu::Context,
         _characterization: &SurfaceCharacterization,

--- a/skia-safe/src/core/surface.rs
+++ b/skia-safe/src/core/surface.rs
@@ -225,20 +225,13 @@ impl RCHandle<SkSurface> {
         })
     }
 
-    // TODO: support TextureReleaseProc / ReleaseContext
-
+    #[deprecated(since = "0.0.0", note = "Removed without replacement")]
     pub fn from_backend_texture_with_caracterization(
-        context: &mut gpu::Context,
-        characterization: &SurfaceCharacterization,
-        backend_texture: &gpu::BackendTexture,
-    ) -> Option<Self> {
-        Self::from_ptr(unsafe {
-            sb::C_SkSurface_MakeFromBackendTexture2(
-                context.native_mut(),
-                characterization.native(),
-                backend_texture.native(),
-            )
-        })
+        _context: &mut gpu::Context,
+        _characterization: &SurfaceCharacterization,
+        _backend_texture: &gpu::BackendTexture,
+    ) -> ! {
+        panic!("Removed without replacement")
     }
 }
 
@@ -283,7 +276,9 @@ impl RCHandle<SkSurface> {
         note = "Use recordingContext() and RecordingContext::as_direct_context()"
     )]
     pub fn context(&mut self) -> Option<gpu::Context> {
-        gpu::Context::from_unshared_ptr(unsafe { self.native_mut().getContext() })
+        self.recording_context()
+            .and_then(|mut rc| rc.as_direct_context())
+            .map(|dc| dc.into())
     }
 
     pub fn recording_context(&mut self) -> Option<gpu::RecordingContext> {

--- a/skia-safe/src/core/surface.rs
+++ b/skia-safe/src/core/surface.rs
@@ -178,7 +178,7 @@ impl RCHandle<SkSurface> {
         color_space: impl Into<Option<crate::ColorSpace>>,
         surface_props: Option<&SurfaceProps>,
     ) -> Option<Self> {
-        self.from_mtk_view(
+        Self::from_mtk_view(
             context,
             mtk_view,
             origin,

--- a/skia-safe/src/core/surface.rs
+++ b/skia-safe/src/core/surface.rs
@@ -143,7 +143,7 @@ impl RCHandle<SkSurface> {
 
     #[cfg(feature = "metal")]
     pub fn from_ca_metal_layer(
-        context: &mut gpu::Context,
+        context: &mut gpu::RecordingContext,
         layer: gpu::mtl::Handle,
         origin: gpu::SurfaceOrigin,
         sample_count: impl Into<Option<usize>>,
@@ -168,8 +168,30 @@ impl RCHandle<SkSurface> {
     }
 
     #[cfg(feature = "metal")]
+    #[deprecated(since = "0.0.0", note = "use from_mtk_view()")]
     pub fn from_ca_mtk_view(
         context: &mut gpu::Context,
+        mtk_view: gpu::mtl::Handle,
+        origin: gpu::SurfaceOrigin,
+        sample_count: impl Into<Option<usize>>,
+        color_type: crate::ColorType,
+        color_space: impl Into<Option<crate::ColorSpace>>,
+        surface_props: Option<&SurfaceProps>,
+    ) -> Option<Self> {
+        self.from_mtk_view(
+            context,
+            mtk_view,
+            origin,
+            sample_count,
+            color_type,
+            color_space,
+            surface_props,
+        )
+    }
+
+    #[cfg(feature = "metal")]
+    pub fn from_mtk_view(
+        context: &mut gpu::RecordingContext,
         mtk_view: gpu::mtl::Handle,
         origin: gpu::SurfaceOrigin,
         sample_count: impl Into<Option<usize>>,

--- a/skia-safe/src/core/surface_characterization.rs
+++ b/skia-safe/src/core/surface_characterization.rs
@@ -150,6 +150,11 @@ impl Handle<SkSurfaceCharacterization> {
         self.native().fUsesGLFBO0 == sb::SkSurfaceCharacterization_UsesGLFBO0::kYes
     }
 
+    pub fn vk_rt_supports_input_attachment(&self) -> bool {
+        self.native().fVkRTSupportsInputAttachment
+            == sb::SkSurfaceCharacterization_VkRTSupportsInputAttachment::kYes
+    }
+
     pub fn vulkan_secondary_cb_compatible(&self) -> bool {
         self.native().fVulkanSecondaryCBCompatible
             == sb::SkSurfaceCharacterization_VulkanSecondaryCBCompatible::kYes

--- a/skia-safe/src/core/typeface.rs
+++ b/skia-safe/src/core/typeface.rs
@@ -231,6 +231,12 @@ impl RCHandle<SkTypeface> {
         name.as_str().into()
     }
 
+    pub fn post_script_name(&self) -> Option<String> {
+        let mut name = interop::String::default();
+        unsafe { self.native().getPostScriptName(name.native_mut()) }
+            .if_true_then_some(|| name.as_str().into())
+    }
+
     // TODO: openStream()
     // TODO: createScalerContext()
 

--- a/skia-safe/src/effects/runtime_effect.rs
+++ b/skia-safe/src/effects/runtime_effect.rs
@@ -166,10 +166,6 @@ impl RCHandle<SkRuntimeEffect> {
         unimplemented!("removed without replacement")
     }
 
-    pub fn hash(&self) -> u32 {
-        unsafe { sb::C_SkRuntimeEffect_hash(self.native()) }
-    }
-
     #[deprecated(since = "0.35.0", note = "Use uniform_size() instead")]
     pub fn input_size(&self) -> usize {
         self.uniform_size()

--- a/skia-safe/src/gpu/backend_surface.rs
+++ b/skia-safe/src/gpu/backend_surface.rs
@@ -386,7 +386,6 @@ impl Handle<GrBackendRenderTarget> {
     #[cfg(feature = "d3d")]
     pub fn new_d3d(
         (width, height): (i32, i32),
-        sample_cnt: i32,
         d3d_info: &d3d::TextureResourceInfo,
     ) -> Self {
         Self::construct(|brt| unsafe {
@@ -394,7 +393,6 @@ impl Handle<GrBackendRenderTarget> {
                 brt,
                 width,
                 height,
-                sample_cnt,
                 d3d_info.native(),
             )
         })

--- a/skia-safe/src/gpu/backend_surface.rs
+++ b/skia-safe/src/gpu/backend_surface.rs
@@ -384,17 +384,9 @@ impl Handle<GrBackendRenderTarget> {
     }
 
     #[cfg(feature = "d3d")]
-    pub fn new_d3d(
-        (width, height): (i32, i32),
-        d3d_info: &d3d::TextureResourceInfo,
-    ) -> Self {
+    pub fn new_d3d((width, height): (i32, i32), d3d_info: &d3d::TextureResourceInfo) -> Self {
         Self::construct(|brt| unsafe {
-            sb::C_GrBackendRenderTarget_ConstructD3D(
-                brt,
-                width,
-                height,
-                d3d_info.native(),
-            )
+            sb::C_GrBackendRenderTarget_ConstructD3D(brt, width, height, d3d_info.native())
         })
     }
 

--- a/skia-safe/src/gpu/backend_surface_mutable_state.rs
+++ b/skia-safe/src/gpu/backend_surface_mutable_state.rs
@@ -12,6 +12,14 @@ impl NativeDrop for GrBackendSurfaceMutableState {
     }
 }
 
+impl Default for BackendSurfaceMutableState {
+    fn default() -> Self {
+        BackendSurfaceMutableState::construct(|s| unsafe {
+            sb::C_GrBackendSurfaceMutableState_Construct(s)
+        })
+    }
+}
+
 impl BackendSurfaceMutableState {
     #[cfg(feature = "vulkan")]
     pub fn new_vk(layout: crate::gpu::vk::ImageLayout, queue_family_index: u32) -> Self {

--- a/skia-safe/src/gpu/d3d/backend_context.rs
+++ b/skia-safe/src/gpu/d3d/backend_context.rs
@@ -1,4 +1,4 @@
-use super::cp;
+use super::{cp, MemoryAllocator};
 use super::{ID3D12CommandQueue, ID3D12Device, IDXGIAdapter1};
 use crate::gpu;
 use crate::prelude::*;
@@ -10,6 +10,7 @@ pub struct BackendContext {
     pub adapter: cp<IDXGIAdapter1>,
     pub device: cp<ID3D12Device>,
     pub queue: cp<ID3D12CommandQueue>,
+    pub memory_allocator: Option<MemoryAllocator>,
     pub protected_context: gpu::Protected,
 }
 unsafe impl Send for BackendContext {}

--- a/skia-safe/src/gpu/d3d/types.rs
+++ b/skia-safe/src/gpu/d3d/types.rs
@@ -1,7 +1,7 @@
 use super::{ID3D12Resource, D3D12_RESOURCE_STATES, DXGI_FORMAT};
 use crate::gpu;
 use crate::prelude::*;
-use skia_bindings::GrD3DTextureResourceInfo;
+use skia_bindings::{GrD3DAlloc, GrD3DMemoryAllocator, GrD3DTextureResourceInfo, SkRefCntBase};
 use winapi::{
     shared::dxgiformat,
     shared::dxgitype,
@@ -31,12 +31,28 @@ fn test_cp_layout() {
 
 // TODO: add remaining cp functions to ComPtr via traits (get, reset, retain).
 
+pub type Alloc = RCHandle<GrD3DAlloc>;
+
+impl NativeRefCountedBase for GrD3DAlloc {
+    type Base = SkRefCntBase;
+}
+
+// TODO: support the implementation of custom D3D memory allocator's
+// virtual createResource() function.
+pub type MemoryAllocator = RCHandle<GrD3DMemoryAllocator>;
+
+impl NativeRefCountedBase for GrD3DMemoryAllocator {
+    type Base = SkRefCntBase;
+}
+
 #[repr(C)]
 #[derive(Clone)]
 pub struct TextureResourceInfo {
     pub resource: cp<ID3D12Resource>,
+    pub alloc: Option<Alloc>,
     pub resource_state: D3D12_RESOURCE_STATES,
     pub format: DXGI_FORMAT,
+    pub sample_count: u32,
     pub level_count: u32,
     pub sample_quality_pattern: std::os::raw::c_uint,
     pub protected: gpu::Protected,
@@ -48,11 +64,20 @@ impl TextureResourceInfo {
     pub fn from_resource(resource: cp<ID3D12Resource>) -> Self {
         Self {
             resource,
+            alloc: None,
             resource_state: d3d12::D3D12_RESOURCE_STATE_COMMON,
             format: dxgiformat::DXGI_FORMAT_UNKNOWN,
+            sample_count: 1,
             level_count: 0,
             sample_quality_pattern: dxgitype::DXGI_STANDARD_MULTISAMPLE_QUALITY_PATTERN,
             protected: gpu::Protected::No,
+        }
+    }
+
+    pub fn with_state(self, resource_state: D3D12_RESOURCE_STATES) -> Self {
+        Self {
+            resource_state,
+            ..self
         }
     }
 }

--- a/skia-safe/src/gpu/d3d/types.rs
+++ b/skia-safe/src/gpu/d3d/types.rs
@@ -32,6 +32,8 @@ fn test_cp_layout() {
 // TODO: add remaining cp functions to ComPtr via traits (get, reset, retain).
 
 pub type Alloc = RCHandle<GrD3DAlloc>;
+unsafe impl Send for Alloc {}
+unsafe impl Sync for Alloc {}
 
 impl NativeRefCountedBase for GrD3DAlloc {
     type Base = SkRefCntBase;
@@ -40,6 +42,8 @@ impl NativeRefCountedBase for GrD3DAlloc {
 // TODO: support the implementation of custom D3D memory allocator's
 // virtual createResource() function.
 pub type MemoryAllocator = RCHandle<GrD3DMemoryAllocator>;
+unsafe impl Send for MemoryAllocator {}
+unsafe impl Sync for MemoryAllocator {}
 
 impl NativeRefCountedBase for GrD3DMemoryAllocator {
     type Base = SkRefCntBase;

--- a/skia-safe/src/gpu/recording_context.rs
+++ b/skia-safe/src/gpu/recording_context.rs
@@ -78,6 +78,21 @@ impl RCHandle<GrRecordingContext> {
         }
     }
 
+    pub fn max_texture_size(&self) -> i32 {
+        unsafe { self.native().maxTextureSize() }
+    }
+
+    pub fn max_render_target_size(&self) -> i32 {
+        unsafe { self.native().maxRenderTargetSize() }
+    }
+
+    pub fn color_type_supported_as_image(&self, color_type: ColorType) -> bool {
+        unsafe {
+            self.native()
+                .colorTypeSupportedAsImage(color_type.into_native())
+        }
+    }
+
     pub fn max_surface_sample_count_for_color_type(&self, color_type: ColorType) -> usize {
         unsafe {
             self.native()

--- a/skia-safe/src/gpu/vk.rs
+++ b/skia-safe/src/gpu/vk.rs
@@ -27,6 +27,7 @@ pub use sb::VkFormatFeatureFlags as FormatFeatureFlags;
 pub use sb::VkImage as Image;
 pub use sb::VkImageLayout as ImageLayout;
 pub use sb::VkImageTiling as ImageTiling;
+pub use sb::VkImageUsageFlags as ImageUsageFlags;
 pub use sb::VkInstance as Instance;
 pub use sb::VkOffset2D as Offset2D;
 pub use sb::VkPhysicalDevice as PhysicalDevice;

--- a/skia-safe/src/gpu/vk/types.rs
+++ b/skia-safe/src/gpu/vk/types.rs
@@ -183,6 +183,8 @@ pub struct ImageInfo {
     pub tiling: vk::ImageTiling,
     pub layout: vk::ImageLayout,
     pub format: vk::Format,
+    pub image_usage_flags: vk::ImageUsageFlags,
+    pub sample_count: u32,
     pub level_count: u32,
     pub current_queue_family: u32,
     pub protected: Protected,
@@ -206,6 +208,8 @@ impl Default for ImageInfo {
             tiling: vk::ImageTiling::OPTIMAL,
             layout: vk::ImageLayout::UNDEFINED,
             format: vk::Format::UNDEFINED,
+            image_usage_flags: 0,
+            sample_count: 1,
             level_count: 0,
             current_queue_family: vk::QUEUE_FAMILY_IGNORED,
             protected: Protected::No,
@@ -248,6 +252,7 @@ impl ImageInfo {
             protected,
             ycbcr_conversion_info,
             sharing_mode,
+            ..Self::default()
         }
     }
 

--- a/skia-safe/src/gpu/vk/types.rs
+++ b/skia-safe/src/gpu/vk/types.rs
@@ -65,9 +65,14 @@ impl Alloc {
         size: vk::DeviceSize,
         flags: AllocFlag,
     ) -> Alloc {
-        Alloc::construct(|alloc| {
-            sb::C_GrVkAlloc_Construct(alloc, memory, offset, size, flags.bits())
-        })
+        Alloc {
+            memory,
+            offset,
+            size,
+            flags,
+            backend_memory: 0,
+            uses_system_heap: false,
+        }
     }
 }
 

--- a/skia-safe/src/modules/paragraph/dart_types.rs
+++ b/skia-safe/src/modules/paragraph/dart_types.rs
@@ -95,3 +95,9 @@ fn test_text_height_behavior_naming() {
 }
 
 // m84: LineMetricStyle is declared but not used in the public API yet.
+
+pub use sb::skia_textlayout_DrawOptions as DrawOptions;
+#[test]
+fn test_draw_options_naming() {
+    let _ = DrawOptions::Replay;
+}

--- a/skia-safe/src/modules/paragraph/font_collection.rs
+++ b/skia-safe/src/modules/paragraph/font_collection.rs
@@ -138,6 +138,10 @@ impl RCHandle<skia_textlayout_FontCollection> {
             &mut *sb::C_FontCollection_paragraphCache(self.native_mut())
         })
     }
+
+    pub fn clear_caches(&mut self) {
+        unsafe { self.native_mut().clearCaches() }
+    }
 }
 
 type Typefaces = Handle<sb::Typefaces>;

--- a/skia-safe/src/modules/paragraph/paragraph_style.rs
+++ b/skia-safe/src/modules/paragraph/paragraph_style.rs
@@ -1,4 +1,4 @@
-use super::{FontFamilies, TextAlign, TextDirection, TextStyle};
+use super::{DrawOptions, FontFamilies, TextAlign, TextDirection, TextStyle};
 use crate::interop::{AsStr, FromStrs, SetStr};
 use crate::modules::paragraph::TextHeightBehavior;
 use crate::prelude::*;
@@ -36,7 +36,7 @@ impl Default for Handle<sb::skia_textlayout_StrutStyle> {
 
 impl Handle<sb::skia_textlayout_StrutStyle> {
     pub fn new() -> Self {
-        StrutStyle::from_native_c(unsafe { sb::skia_textlayout_StrutStyle::new() })
+        StrutStyle::construct(|ss| unsafe { sb::C_StrutStyle_Construct(ss) })
     }
 
     pub fn font_families(&self) -> FontFamilies {
@@ -141,7 +141,7 @@ impl Default for Handle<sb::skia_textlayout_ParagraphStyle> {
 
 impl Handle<sb::skia_textlayout_ParagraphStyle> {
     pub fn new() -> Self {
-        Self::from_native_c(unsafe { sb::skia_textlayout_ParagraphStyle::new() })
+        Self::construct(|ps| unsafe { sb::C_ParagraphStyle_Construct(ps) })
     }
 
     pub fn strut_style(&self) -> &StrutStyle {
@@ -195,6 +195,8 @@ impl Handle<sb::skia_textlayout_ParagraphStyle> {
         self
     }
 
+    // TODO: Support u16 ellipsis, but why? Doesn't SkString support UTF-8?
+
     pub fn ellipsis(&self) -> &str {
         self.native().fEllipsis.as_str()
     }
@@ -227,7 +229,7 @@ impl Handle<sb::skia_textlayout_ParagraphStyle> {
     }
 
     pub fn ellipsized(&self) -> bool {
-        !self.native().fEllipsis.as_str().is_empty()
+        unsafe { sb::C_ParagraphStyle_ellipsized(self.native()) }
     }
 
     pub fn effective_align(&self) -> TextAlign {
@@ -240,6 +242,15 @@ impl Handle<sb::skia_textlayout_ParagraphStyle> {
 
     pub fn turn_hinting_off(&mut self) -> &mut Self {
         self.native_mut().fHintingIsOn = false;
+        self
+    }
+
+    pub fn draw_options(&self) -> DrawOptions {
+        self.native().fDrawingOptions
+    }
+
+    pub fn set_draw_options(&mut self, value: DrawOptions) -> &mut Self {
+        self.native_mut().fDrawingOptions = value;
         self
     }
 }

--- a/skia-safe/src/modules/paragraph/paragraph_style.rs
+++ b/skia-safe/src/modules/paragraph/paragraph_style.rs
@@ -111,19 +111,20 @@ impl Handle<sb::skia_textlayout_StrutStyle> {
     }
 }
 
-pub type ParagraphStyle = Handle<sb::skia_textlayout_ParagraphStyle>;
+// Can't use Handle<> here, std::u16string maintains an interior pointer.
+pub type ParagraphStyle = RefHandle<sb::skia_textlayout_ParagraphStyle>;
 unsafe impl Send for ParagraphStyle {}
 unsafe impl Sync for ParagraphStyle {}
 
 impl NativeDrop for sb::skia_textlayout_ParagraphStyle {
     fn drop(&mut self) {
-        unsafe { sb::C_ParagraphStyle_destruct(self) }
+        unsafe { sb::C_ParagraphStyle_delete(self) }
     }
 }
 
-impl NativeClone for sb::skia_textlayout_ParagraphStyle {
+impl Clone for ParagraphStyle {
     fn clone(&self) -> Self {
-        construct(|ps| unsafe { sb::C_ParagraphStyle_CopyConstruct(ps, self) })
+        Self::from_ptr(unsafe { sb::C_ParagraphStyle_NewCopy(self.native()) }).unwrap()
     }
 }
 
@@ -133,15 +134,15 @@ impl NativePartialEq for sb::skia_textlayout_ParagraphStyle {
     }
 }
 
-impl Default for Handle<sb::skia_textlayout_ParagraphStyle> {
+impl Default for RefHandle<sb::skia_textlayout_ParagraphStyle> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Handle<sb::skia_textlayout_ParagraphStyle> {
+impl RefHandle<sb::skia_textlayout_ParagraphStyle> {
     pub fn new() -> Self {
-        Self::construct(|ps| unsafe { sb::C_ParagraphStyle_Construct(ps) })
+        Self::from_ptr(unsafe { sb::C_ParagraphStyle_New() }).unwrap()
     }
 
     pub fn strut_style(&self) -> &StrutStyle {

--- a/skia-safe/tests/send_sync.rs
+++ b/skia-safe/tests/send_sync.rs
@@ -187,19 +187,23 @@ mod gpu {
         assert_impl_all!(DrawableInfo: Send, Sync);
         assert_impl_all!(BackendDrawableInfo: Send, Sync);
         // Note that we can't make most of vk.rs re-export of native Vulkan types Send nor Sync,
-        // because they are just re-exports of simple pointers, which already implements a negative
-        // Send & Sync that can not be overriden...
+        // because they are just re-exports of simple pointers, which already implement
+        // !Send & !Sync that can not be overriden...
     }
 
     #[cfg(feature = "d3d")]
     mod d3d {
-        use skia_safe::gpu::d3d::{BackendContext, FenceInfo, TextureResourceInfo};
+        use skia_safe::gpu::d3d::{
+            Alloc, BackendContext, FenceInfo, MemoryAllocator, TextureResourceInfo,
+        };
         use static_assertions::*;
         // not sure if BackendContext is Sync, so we'd set it to Send only for now.
         assert_impl_all!(BackendContext: Send);
         assert_not_impl_any!(BackendContext: Sync);
         assert_impl_all!(TextureResourceInfo: Send, Sync);
         assert_impl_all!(FenceInfo: Send, Sync);
+        assert_impl_all!(Alloc: Send, Sync);
+        assert_impl_all!(MemoryAllocator: Send, Sync);
     }
 }
 


### PR DESCRIPTION
This PR updates rust-skia to support Skia's `chrome/m87` branch.

- [x] Update `README.md` ([rendered](https://github.com/pragmatrix/rust-skia/blob/m87/README.md))  
  > Most important here is to change the Skia branch name and the current Skia submodule tag at the top of the `README.md` file.
- [x] Diff the the following files to see if the build organization has changed significantly:
  - [x] `/BUILD.gn`
  - [x] `/modules/skshaper/BUILD.gn`
  - [x] `/modules/paragraph/BUILD.gn`
- [x] Skia builds ([release notes](https://github.com/google/skia/blob/chrome/m87/RELEASE_NOTES.txt)).
- [x] `/skia-bindings` builds.
- [x] `/skia-safe`: Update & add new wrappers by diffing include files.  
  > Add TODOs for everything that can not be updated right now, and attempt to stay compatible with previous versions of skia-safe without trying too hard before version 1.0. Use `deprecated` attributes if needed.
  - [x] `codec/`
  - [x] `core/`
  - [x] `docs/`
  - [x] `effects/`
  - [x] `gpu/`
    - [x] `d3d/`
    - [x] `gl/`
    - [x] `mtl/`
    - [x] `vk/`
  - [x] `modules/`
    - [x] `paragraph/`
    - [x] `shaper/`
  - [x] `pathops/`
  - [x] `svg/`
  - [x] `utils/`
- [x] Review Send & Sync implementations for new wrappers.
- [x] ~One week before Chrome 87 stable will be released? ([Schedule](https://www.chromestatus.com/features/schedule))
- [x] Any pending changes in the Skia `chrome/m87` branch that aren't synchronized yet?
- [x] Rebase on or merge with master.
- [x] Update versions of `skia-bindings/Cargo.toml` and `skia-safe/Cargo.toml` and also add the version to the new `deprecated` attributes.
- [x] Do the tags/hashes in `skia-bindings/Cargo.toml` under `[package.metadata]` match the submodules `depot_tools` and `skia`?
- [x] Builds with `RUSTFLAGS=-Clink-dead-code` on Windows (#318):
  ```bash
  RUSTFLAGS=-Clink-dead-code (cd skia-org && cargo build -vv --features gl,vulkan,d3d,textlayout)
  ```
- [x] Do one final review of all the changes.
