### PR TITLE
`#[deny(useless_deprecated)]` on by default

### DIFF
--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -174,20 +174,12 @@ impl<'lt> Default for OwnedCanvas<'lt> {
     }
 }
 
-#[deprecated(
-    since = "0.34.0",
-    note = "Use `&mut canvas` to pass an exclusive reference."
-)]
 impl AsMut<Canvas> for Canvas {
     fn as_mut(&mut self) -> &mut Canvas {
         self
     }
 }
 
-#[deprecated(
-    since = "0.34.0",
-    note = "Use `&mut canvas` to pass an exclusive reference."
-)]
 impl<'lt> AsMut<Canvas> for OwnedCanvas<'lt> {
     fn as_mut(&mut self) -> &mut Canvas {
         self.deref_mut()


### PR DESCRIPTION
This was causing the CI build to fail for all my other PRs (not sure why it wasn't failing locally).