### PR TITLE
replace curl with ureq:

### DIFF
--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -59,7 +59,8 @@ regex = "1.2.1"
 heck = "0.3.1"
 
 # for downloading and extracting prebuilt binaries and skia / depot_tools archives:
-curl = "0.4.22"
+# curl = "0.4.22"
+ureq = "1.5.1"
 flate2 = "1.0.7"
 tar = "0.4.26"
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -59,7 +59,6 @@ regex = "1.2.1"
 heck = "0.3.1"
 
 # for downloading and extracting prebuilt binaries and skia / depot_tools archives:
-# curl = "0.4.22"
 ureq = "1.5.1"
 flate2 = "1.0.7"
 tar = "0.4.26"

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -1123,8 +1123,8 @@ pub(crate) mod rewrite {
     }
 
     pub fn k_xxx(name: &str, variant: &str) -> String {
-        if variant.starts_with('k') {
-            variant[1..].into()
+        if let Some(stripped) = variant.strip_prefix('k') {
+            stripped.into()
         } else {
             panic!(
                 "Variant name '{}' of enum type '{}' is expected to start with a 'k'",
@@ -1356,8 +1356,8 @@ pub(crate) mod definitions {
             defines
                 .split_whitespace()
                 .map(|d| {
-                    if d.starts_with(prefix) {
-                        &d[prefix.len()..]
+                    if let Some(stripped) = d.strip_prefix(prefix) {
+                        stripped
                     } else {
                         panic!("missing '-D' prefix from a definition")
                     }

--- a/skia-bindings/build_support/utils.rs
+++ b/skia-bindings/build_support/utils.rs
@@ -1,25 +1,15 @@
-use curl::easy::Easy;
 use std::io;
+use std::io::Read;
 
 /// Download a file from the given URL and return the data.
 pub fn download(url: impl AsRef<str>) -> io::Result<Vec<u8>> {
-    let mut data = Vec::new();
-    let mut handle = Easy::new();
-    handle.url(url.as_ref())?;
-    handle.fail_on_error(true)?;
-    handle.follow_location(true)?;
-    let curl_result = {
-        let mut transfer = handle.transfer();
-        transfer
-            .write_function(|new_data| {
-                data.extend_from_slice(new_data);
-                Ok(new_data.len())
-            })
-            .unwrap();
-        transfer.perform()
-    };
-    match curl_result {
-        Err(e) => Err(io::Error::new(io::ErrorKind::Other, e)),
-        Ok(()) => Ok(data),
+    let resp = ureq::get(url.as_ref()).timeout_connect(10_000).call();
+    if let Some(error) = resp.synthetic_error() {
+        Err(io::Error::from_raw_os_error(error.status() as i32))
+    } else {
+        let mut reader = resp.into_reader();
+        let mut data = Vec::new();
+        let bits = reader.read_to_end(&mut data)?;
+        Ok(data)
     }
 }

--- a/skia-bindings/build_support/utils.rs
+++ b/skia-bindings/build_support/utils.rs
@@ -9,7 +9,7 @@ pub fn download(url: impl AsRef<str>) -> io::Result<Vec<u8>> {
     } else {
         let mut reader = resp.into_reader();
         let mut data = Vec::new();
-        let bits = reader.read_to_end(&mut data)?;
+        reader.read_to_end(&mut data)?;
         Ok(data)
     }
 }


### PR DESCRIPTION
Related to this, https://github.com/Kethku/neovide/issues/371

I figured since curl was just being used in one place, we could just use something rust native to relieve the dependency.