### PR TITLE
Allow cross-compilation for arbitrary targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /Cargo.lock
-/target/
+target/
 /.cargo/credentials
 /cmake-build-debug/

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -53,7 +53,7 @@ shaper = ["textlayout"]
 
 [build-dependencies]
 cc = "1.0.37"
-bindgen = "0.55.1"
+bindgen = "0.56.0"
 # For enum variant name replacements.
 regex = "1.2.1"
 heck = "0.3.1"

--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -68,10 +68,12 @@ fn main() {
     let build_config = skia::BuildConfiguration::default();
     let binaries_config = skia::BinariesConfiguration::from_cargo_env(&build_config);
 
+    // Used by both offline builds and binding generation
+    cargo::rerun_if_env_changed("SYSROOT");
+
     //
     // offline build?
     //
-
     if let Some(offline_source_dir) = env::offline_source_dir() {
         println!("STARTING OFFLINE BUILD");
 

--- a/skia-bindings/build_support/ios.rs
+++ b/skia-bindings/build_support/ios.rs
@@ -5,14 +5,22 @@ use std::process::{Command, Stdio};
 
 // TODO: add support for 32 bit devices and simulators.
 
+pub fn extra_skia_cflags(arch: &str, flags: &mut Vec<&str>) {
+    if is_simulator(arch) {
+        flags.push("-mios-simulator-version-min=10.0");
+    } else {
+        flags.push("-miphoneos-version-min=10.0");
+    }
+}
+
 pub fn additional_clang_args(arch: &str) -> Vec<String> {
     let mut args: Vec<String> = Vec::new();
 
     if is_simulator(arch) {
-        args.push("-mios-simulator-version-min=7.0".into());
+        args.push("-mios-simulator-version-min=10.0".into());
         args.push("-m64".into());
     } else {
-        args.push("-miphoneos-version-min=7.0".into());
+        args.push("-miphoneos-version-min=10.0".into());
         args.push("-arch".into());
         args.push(clang::target_arch(arch).into());
     }

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -262,9 +262,11 @@ impl FinalBuildConfiguration {
                     cflags.push("-flto");
                 }
                 */
-
-                opt_level_arg = format!("-O{}", opt_level);
-                cflags.push(&opt_level_arg);
+                // When targeting windows `-O` isn't supported.
+                if !target.is_windows() {
+                    opt_level_arg = format!("-O{}", opt_level);
+                    cflags.push(&opt_level_arg);
+                }
             }
 
             match target.as_strs() {

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -49,8 +49,8 @@ impl Default for BuildConfiguration {
                 particles: false,
             },
             definitions: Vec::new(),
-            cc: cargo::env_var("CC").unwrap_or("clang".to_string()),
-            cxx: cargo::env_var("CXX").unwrap_or("clang++".to_string()),
+            cc: cargo::env_var("CC").unwrap_or_else(|| "clang".to_string()),
+            cxx: cargo::env_var("CXX").unwrap_or_else(|| "clang++".to_string()),
         }
     }
 }

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -308,7 +308,12 @@ impl FinalBuildConfiguration {
                     use_expat = true;
                 }
                 (arch, _, os, _) => {
-                    args.push(("target_os", quote(os)));
+                    let skia_target_os = match os {
+                        "darwin" => "mac",
+                        "windows" => "win",
+                        _ => os,
+                    };
+                    args.push(("target_os", quote(skia_target_os)));
                     args.push(("target_cpu", quote(clang::target_arch(arch))));
                 }
             }

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -721,15 +721,6 @@ fn generate_bindings(build: &FinalBuildConfiguration, output_directory: &Path) {
         .clang_args(&["-x", "c++"])
         .clang_arg("-v");
 
-    // on macOS some arrays that are used in opaque types get too large to support Debug.
-    // (for example High Sierra: [u16; 105])
-    // TODO: may reenable when const generics land in stable.
-    let builder = if cfg!(target_os = "macos") {
-        builder.derive_debug(false)
-    } else {
-        builder
-    };
-
     // don't generate destructors on Windows: https://github.com/rust-skia/rust-skia/issues/318
     let mut builder = if cfg!(target_os = "windows") {
         builder.with_codegen_config({

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -307,6 +307,11 @@ impl FinalBuildConfiguration {
                     // in the system.
                     use_expat = true;
                 }
+                (arch, _, "ios", _) => {
+                    args.push(("target_os", quote("ios")));
+                    args.push(("target_cpu", quote(clang::target_arch(arch))));
+                    ios::extra_skia_cflags(arch, &mut cflags);
+                }
                 (arch, _, os, _) => {
                     let skia_target_os = match os {
                         "darwin" => "mac",

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -307,13 +307,9 @@ impl FinalBuildConfiguration {
                     // in the system.
                     use_expat = true;
                 }
-                (arch, "apple", "ios", _) => {
-                    args.push(("target_os", quote("ios")));
-                    args.push(("target_cpu", quote(clang::target_arch(arch))));
-                }
                 (arch, _, os, _) => {
-                    args.push(("target_cpu", quote(clang::target_arch(arch))));
                     args.push(("target_os", quote(os)));
+                    args.push(("target_cpu", quote(clang::target_arch(arch))));
                 }
             }
 

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -257,9 +257,11 @@ impl FinalBuildConfiguration {
             }
 
             if let Some(opt_level) = &build.opt_level {
+                /* LTO generates corrupt libraries on the host platforms when building with --release
                 if opt_level.parse::<usize>() != Ok(0) {
                     cflags.push("-flto");
                 }
+                */
 
                 opt_level_arg = format!("-O{}", opt_level);
                 cflags.push(&opt_level_arg);


### PR DESCRIPTION
This allows manually setting the sysroot (instead of only automatically detecting sysroot, and only on macOS). Additionally, it correctly sets the target flag for the compiler on all platforms. There seems to be an env var `SDKROOT` that is used by clang to set sysroot without CLI flags, so I've reused that variable name for consistency.

Duplicated from #432 but moved to a new branch.