### PR TITLE
Add docs

### DIFF
--- a/skia-safe/src/core/path.rs
+++ b/skia-safe/src/core/path.rs
@@ -16,24 +16,12 @@ pub use path_types::PathDirection as Direction;
 pub use path_types::PathFillType as FillType;
 
 pub use skia_bindings::SkPath_ArcSize as ArcSize;
-#[test]
-fn test_arc_size_naming() {
-    let _ = ArcSize::Small;
-}
 
 pub use skia_bindings::SkPath_AddPathMode as AddPathMode;
-#[test]
-fn test_add_path_mode_naming() {
-    let _ = AddPathMode::Append;
-}
 
 pub use path_types::PathSegmentMask as SegmentMask;
 
 pub use skia_bindings::SkPath_Verb as Verb;
-#[test]
-pub fn test_verb_naming() {
-    let _ = Verb::Line;
-}
 
 #[repr(C)]
 pub struct Iter<'a>(SkPath_Iter, PhantomData<&'a Handle<SkPath>>);
@@ -175,7 +163,11 @@ impl Iterator for RawIter<'_> {
     }
 }
 
+/// A Skia shape. This is just the abstract shape, which could be either a fill or a stroke
+/// depending on the defined paint (see the documentation for `Paint`). This type is
+/// copy-on-write, and so cloning it will share underlying storage until it is mutated.
 pub type Path = Handle<SkPath>;
+
 unsafe impl Send for Path {}
 unsafe impl Sync for Path {}
 
@@ -204,6 +196,15 @@ impl Default for Handle<SkPath> {
 }
 
 impl Handle<SkPath> {
+    /// Create a path from a set of points and the associated verbs. Verbs are here specified
+    /// as bytes, one byte per verb. The `Verb` enum is 32 bits, and you can get the bytes needed
+    /// for this function by simply using `foo_verb as u8`.
+    ///
+    /// Set `fill_type` to choose winding vs even-odd fill mode.
+    ///
+    /// `is_volatile` selects whether the path is "volatile". A volatile path will never be cached,
+    /// a non-volatile path will have intermediate values needed for drawing stored on the path itself
+    /// in order to speed up drawing.
     pub fn new_from(
         points: &[Point],
         verbs: &[u8],
@@ -226,6 +227,7 @@ impl Handle<SkPath> {
         })
     }
 
+    /// Create a simple rectangle, optionally speciying winding order.
     pub fn rect(rect: impl AsRef<Rect>, dir: impl Into<Option<PathDirection>>) -> Self {
         Self::construct(|path| unsafe {
             sb::C_SkPath_Rect(
@@ -236,6 +238,8 @@ impl Handle<SkPath> {
         })
     }
 
+    /// Create a simple oval with the position, width and height specified by the input rectangle,
+    /// optionally specifying winding order.
     pub fn oval(oval: impl AsRef<Rect>, dir: impl Into<Option<PathDirection>>) -> Self {
         Self::construct(|path| unsafe {
             sb::C_SkPath_Oval(
@@ -246,6 +250,9 @@ impl Handle<SkPath> {
         })
     }
 
+    /// Create a simple oval with the position, width and height specified by the input rectangle,
+    /// optionally specifying winding order. An oval is created out of multiple segments, and this
+    /// allows you to choose which segment is considered the "first" one.
     pub fn oval_with_start_index(
         oval: impl AsRef<Rect>,
         dir: PathDirection,
@@ -261,6 +268,7 @@ impl Handle<SkPath> {
         })
     }
 
+    /// Create a circle, optionally specifying winding order.
     pub fn circle(
         center: impl Into<Point>,
         radius: scalar,
@@ -278,6 +286,8 @@ impl Handle<SkPath> {
         })
     }
 
+    /// Create a rounded rectangle, optionally specifying winding order (see documentation for `RRect` for
+    /// more info).
     pub fn rrect(rect: impl AsRef<RRect>, dir: impl Into<Option<PathDirection>>) -> Self {
         Self::construct(|path| unsafe {
             sb::C_SkPath_RRect(
@@ -288,6 +298,9 @@ impl Handle<SkPath> {
         })
     }
 
+    /// Create a rounded rectangle, optionally specifying winding order (see documentation for `RRect` for
+    /// more info). A rounded rectangle is made out of multiple segments, and this allows you to select
+    /// which segment is considered the "first" one.
     pub fn rrect_with_start_index(
         rect: impl AsRef<RRect>,
         dir: PathDirection,
@@ -303,6 +316,13 @@ impl Handle<SkPath> {
         })
     }
 
+    /// Create a possibly-closed arbitrary polygon with flat sides, from a series of points.
+    ///
+    /// Set `fill_type` to choose winding vs even-odd fill mode.
+    ///
+    /// `is_volatile` selects whether the path is "volatile". A volatile path will never be cached,
+    /// a non-volatile path will have intermediate values needed for drawing stored on the path itself
+    /// in order to speed up drawing.
     pub fn polygon(
         pts: &[Point],
         is_closed: bool,
@@ -321,18 +341,27 @@ impl Handle<SkPath> {
         })
     }
 
+    /// Create a path representing just a single straight line between two points.
     pub fn line(a: impl Into<Point>, b: impl Into<Point>) -> Self {
         Self::polygon(&[a.into(), b.into()], false, None, None)
     }
 
+    /// Create an empty path.
     pub fn new() -> Self {
         Self::construct(|path| unsafe { sb::C_SkPath_Construct(path) })
     }
 
+    /// Returns true if this path can be interpolated with the path specified by `compare`. This is
+    /// true if both paths have the same number of segments, and the verb for each segment matches.
+    /// If the verb is `Conic`, then the weights must match.
     pub fn is_interpolatable(&self, compare: &Path) -> bool {
         unsafe { self.native().isInterpolatable(compare.native()) }
     }
 
+    /// Create a new path that interpolates between this path and the path specified by `ending`.
+    /// `weight` should be between 0 and 1. 0 means that the output will be equal to `self`,
+    /// and 1 means that the output will be equal to `ending`. Returns false if the paths are not
+    /// interpolatable (see `is_interpolatable`).
     pub fn interpolate(&self, ending: &Path, weight: scalar) -> Option<Path> {
         let mut out = Path::default();
         unsafe {
@@ -342,19 +371,24 @@ impl Handle<SkPath> {
         .if_true_some(out)
     }
 
+    /// Returns the fill rule for this path (see documentation for `PathFillType`).
     pub fn fill_type(&self) -> PathFillType {
         unsafe { sb::C_SkPath_getFillType(self.native()) }
     }
 
+    /// Sets the fill rule for this path (see documentation for `PathFillType`).
     pub fn set_fill_type(&mut self, ft: PathFillType) -> &mut Self {
         self.native_mut().set_fFillType(ft as _);
         self
     }
 
+    /// Returns true if the fill type is an "inverse" type (see documentation for `PathFillType`).
     pub fn is_inverse_fill_type(&self) -> bool {
         self.fill_type().is_inverse()
     }
 
+    /// Sets the fill type of this path to be the "inverted" equivalent of the current fill type
+    /// (see `PathFillType`)
     pub fn toggle_inverse_fill_type(&mut self) -> &mut Self {
         let inverse = self.native().fFillType() ^ 2;
         self.native_mut().set_fFillType(inverse);
@@ -371,55 +405,79 @@ impl Handle<SkPath> {
         panic!("Removed")
     }
 
+    /// Returns true if the path is fully convex.
     pub fn is_convex(&self) -> bool {
         unsafe { sb::C_SkPath_isConvex(self.native()) }
     }
 
+    /// If the path is an oval, returns the bounding rectangle. Otherwise, returns `None`.
     pub fn is_oval(&self) -> Option<Rect> {
         let mut bounds = Rect::default();
         unsafe { self.native().isOval(bounds.native_mut()) }.if_true_some(bounds)
     }
 
+    /// If the path is a rounded rectangle, returns the `RRect` that specifies its shape. Otherwise,
+    /// returns `None`.
     pub fn is_rrect(&self) -> Option<RRect> {
         let mut rrect = RRect::default();
         unsafe { self.native().isRRect(rrect.native_mut()) }.if_true_some(rrect)
     }
 
+    /// Clears the path segments, deleting the internal storage and setting all metadata (such as fill
+    /// type) to their respective default values.
     pub fn reset(&mut self) -> &mut Self {
         unsafe { self.native_mut().reset() };
         self
     }
 
+    /// Clears the path segments, setting all metadata (such as fill type) to their respective default
+    /// values. Unlike `reset`, this does _not_ delete the internal storage, and so it is useful if you
+    /// want to avoid reallocating if you're creating a new path that will have the same number of
+    /// segments as an existing path.
     pub fn rewind(&mut self) -> &mut Self {
         unsafe { self.native_mut().rewind() };
         self
     }
 
+    /// Returns true if the path has no segments.
     pub fn is_empty(&self) -> bool {
         unsafe { sb::C_SkPath_isEmpty(self.native()) }
     }
 
+    /// Returns true if the path's verb array was last modified by `fn close`.
     pub fn is_last_contour_closed(&self) -> bool {
         unsafe { self.native().isLastContourClosed() }
     }
 
+    /// Returns true if all the points in this shape have values that are finite. Returns false if
+    /// any point has a component that is infinity, negative infinity or NaN.
     pub fn is_finite(&self) -> bool {
         unsafe { sb::C_SkPath_isFinite(self.native()) }
     }
 
+    /// Returns whether this path is volatile or not. A volatile path will not have metadata required
+    /// for drawing internally cached. Paths are non-volatile by default.
     pub fn is_volatile(&self) -> bool {
         self.native().fIsVolatile() != 0
     }
 
+    /// Set whether this path is volatile or not. A volatile path will not have metadata required
+    /// for drawing internally cached. Paths are non-volatile by default. If you expect to draw a path
+    /// multiple times without mutating it then you should leave it as non-volatile. If you are
+    /// regenerating the path every time you draw it then you should set the path to be volatile.
     pub fn set_is_volatile(&mut self, is_volatile: bool) -> &mut Self {
         self.native_mut().set_fIsVolatile(is_volatile as _);
         self
     }
 
+    /// Checks whether a line between the two supplied points is "degenerate", i.e. if the points are
+    /// close enough that they can be treated as a single point.
     pub fn is_line_degenerate(p1: impl Into<Point>, p2: impl Into<Point>, exact: bool) -> bool {
         unsafe { SkPath::IsLineDegenerate(p1.into().native(), p2.into().native(), exact) }
     }
 
+    /// Checks whether a quadratic bezier curve is degenerate, i.e. if its length is small enough that
+    /// it can be treated as a single point.
     pub fn is_quad_degenerate(
         p1: impl Into<Point>,
         p2: impl Into<Point>,
@@ -436,6 +494,8 @@ impl Handle<SkPath> {
         }
     }
 
+    /// Checks whether a cubic bezier curve is degenerate, i.e. if its length is small enough that
+    /// it can be treated as a single point.
     pub fn is_cubic_degenerate(
         p1: impl Into<Point>,
         p2: impl Into<Point>,
@@ -454,16 +514,19 @@ impl Handle<SkPath> {
         }
     }
 
+    /// If this path is a single line, return the start- and endpoints. Otherwise, return `None`.
     pub fn is_line(&self) -> Option<(Point, Point)> {
         let mut line = [Point::default(); 2];
         unsafe { self.native().isLine(line.native_mut().as_mut_ptr()) }
             .if_true_some((line[0], line[1]))
     }
 
+    /// Returns the number of points in this path.
     pub fn count_points(&self) -> usize {
         unsafe { self.native().countPoints().try_into().unwrap() }
     }
 
+    /// Returns the nth point in the path.
     pub fn get_point(&self, index: usize) -> Option<Point> {
         let p = Point::from_native_c(unsafe {
             sb::C_SkPath_getPoint(self.native(), index.try_into().unwrap())
@@ -477,6 +540,8 @@ impl Handle<SkPath> {
         }
     }
 
+    /// Writes the points in this path to the `points` array, returning the number of points that
+    /// were written.
     pub fn get_points(&self, points: &mut [Point]) -> usize {
         unsafe {
             self.native().getPoints(
@@ -488,10 +553,13 @@ impl Handle<SkPath> {
         .unwrap()
     }
 
+    /// Returns the number of verbs in the path.
     pub fn count_verbs(&self) -> usize {
         unsafe { self.native().countVerbs() }.try_into().unwrap()
     }
 
+    /// Writes the verbs in this path to the `verbs` array, returning the number of verbs that were
+    /// written.
     pub fn get_verbs(&self, verbs: &mut [u8]) -> usize {
         unsafe {
             self.native()
@@ -501,28 +569,41 @@ impl Handle<SkPath> {
         .unwrap()
     }
 
+    /// Returns an approximation of the memory used by this path.
     pub fn approximate_bytes_used(&self) -> usize {
         unsafe { self.native().approximateBytesUsed() }
     }
 
+    /// Swaps the data of this path and another path.
     pub fn swap(&mut self, other: &mut Path) -> &mut Self {
         unsafe { self.native_mut().swap(other.native_mut()) }
         self
     }
 
+    /// Returns the approximate bounding box of this path. For paths containing curves, this may be
+    /// larger than the tight bounding box, but is far cheaper to calculate. Additionally, the value
+    /// is cached. For the tight bounding box, see `compute_tight_bounds`.
     pub fn bounds(&self) -> &Rect {
         Rect::from_native_ref(unsafe { &*sb::C_SkPath_getBounds(self.native()) })
     }
 
+    /// Updates the cached bounding box, if it has become out-of-date.
     pub fn update_bounds_cache(&mut self) -> &mut Self {
         self.bounds();
         self
     }
 
+    /// Calculate the precise bounding box. This is more expensive to compute than the approximate
+    /// bounding box, and its value is not cached. However, it is guarateed to be the smallest
+    /// rectangle that can contain this path.
     pub fn compute_tight_bounds(&self) -> Rect {
         Rect::from_native_c(unsafe { sb::C_SkPath_computeTightBounds(self.native()) })
     }
 
+    /// Returns true if the rectangle is contained within the outline of this path. This function is
+    /// an approximation, and can return false even if the rectangle is contained within this path's
+    /// outline. However, it will never return true when the rectangle is _not_ contained within this
+    /// path's outline.
     pub fn conservatively_contains_rect(&self, rect: impl AsRef<Rect>) -> bool {
         unsafe {
             self.native()
@@ -530,6 +611,7 @@ impl Handle<SkPath> {
         }
     }
 
+    /// Reserve space in the verb and point arrays for `extra_pt_count` additional points.
     pub fn inc_reserve(&mut self, extra_pt_count: usize) -> &mut Self {
         unsafe {
             self.native_mut()
@@ -543,6 +625,7 @@ impl Handle<SkPath> {
         self
     }
 
+    /// Move the cursor (i.e. the point where the next contour will start) to the point `p`.
     pub fn move_to(&mut self, p: impl Into<Point>) -> &mut Self {
         let p = p.into();
         unsafe {
@@ -551,6 +634,8 @@ impl Handle<SkPath> {
         self
     }
 
+    /// Move the cursor (i.e. the point where the next contour will start) by `d`, relative to
+    /// the current cursor position.
     pub fn r_move_to(&mut self, d: impl Into<Vector>) -> &mut Self {
         let d = d.into();
         unsafe {
@@ -559,6 +644,7 @@ impl Handle<SkPath> {
         self
     }
 
+    /// Append a straight line to this path, from the current cursor location to the point `p`.
     pub fn line_to(&mut self, p: impl Into<Point>) -> &mut Self {
         let p = p.into();
         unsafe {
@@ -567,6 +653,7 @@ impl Handle<SkPath> {
         self
     }
 
+    /// Append a straight line to this path, from the current cursor location to the point `cursor + d`.
     pub fn r_line_to(&mut self, d: impl Into<Vector>) -> &mut Self {
         let d = d.into();
         unsafe {
@@ -575,23 +662,32 @@ impl Handle<SkPath> {
         self
     }
 
-    pub fn quad_to(&mut self, p1: impl Into<Point>, p2: impl Into<Point>) -> &mut Self {
-        let p1 = p1.into();
-        let p2 = p2.into();
+    /// Append a quadratic bezier curve to this path, from the current cursor location to the point `end`,
+    /// with the control point `control`.
+    pub fn quad_to(&mut self, control: impl Into<Point>, end: impl Into<Point>) -> &mut Self {
+        let p1 = control.into();
+        let p2 = end.into();
         unsafe {
             self.native_mut().quadTo(p1.x, p1.y, p2.x, p2.y);
         }
         self
     }
 
-    pub fn r_quad_to(&mut self, dx1: impl Into<Vector>, dx2: impl Into<Vector>) -> &mut Self {
-        let (dx1, dx2) = (dx1.into(), dx2.into());
+    /// Append a quadratic bezier curve to this path, from the current cursor location to the point
+    /// `cursor + end_d`, with the control point `cursor + control_d`.
+    pub fn r_quad_to(
+        &mut self,
+        control_d: impl Into<Vector>,
+        end_d: impl Into<Vector>,
+    ) -> &mut Self {
+        let (dx1, dx2) = (control_d.into(), end_d.into());
         unsafe {
             self.native_mut().rQuadTo(dx1.x, dx1.y, dx2.x, dx2.y);
         }
         self
     }
 
+    /// Append a conic curve to this path.
     pub fn conic_to(&mut self, p1: impl Into<Point>, p2: impl Into<Point>, w: scalar) -> &mut Self {
         let p1 = p1.into();
         let p2 = p2.into();
@@ -601,6 +697,7 @@ impl Handle<SkPath> {
         self
     }
 
+    /// Append a conic curve to this path, relative to the current cursor position.
     pub fn r_conic_to(
         &mut self,
         d1: impl Into<Vector>,
@@ -614,13 +711,15 @@ impl Handle<SkPath> {
         self
     }
 
+    /// Append a cubic bezier curve to this path, from the current cursor location to the point `end`,
+    /// with the control points `control1` and `control2`.
     pub fn cubic_to(
         &mut self,
-        p1: impl Into<Point>,
-        p2: impl Into<Point>,
-        p3: impl Into<Point>,
+        control1: impl Into<Point>,
+        control2: impl Into<Point>,
+        end: impl Into<Point>,
     ) -> &mut Self {
-        let (p1, p2, p3) = (p1.into(), p2.into(), p3.into());
+        let (p1, p2, p3) = (control1.into(), control2.into(), end.into());
         unsafe {
             self.native_mut()
                 .cubicTo(p1.x, p1.y, p2.x, p2.y, p3.x, p3.y);
@@ -628,13 +727,15 @@ impl Handle<SkPath> {
         self
     }
 
+    /// Append a cubic bezier curve to this path, from the current cursor location to the point `cursor + end_d`,
+    /// with the control points `cursor + control_d1` and `cursor + control_d2`.
     pub fn r_cubic_to(
         &mut self,
-        d1: impl Into<Vector>,
-        d2: impl Into<Vector>,
-        d3: impl Into<Vector>,
+        control_d1: impl Into<Vector>,
+        control_d2: impl Into<Vector>,
+        end_d: impl Into<Vector>,
     ) -> &mut Self {
-        let (d1, d2, d3) = (d1.into(), d2.into(), d3.into());
+        let (d1, d2, d3) = (control_d1.into(), control_d2.into(), end_d.into());
         unsafe {
             self.native_mut()
                 .rCubicTo(d1.x, d1.y, d2.x, d2.y, d3.x, d3.y);
@@ -642,6 +743,7 @@ impl Handle<SkPath> {
         self
     }
 
+    /// Append an arc curve to this path.
     pub fn arc_to(
         &mut self,
         oval: impl AsRef<Rect>,
@@ -660,6 +762,9 @@ impl Handle<SkPath> {
         self
     }
 
+    /// Append an arc curve to this path, bounded by the triangle defined by the cursor, p1 and p2. The
+    /// arc is a component of a circle with the specified radius, positioned such that it touches both
+    /// tangent lines.
     pub fn arc_to_tangent(
         &mut self,
         p1: impl Into<Point>,
@@ -673,6 +778,10 @@ impl Handle<SkPath> {
         self
     }
 
+    /// Append an arc curve to this path, that is part of the oval defined by xy rotated by `x_axis_rotate`
+    /// (specified in degrees). The `PathDirection` specifies whether it is clockwise or anticlockwise and
+    /// `large_arc` specifies whether the smaller or larger of the two arc lengths is chosen. The arc ends
+    /// at `xy`.
     pub fn arc_to_rotated(
         &mut self,
         r: impl Into<Point>,
@@ -689,6 +798,10 @@ impl Handle<SkPath> {
         self
     }
 
+    /// Append an arc curve to this path, that is part of the oval defined by xy rotated by `x_axis_rotate`
+    /// (specified in degrees). The `PathDirection` specifies whether it is clockwise or anticlockwise and
+    /// `large_arc` specifies whether the smaller or larger of the two arc lengths is chosen. The arc ends
+    /// at `cursor + xy`.
     pub fn r_arc_to_rotated(
         &mut self,
         r: impl Into<Point>,
@@ -705,6 +818,7 @@ impl Handle<SkPath> {
         self
     }
 
+    /// Close the path, appending a line between the first and last point of the path.
     pub fn close(&mut self) -> &mut Self {
         unsafe {
             self.native_mut().close();
@@ -712,6 +826,7 @@ impl Handle<SkPath> {
         self
     }
 
+    /// Converts a conic curve to a series of quads and writes them to `pts`.
     pub fn convert_conic_to_quads(
         p0: impl Into<Point>,
         p1: impl Into<Point>,
@@ -741,6 +856,8 @@ impl Handle<SkPath> {
     }
 
     // TODO: return type is probably worth a struct.
+    /// If the path is equivalent to a rectangle when filled, returns a tuple with the rectangle, whether
+    /// the rectangle is closed, and the direction of the path. Otherwise, returns `None`.
     pub fn is_rect(&self) -> Option<(Rect, bool, PathDirection)> {
         let mut rect = Rect::default();
         let mut is_closed = Default::default();
@@ -752,6 +869,7 @@ impl Handle<SkPath> {
         .if_true_some((rect, is_closed, direction))
     }
 
+    /// Appends a rectangle to the current path. See `fn rect`.
     pub fn add_rect(
         &mut self,
         rect: impl AsRef<Rect>,
@@ -766,6 +884,7 @@ impl Handle<SkPath> {
         self
     }
 
+    /// Appends an oval to the current path. See `fn oval` and `fn oval_with_start_index`.
     pub fn add_oval(
         &mut self,
         oval: impl AsRef<Rect>,
@@ -780,6 +899,7 @@ impl Handle<SkPath> {
         self
     }
 
+    /// Appends a circle to the current path. See `fn circle` and `fn circle_with_start_index`.
     pub fn add_circle(
         &mut self,
         p: impl Into<Point>,
@@ -792,6 +912,8 @@ impl Handle<SkPath> {
         self
     }
 
+    /// Appends an arc to the path, that is the segment between `start_angle` and `start_angle + sweep_angle`
+    /// degrees of the oval specified by `oval`, starting at the current cursor position.
     pub fn add_arc(
         &mut self,
         oval: impl AsRef<Rect>,
@@ -807,6 +929,7 @@ impl Handle<SkPath> {
 
     // decided to only provide the simpler variant of the two, if radii needs to be specified,
     // add_rrect can be used.
+    /// Simple helper function for `add_rrect` that takes a rectangle and the corner radii.
     pub fn add_round_rect(
         &mut self,
         rect: impl AsRef<Rect>,
@@ -821,6 +944,7 @@ impl Handle<SkPath> {
         self
     }
 
+    /// Append a rounded rectangle to the path. See `fn rrect` and `fn rrect_with_start_index`.
     pub fn add_rrect(
         &mut self,
         rrect: impl AsRef<RRect>,
@@ -835,6 +959,7 @@ impl Handle<SkPath> {
         self
     }
 
+    /// Append a polygon to the path. See `fn polygon`.
     pub fn add_poly(&mut self, pts: &[Point], close: bool) -> &mut Self {
         unsafe {
             self.native_mut()
@@ -845,6 +970,9 @@ impl Handle<SkPath> {
 
     // TODO: addPoly(initializer_list)
 
+    /// Combine this path with `src`, with positions in `src` offset by the vector `d`.
+    /// `AddPathMode::Append` combines the shapes without connecting them, `AddPathMode::Extend`
+    /// connects the current cursor to the start of the `src` path if the current contour is not closed.
     pub fn add_path(
         &mut self,
         src: &Path,
@@ -858,6 +986,9 @@ impl Handle<SkPath> {
     }
 
     // TODO: rename to add_path_with_matrix() ?
+    /// Combine this path with `src`, with positions in `src` transformed by the matrix `matrix`.
+    /// `AddPathMode::Append` combines the shapes without connecting them, `AddPathMode::Extend`
+    /// connects the current cursor to the start of the `src` path if the current contour is not closed.
     pub fn add_path_matrix(
         &mut self,
         src: &Path,
@@ -872,11 +1003,15 @@ impl Handle<SkPath> {
         self
     }
 
+    /// Combine this path with `src`, from end to start, with positions in `src` offset by the vector `d`.
+    /// This is always treated as `AddPathMode::Extend` (i.e. always connects the current cursor with the
+    /// end point of `src`).
     pub fn reverse_add_path(&mut self, src: &Path) -> &mut Self {
         unsafe { self.native_mut().reverseAddPath(src.native()) };
         self
     }
 
+    /// Create a new path that is the same as this one but with all points offset by the given vector `d`.
     #[must_use]
     pub fn with_offset(&self, d: impl Into<Vector>) -> Path {
         let d = d.into();
@@ -885,6 +1020,7 @@ impl Handle<SkPath> {
         path
     }
 
+    /// Move this path by vector `d`.
     pub fn offset(&mut self, d: impl Into<Vector>) -> &mut Self {
         let d = d.into();
         let self_ptr = self.native_mut() as *mut _;
@@ -892,11 +1028,27 @@ impl Handle<SkPath> {
         self
     }
 
+    /// Create a new path that is the same as this one but transformed by the matrix `matrix`.
+    ///
+    /// If the matrix has a bottom row other than `0, 0, 1` (i.e. if it transforms the `w` component of the
+    /// path's points) then the points will be perspective clipped, which avoids dividing by zero or returning
+    /// negative values for `w`. This is usually what you want as it avoids confusing results, but if you
+    /// want to disable this behavior see `fn with_transform_with_perspective_clip`.
     #[must_use]
     pub fn with_transform(&self, matrix: &Matrix) -> Path {
         self.with_transform_with_perspective_clip(matrix, ApplyPerspectiveClip::Yes)
     }
 
+    /// Create a new path that is the same as this one but transformed by the matrix `matrix`.
+    ///
+    /// In the case that `perspective_clip` is `ApplyPerspectiveClip::Yes`: If the matrix has a bottom row other
+    /// than `0, 0, 1` (i.e. if it transforms the `w` component of the path's points) then the points will
+    /// be perspective clipped, which avoids dividing by zero or returning negative values for `w`. This is
+    /// usually what you want as it avoids confusing results.
+    ///
+    /// In the case that `perspective_clip` is `ApplyPerspectiveClip::No`: The math is applied in a "brute force"
+    /// manner, meaning that strange results may occur when the matrix has a bottom row that transforms the `w`
+    /// component.
     pub fn with_transform_with_perspective_clip(
         &self,
         matrix: &Matrix,
@@ -910,10 +1062,26 @@ impl Handle<SkPath> {
         path
     }
 
+    /// Transform this path in-place by the matrix `matrix`.
+    ///
+    /// If the matrix has a bottom row other than `0, 0, 1` (i.e. if it transforms the `w` component of the
+    /// path's points) then the points will be perspective clipped, which avoids dividing by zero or returning
+    /// negative values for `w`. This is usually what you want as it avoids confusing results, but if you
+    /// want to disable this behavior see `fn transform_with_perspective_clip`.
     pub fn transform(&mut self, matrix: &Matrix) -> &mut Self {
         self.transform_with_perspective_clip(matrix, ApplyPerspectiveClip::Yes)
     }
 
+    /// Transform this path in-place by the matrix `matrix`.
+    ///
+    /// In the case that `perspective_clip` is `ApplyPerspectiveClip::Yes`: If the matrix has a bottom row other
+    /// than `0, 0, 1` (i.e. if it transforms the `w` component of the path's points) then the points will
+    /// be perspective clipped, which avoids dividing by zero or returning negative values for `w`. This is
+    /// usually what you want as it avoids confusing results.
+    ///
+    /// In the case that `perspective_clip` is `ApplyPerspectiveClip::No`: The math is applied in a "brute force"
+    /// manner, meaning that strange results may occur when the matrix has a bottom row that transforms the `w`
+    /// component.
     pub fn transform_with_perspective_clip(
         &mut self,
         matrix: &Matrix,
@@ -927,11 +1095,14 @@ impl Handle<SkPath> {
         self
     }
 
+    /// Get the last point that the path ends at, if the path is non-empty and the last contour is not closed.
+    /// This is the cursor that is used when adding new contours to the path.
     pub fn last_pt(&self) -> Option<Point> {
         let mut last_pt = Point::default();
         unsafe { self.native().getLastPt(last_pt.native_mut()) }.if_true_some(last_pt)
     }
 
+    /// See `with_transform_with_perspective_clip`.
     pub fn make_transform(
         &mut self,
         m: &Matrix,
@@ -943,25 +1114,34 @@ impl Handle<SkPath> {
         )
     }
 
+    /// Create a new path that is the same as this one, but scaled by `sx` in the x direction and `sy` in the
+    /// y direction, around the point (0, 0).
     pub fn make_scale(&mut self, (sx, sy): (scalar, scalar)) -> Path {
         self.make_transform(&Matrix::scale((sx, sy)), ApplyPerspectiveClip::No)
     }
 
+    /// Set the cursor position that will be used when adding new components to this path. You probably
+    /// want to use `move_to` instead.
     pub fn set_last_pt(&mut self, p: impl Into<Point>) -> &mut Self {
         let p = p.into();
         unsafe { self.native_mut().setLastPt(p.x, p.y) };
         self
     }
 
+    /// Returns a bitset where the corresponding bit is set if the path contains one or more components of
+    /// that type.
     pub fn segment_masks(&self) -> SegmentMask {
         SegmentMask::from_bits_truncate(unsafe { sb::C_SkPath_getSegmentMasks(self.native()) })
     }
 
+    /// Returns true if the point `p` is within the path's outline.
     pub fn contains(&self, p: impl Into<Point>) -> bool {
         let p = p.into();
         unsafe { self.native().contains(p.x, p.y) }
     }
 
+    /// Write this path out to a value of type `SkData`. This is for debugging purposes, if you want to write
+    /// the path out in a format that can be read back later, you should use `fn serialize`.
     pub fn dump_as_data(&self, force_close: bool, dump_as_hex: bool) -> Data {
         let mut stream = DynamicMemoryWStream::new();
         unsafe {
@@ -981,12 +1161,16 @@ impl Handle<SkPath> {
 
     // TODO: writeToMemory()?
 
+    /// Write this path to memory in a format that can be deserialized by the same version of Skia. The format
+    /// is unspecified and not guaranteed to be compatible across versions.
     pub fn serialize(&self) -> Data {
         Data::from_ptr(unsafe { sb::C_SkPath_serialize(self.native()) }).unwrap()
     }
 
     // TODO: readFromMemory()?
 
+    /// Read this path from data in memory. The format that this function reads is unspecified, other than that
+    /// it can read the format produced by the `Path::serialize` function in the same version of Skia.
     pub fn deserialize(data: &Data) -> Option<Path> {
         let mut path = Path::default();
         let bytes = data.as_bytes();
@@ -998,49 +1182,74 @@ impl Handle<SkPath> {
         .if_true_some(path)
     }
 
+    /// Return a non-zero, globally-unique identifier that represents this path and compares equal between two
+    /// identical paths and non-equal otherwise. It takes into account verbs, points and conic weights, but not
+    /// fill type.
     pub fn generation_id(&self) -> u32 {
         unsafe { self.native().getGenerationID() }
     }
 
+    /// Returns true if the data in the path is consistent. Returns false if internal values are out of range, or if
+    /// internal storage has an unexpected size.
     pub fn is_valid(&self) -> bool {
         unsafe { sb::C_SkPath_isValid(self.native()) }
     }
 }
 
-#[test]
-fn test_get_points() {
-    let mut p = Path::new();
-    p.add_rect(Rect::new(0.0, 0.0, 10.0, 10.0), None);
-    let points_count = p.count_points();
-    let mut points = vec![Point::default(); points_count];
-    let count_returned = p.get_points(&mut points);
-    assert_eq!(count_returned, points.len());
-    assert_eq!(count_returned, 4);
-}
+#[cfg(test)]
+mod tests {
+    use super::{AddPathMode, ArcSize, Path, PathFillType, Point, Rect, Verb};
 
-#[test]
-fn test_fill_type() {
-    let mut p = Path::default();
-    assert_eq!(p.fill_type(), PathFillType::Winding);
-    p.set_fill_type(PathFillType::EvenOdd);
-    assert_eq!(p.fill_type(), PathFillType::EvenOdd);
-    assert!(!p.is_inverse_fill_type());
-    p.toggle_inverse_fill_type();
-    assert_eq!(p.fill_type(), PathFillType::InverseEvenOdd);
-    assert!(p.is_inverse_fill_type());
-}
+    #[test]
+    pub fn test_verb_naming() {
+        let _ = Verb::Line;
+    }
 
-#[test]
-fn test_is_volatile() {
-    let mut p = Path::default();
-    assert!(!p.is_volatile());
-    p.set_is_volatile(true);
-    assert!(p.is_volatile());
-}
+    #[test]
+    fn test_arc_size_naming() {
+        let _ = ArcSize::Small;
+    }
 
-#[test]
-fn test_path_rect() {
-    let r = Rect::new(0.0, 0.0, 100.0, 100.0);
-    let path = Path::rect(r, None);
-    assert_eq!(*path.bounds(), r);
+    #[test]
+    fn test_add_path_mode_naming() {
+        let _ = AddPathMode::Append;
+    }
+
+    #[test]
+    fn test_get_points() {
+        let mut p = Path::new();
+        p.add_rect(Rect::new(0.0, 0.0, 10.0, 10.0), None);
+        let points_count = p.count_points();
+        let mut points = vec![Point::default(); points_count];
+        let count_returned = p.get_points(&mut points);
+        assert_eq!(count_returned, points.len());
+        assert_eq!(count_returned, 4);
+    }
+
+    #[test]
+    fn test_fill_type() {
+        let mut p = Path::default();
+        assert_eq!(p.fill_type(), PathFillType::Winding);
+        p.set_fill_type(PathFillType::EvenOdd);
+        assert_eq!(p.fill_type(), PathFillType::EvenOdd);
+        assert!(!p.is_inverse_fill_type());
+        p.toggle_inverse_fill_type();
+        assert_eq!(p.fill_type(), PathFillType::InverseEvenOdd);
+        assert!(p.is_inverse_fill_type());
+    }
+
+    #[test]
+    fn test_is_volatile() {
+        let mut p = Path::default();
+        assert!(!p.is_volatile());
+        p.set_is_volatile(true);
+        assert!(p.is_volatile());
+    }
+
+    #[test]
+    fn test_path_rect() {
+        let r = Rect::new(0.0, 0.0, 100.0, 100.0);
+        let path = Path::rect(r, None);
+        assert_eq!(*path.bounds(), r);
+    }
 }

--- a/skia-safe/src/core/surface.rs
+++ b/skia-safe/src/core/surface.rs
@@ -108,13 +108,23 @@ impl RCHandle<SkSurface> {
         })
     }
 
-    pub fn from_backend_render_target(
-        context: &mut gpu::Context,
-        backend_render_target: &gpu::BackendRenderTarget,
+    /// Create a new surface from a render target (see the documentation for `BackendRenderTarget`
+    /// for more details). Usually, this is the framebuffer. You can set the destination color
+    /// space, which affects how images are rendered, how gradients are calculated, how alpha
+    /// blending and anti-aliasing work, etc. If in doubt, use `ColorSpace::new_srgb()`. Specifying
+    /// `None` defaults to legacy behaviour, which is not color-correct.
+    ///
+    /// The `ColorType` _must_ match the `Format` specifed in the `FramebufferInfo` that was used to
+    /// create the `BackendRenderTarget`. `ColorType` is backend-agnostic, but the `Format` is
+    /// specific to each backend, and right now there is no automatic conversion. Therefore, this
+    /// needs to be handled manually. If these values do not match, `None` is returned.
+    pub fn from_backend_render_target<'a>(
+        context: &'a mut gpu::Context,
+        backend_render_target: &'a gpu::BackendRenderTarget,
         origin: gpu::SurfaceOrigin,
         color_type: crate::ColorType,
         color_space: impl Into<Option<crate::ColorSpace>>,
-        surface_props: Option<&SurfaceProps>,
+        surface_props: impl Into<Option<&'a SurfaceProps>>,
     ) -> Option<Self> {
         Self::from_ptr(unsafe {
             sb::C_SkSurface_MakeFromBackendRenderTarget(
@@ -123,7 +133,7 @@ impl RCHandle<SkSurface> {
                 origin,
                 color_type.into_native(),
                 color_space.into().into_ptr_or_null(),
-                surface_props.native_ptr_or_null(),
+                surface_props.into().native_ptr_or_null(),
             )
         })
     }

--- a/skia-safe/src/core/surface_props.rs
+++ b/skia-safe/src/core/surface_props.rs
@@ -3,9 +3,12 @@ use skia_bindings as sb;
 use skia_bindings::{SkPixelGeometry, SkSurfaceProps};
 
 // TODO: use the enum rewriter and strip underscores?
+/// The subpixel layout of the display (for subpixel anti-aliasing)
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(i32)]
 pub enum PixelGeometry {
+    /// Unknown subpixel layout (this will disable subpixel anti-aliasing entirely). Using
+    /// this may lead to text and fine details having a blurry look.
     Unknown = SkPixelGeometry::kUnknown_SkPixelGeometry as _,
     RGBH = SkPixelGeometry::kRGB_H_SkPixelGeometry as _,
     BGRH = SkPixelGeometry::kBGR_H_SkPixelGeometry as _,
@@ -14,10 +17,6 @@ pub enum PixelGeometry {
 }
 
 impl NativeTransmutable<SkPixelGeometry> for PixelGeometry {}
-#[test]
-fn test_pixel_geometry_layout() {
-    PixelGeometry::test_layout()
-}
 
 impl PixelGeometry {
     pub fn is_rgb(self) -> bool {
@@ -56,14 +55,13 @@ impl Default for SurfacePropsFlags {
     }
 }
 
+/// The properties of a surface - flags (see `SurfacePropsFlags` and the pixel geometry for
+/// subpixel anti-aliasing.
 #[derive(Copy)]
 #[repr(transparent)]
 pub struct SurfaceProps(SkSurfaceProps);
 
 impl NativeTransmutable<SkSurfaceProps> for SurfaceProps {}
-pub fn test_surface_props_layout() {
-    SurfaceProps::test_layout()
-}
 
 impl Clone for SurfaceProps {
     fn clone(&self) -> Self {
@@ -81,43 +79,69 @@ impl Eq for SurfaceProps {}
 
 impl Default for SurfaceProps {
     fn default() -> Self {
-        SurfaceProps::new(Default::default(), Default::default())
+        Self::new()
     }
 }
 
 impl SurfaceProps {
     // TODO: do we need to wrap the construcor(s) with InitType?
 
-    pub fn new(flags: SurfacePropsFlags, pixel_geometry: PixelGeometry) -> SurfaceProps {
+    /// Initialize a new `SurfaceProps` value with the default flags and pixel geometry.
+    pub fn new() -> Self {
+        Self::from_native_c(unsafe { SkSurfaceProps::new() })
+    }
+
+    /// Initialize a new `SurfaceProps` value, explicitly setting the flags and pixel geometry of the
+    /// surface.
+    pub fn with_options(flags: SurfacePropsFlags, pixel_geometry: PixelGeometry) -> SurfaceProps {
         Self::from_native_c(unsafe {
-            SkSurfaceProps::new(flags.bits(), pixel_geometry.into_native())
+            SkSurfaceProps::new1(flags.bits(), pixel_geometry.into_native())
         })
     }
 
+    /// Get the surface flags. See `SurfacePropsFlags` for more details.
     pub fn flags(self) -> SurfacePropsFlags {
         SurfacePropsFlags::from_bits_truncate(self.native().fFlags)
     }
 
+    /// Get the pixel geomtry of the surface. This is used for subpixel anti-aliasing.
     pub fn pixel_geometry(self) -> PixelGeometry {
         PixelGeometry::from_native_c(self.native().fPixelGeometry)
     }
 
+    /// Check `self.flags()`, returning `true` if this surface is marked to use device-independent fonts.
     pub fn is_use_device_independent_fonts(self) -> bool {
         self.flags()
             .contains(SurfacePropsFlags::USE_DEVICE_INDEPENDENT_FONTS)
     }
 }
 
-#[test]
-fn create() {
-    let props = SurfaceProps::new(
-        SurfacePropsFlags::USE_DEVICE_INDEPENDENT_FONTS,
-        PixelGeometry::RGBH,
-    );
-    assert_eq!(
-        SurfacePropsFlags::USE_DEVICE_INDEPENDENT_FONTS,
-        props.flags()
-    );
-    assert_eq!(PixelGeometry::RGBH, props.pixel_geometry());
-    assert_eq!(true, props.is_use_device_independent_fonts());
+#[cfg(test)]
+mod tests {
+    use super::{PixelGeometry, SurfaceProps, SurfacePropsFlags};
+    use crate::prelude::NativeTransmutable;
+
+    #[test]
+    fn test_pixel_geometry_layout() {
+        PixelGeometry::test_layout()
+    }
+
+    #[test]
+    fn test_surface_props_layout() {
+        SurfaceProps::test_layout()
+    }
+
+    #[test]
+    fn create() {
+        let props = SurfaceProps::with_options(
+            SurfacePropsFlags::USE_DEVICE_INDEPENDENT_FONTS,
+            PixelGeometry::RGBH,
+        );
+        assert_eq!(
+            SurfacePropsFlags::USE_DEVICE_INDEPENDENT_FONTS,
+            props.flags()
+        );
+        assert_eq!(PixelGeometry::RGBH, props.pixel_geometry());
+        assert_eq!(true, props.is_use_device_independent_fonts());
+    }
 }

--- a/skia-safe/src/lib.rs
+++ b/skia-safe/src/lib.rs
@@ -25,7 +25,7 @@ extern crate bitflags;
 extern crate lazy_static;
 
 // Prelude re-exports
-pub use crate::prelude::{Borrows, ConditionallySend, Sendable};
+pub use crate::prelude::{Borrows, ConditionallySend, Handle, RCHandle, Sendable};
 
 /// All Sk* types are accessible via skia_safe::
 pub use crate::core::*;


### PR DESCRIPTION
This builds on top of #436, so the diff will be hard to read without whitespace changes hidden (click the cog icon in GitHub's diff view).

`Handle` and `RCHandle` were not being exported from the top-level of `skia-safe`, which meant that viewing the docs would hide the vast majority of functions - as they are implemented mostly on `Handle<T>` or `RCHandle<T>` instead of `T`. While I think a nicer design would be to use newtypes instead of type aliases in order to improve docs and error messages, this is a nice middle-ground that doesn't break backwards-compatibility. This PR also puts many test functions into test modules, which I can split into a separate PR but I figured that I'd include it since it was already part of the same commit in my master branch anyway and I had enough PRs open already.