### PR TITLE
Wrap YUVAPixmapInfo and YUVAInfo

### DIFF
--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -1044,6 +1044,8 @@ const OPAQUE_TYPES: &[&str] = &[
     // m87:
     "GrD3DAlloc",
     "GrD3DMemoryAllocator",
+    // m87, yuva_pixmaps
+    "std::tuple",
 ];
 
 const BLACKLISTED_TYPES: &[&str] = &[

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -1238,6 +1238,12 @@ const ENUM_TABLE: &[EnumEntry] = &[
     ("SkMipmapMode", rewrite::k_xxx),
     ("Enable", rewrite::k_xxx),
     ("ShaderCacheStrategy", rewrite::k_xxx),
+    // m87:
+    // SkYUVAInfo_PlanarConfig
+    ("PlanarConfig", rewrite::k_xxx),
+    ("Siting", rewrite::k_xxx),
+    // SkYUVAPixmapInfo
+    ("DataType", rewrite::k_xxx),
 ];
 
 pub(crate) mod rewrite {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1998,7 +1998,7 @@ extern "C" bool C_SkYUVAInfo_equals(const SkYUVAInfo* a, const SkYUVAInfo* b) {
 // core/SkYUVAPixmaps.h
 //
 
-extern "C" void C_SkYUVAPixmapInfo_construct(SkYUVAPixmapInfo* uninitialized) {
+extern "C" void C_SkYUVAPixmapInfo_Construct(SkYUVAPixmapInfo* uninitialized) {
     new(uninitialized) SkYUVAPixmapInfo();
 }
 
@@ -2049,6 +2049,38 @@ extern "C" int C_SkYUVAPixmapInfo_NumChannelsAndDataType(SkColorType colorType, 
     auto numDT = SkYUVAPixmapInfo::NumChannelsAndDataType(colorType);
     *dataType = std::get<1>(numDT);
     return std::get<0>(numDT);
+}
+
+extern "C" void C_SkYUVAPixmaps_Construct(SkYUVAPixmaps* uninitialized) {
+    new(uninitialized) SkYUVAPixmaps();
+}
+
+extern "C" void C_SkYUVAPixmaps_destruct(SkYUVAPixmaps* self) {
+    self->~SkYUVAPixmaps();
+}
+
+extern "C" void C_SkYUVAPixmaps_Allocate(SkYUVAPixmaps* uninitialized, const SkYUVAPixmapInfo* yuvaPixmapInfo) {
+    new(uninitialized) SkYUVAPixmaps(SkYUVAPixmaps::Allocate(*yuvaPixmapInfo));
+}
+
+extern "C" void C_SkYUVAPixmaps_FromData(SkYUVAPixmaps* uninitialized, const SkYUVAPixmapInfo* yuvaPixmapInfo, SkData* data) {
+    new(uninitialized) SkYUVAPixmaps(SkYUVAPixmaps::FromData(*yuvaPixmapInfo, sp(data)));
+}
+
+extern "C" void C_SkYUVAPixmaps_FromExternalMemory(SkYUVAPixmaps* uninitialized, const SkYUVAPixmapInfo* yuvaPixmapInfo, void* memory) {
+    new(uninitialized) SkYUVAPixmaps(SkYUVAPixmaps::FromExternalMemory(*yuvaPixmapInfo, memory));
+}
+
+extern "C" void C_SkYUVAPixmaps_FromExternalPixmaps(SkYUVAPixmaps* uninitialized, const SkYUVAInfo* yuvaInfo, const SkPixmap pixmaps[SkYUVAPixmaps::kMaxPlanes]) {
+    new(uninitialized) SkYUVAPixmaps(SkYUVAPixmaps::FromExternalPixmaps(*yuvaInfo, pixmaps));
+}
+
+extern "C" const SkPixmap* C_SkYUVAPixmaps_planes(const SkYUVAPixmaps* self) {
+    return self->planes().data();
+}
+
+extern "C" bool C_SkYUVAPixmaps_isValid(const SkYUVAPixmaps* self) {
+    return self->isValid();
 }
 
 //

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1998,10 +1998,6 @@ extern "C" bool C_SkYUVAInfo_equals(const SkYUVAInfo* a, const SkYUVAInfo* b) {
 // core/SkYUVAPixmaps.h
 //
 
-extern "C" void C_SkYUVAPixmapInfo_Construct(SkYUVAPixmapInfo* uninitialized) {
-    new(uninitialized) SkYUVAPixmapInfo();
-}
-
 extern "C" void C_SkYUVAPixmapInfo_destruct(SkYUVAPixmapInfo* self) {
     self->~SkYUVAPixmapInfo();
 }

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1887,7 +1887,7 @@ extern "C" SkISize C_SkSize_toFloor(const SkSize* size) {
 }
 
 //
-// SkShader
+// core/SkShader.h
 //
 
 extern "C" bool C_SkShader_isOpaque(const SkShader* self) {
@@ -1939,16 +1939,12 @@ extern "C" SkShader* C_SkShader_Deserialize(const void* data, size_t length) {
 }
 
 //
-// SkStream
+// core/SkStream.h
 //
 
 extern "C" void C_SkStream_delete(SkStream* stream) {
     delete stream;
 }
-
-//
-// SkWStream
-//
 
 extern "C" void C_SkWStream_destruct(SkWStream* self) {
     self->~SkWStream();
@@ -1958,17 +1954,9 @@ extern "C" bool C_SkWStream_write(SkWStream* self, const void* buffer, size_t si
     return self->write(buffer, size);
 }
 
-//
-// SkMemoryStream: public SkStreamMemory
-//
-
 extern "C" SkMemoryStream* C_SkMemoryStream_MakeDirect(const void* data, size_t length) {
     return SkMemoryStream::MakeDirect(data, length).release();
 }
-
-//
-// SkDynamicMemoryWStream : public SkWStream
-//
 
 extern "C" void C_SkDynamicMemoryWStream_Construct(SkDynamicMemoryWStream* uninitialized) {
     new(uninitialized) SkDynamicMemoryWStream();
@@ -1980,6 +1968,87 @@ extern "C" SkData* C_SkDynamicMemoryWStream_detachAsData(SkDynamicMemoryWStream*
 
 extern "C" SkStreamAsset* C_SkDynamicMemoryWStream_detachAsStream(SkDynamicMemoryWStream* self) {
     return self->detachAsStream().release();
+}
+
+//
+// core/SkYUVAInfo.h
+//
+
+extern "C" void C_SkYUVAInfo_Construct(SkYUVAInfo* uninitialized) {
+    new(uninitialized) SkYUVAInfo();
+}
+
+extern "C" void C_SkYUVAInfo_destruct(SkYUVAInfo* self) {
+    self->~SkYUVAInfo();
+}
+
+extern "C" int C_SkYUVAInfo_NumPlanes(SkYUVAInfo::PlanarConfig planarConfig) {
+    return SkYUVAInfo::NumPlanes(planarConfig);
+}
+
+extern "C" int C_SkYUVAInfo_NumChannelsInPlane(SkYUVAInfo::PlanarConfig planarConfig, int i) {
+    return SkYUVAInfo::NumChannelsInPlane(planarConfig, i);
+}
+
+extern "C" bool C_SkYUVAInfo_equals(const SkYUVAInfo* a, const SkYUVAInfo* b) {
+    return *a == *b;
+}
+
+//
+// core/SkYUVAPixmaps.h
+//
+
+extern "C" void C_SkYUVAPixmapInfo_construct(SkYUVAPixmapInfo* uninitialized) {
+    new(uninitialized) SkYUVAPixmapInfo();
+}
+
+extern "C" void C_SkYUVAPixmapInfo_destruct(SkYUVAPixmapInfo* self) {
+    self->~SkYUVAPixmapInfo();
+}
+
+extern "C" bool C_SkYUVAPixmapInfo_equals(const SkYUVAPixmapInfo* a, const SkYUVAPixmapInfo* b) {
+    return *a == *b;
+}
+
+extern "C" size_t C_SkYUVAPixmapInfo_rowBytes(const SkYUVAPixmapInfo* self, int i) {
+    return self->rowBytes(i);
+}
+
+extern "C" const SkImageInfo* C_SkYUVAPixmapInfo_planeInfo(const SkYUVAPixmapInfo* self, int i) {
+    return &self->planeInfo(i);
+}
+
+extern "C" bool C_SkYUVAPixmapInfo_isValid(const SkYUVAPixmapInfo* self) {
+    return self->isValid();
+}
+
+extern "C" void C_SkYUVAPixmapInfo_SupportedDataTypes_Construct(SkYUVAPixmapInfo::SupportedDataTypes* uninitialized) {
+    new(uninitialized) SkYUVAPixmapInfo::SupportedDataTypes();
+}
+
+extern "C" void C_SkYUVAPixmapInfo_SupportedDataTypes_destruct(SkYUVAPixmapInfo::SupportedDataTypes* self) {
+    self->~SupportedDataTypes();
+}
+
+extern "C" void C_SkYUVAPixmapInfo_SupportedDataTypes_All(SkYUVAPixmapInfo::SupportedDataTypes* uninitialized) {
+    new(uninitialized) SkYUVAPixmapInfo::SupportedDataTypes(SkYUVAPixmapInfo::SupportedDataTypes::All());
+}
+
+extern "C" bool C_SkYUVAPixmapInfo_SupportedDataTypes_supported(
+    const SkYUVAPixmapInfo::SupportedDataTypes* self, 
+    SkYUVAPixmapInfo::PlanarConfig pc, 
+    SkYUVAPixmapInfo::DataType dt) {
+    return self->supported(pc, dt);
+}
+
+extern "C" SkColorType C_SkYUVAPixmapInfo_DefaultColorTypeForDataType(SkYUVAPixmapInfo::DataType dt, int numChannels) {
+    return SkYUVAPixmapInfo::DefaultColorTypeForDataType(dt, numChannels);
+}
+
+extern "C" int C_SkYUVAPixmapInfo_NumChannelsAndDataType(SkColorType colorType, SkYUVAPixmapInfo::DataType* dataType) {
+    auto numDT = SkYUVAPixmapInfo::NumChannelsAndDataType(colorType);
+    *dataType = std::get<1>(numDT);
+    return std::get<0>(numDT);
 }
 
 //

--- a/skia-safe/src/codec/_codec.rs
+++ b/skia-safe/src/codec/_codec.rs
@@ -114,6 +114,7 @@ impl RCHandle<SkCodec> {
         since = "0.33.1",
         note = "Use the safe variant get_pixels_with_options()."
     )]
+    #[allow(clippy::clippy::missing_safety_doc)]
     pub unsafe fn get_pixels(
         &mut self,
         info: &ImageInfo,
@@ -124,6 +125,7 @@ impl RCHandle<SkCodec> {
             .getPixels(info.native(), pixels, row_bytes, ptr::null())
     }
 
+    #[allow(clippy::clippy::missing_safety_doc)]
     pub unsafe fn get_pixels_to_pixmap(
         &mut self,
         pixmap: &Pixmap,

--- a/skia-safe/src/core.rs
+++ b/skia-safe/src/core.rs
@@ -236,8 +236,8 @@ pub use vertices::Vertices;
 pub mod yuva_index;
 pub use yuva_index::YUVAIndex;
 
-mod yuva_info_;
-pub use yuva_info_::*;
+pub mod yuva_info;
+pub use yuva_info::YUVAInfo;
 
 mod yuva_pixmaps;
 pub use yuva_pixmaps::*;

--- a/skia-safe/src/core.rs
+++ b/skia-safe/src/core.rs
@@ -236,6 +236,12 @@ pub use vertices::Vertices;
 pub mod yuva_index;
 pub use yuva_index::YUVAIndex;
 
+mod yuva_info_;
+pub use yuva_info_::*;
+
+mod yuva_pixmaps;
+pub use yuva_pixmaps::*;
+
 mod yuva_size_info;
 pub use yuva_size_info::*;
 

--- a/skia-safe/src/core/bitmap.rs
+++ b/skia-safe/src/core/bitmap.rs
@@ -93,6 +93,7 @@ impl Handle<SkBitmap> {
         unsafe { self.native_mut().setAlphaType(alpha_type) }
     }
 
+    #[allow(clippy::clippy::missing_safety_doc)]
     pub unsafe fn pixels(&mut self) -> *mut ffi::c_void {
         self.pixmap().writable_addr()
     }
@@ -223,6 +224,7 @@ impl Handle<SkBitmap> {
             .expect("Bitmap::alloc_n32_pixels_failed")
     }
 
+    #[allow(clippy::clippy::missing_safety_doc)]
     pub unsafe fn install_pixels(
         &mut self,
         image_info: &ImageInfo,
@@ -313,6 +315,7 @@ impl Handle<SkBitmap> {
         self.pixmap().get_alpha_f(p)
     }
 
+    #[allow(clippy::clippy::missing_safety_doc)]
     pub unsafe fn get_addr(&self, p: impl Into<IPoint>) -> *const ffi::c_void {
         let p = p.into();
         self.native().getAddr(p.x, p.y)
@@ -328,6 +331,7 @@ impl Handle<SkBitmap> {
         }
     }
 
+    #[allow(clippy::clippy::missing_safety_doc)]
     pub unsafe fn read_pixels(
         &self,
         dst_info: &ImageInfo,

--- a/skia-safe/src/core/data.rs
+++ b/skia-safe/src/core/data.rs
@@ -71,10 +71,12 @@ impl RCHandle<SkData> {
     /// Constructs Data from a given byte slice without copying it.
     ///
     /// Users must make sure that the underlying slice will outlive the lifetime of the Data.
+    #[allow(clippy::clippy::missing_safety_doc)]
     pub unsafe fn new_bytes(data: &[u8]) -> Self {
         Data::from_ptr(sb::C_SkData_MakeWithoutCopy(data.as_ptr() as _, data.len())).unwrap()
     }
 
+    #[allow(clippy::clippy::missing_safety_doc)]
     pub unsafe fn new_uninitialized(length: usize) -> Data {
         Data::from_ptr(sb::C_SkData_MakeUninitialized(length)).unwrap()
     }

--- a/skia-safe/src/core/data_table.rs
+++ b/skia-safe/src/core/data_table.rs
@@ -42,6 +42,7 @@ impl RCHandle<SkDataTable> {
         unsafe { self.at_t(index) }
     }
 
+    #[allow(clippy::clippy::missing_safety_doc)]
     pub unsafe fn at_t<T: Copy>(&self, index: usize) -> &[T] {
         assert!(index < self.count());
         let mut size = usize::default();

--- a/skia-safe/src/core/pixel_ref.rs
+++ b/skia-safe/src/core/pixel_ref.rs
@@ -27,6 +27,7 @@ impl RCHandle<SkPixelRef> {
         unsafe { sb::C_SkPixelRef_height(self.native()) }
     }
 
+    #[allow(clippy::clippy::missing_safety_doc)]
     pub unsafe fn pixels(&self) -> *mut c_void {
         sb::C_SkPixelRef_pixels(self.native())
     }

--- a/skia-safe/src/core/pixmap.rs
+++ b/skia-safe/src/core/pixmap.rs
@@ -81,6 +81,7 @@ impl Handle<SkPixmap> {
         self.native().fRowBytes
     }
 
+    #[allow(clippy::clippy::missing_safety_doc)]
     pub unsafe fn addr(&self) -> *const c_void {
         self.native().fPixels
     }
@@ -153,6 +154,7 @@ impl Handle<SkPixmap> {
         assert!(p.y >= 0 && p.y < self.height());
     }
 
+    #[allow(clippy::clippy::missing_safety_doc)]
     pub unsafe fn addr_at(&self, p: impl Into<IPoint>) -> *const c_void {
         let p = p.into();
         (self.addr() as *const raw::c_char).add(self.info().compute_offset(p, self.row_bytes()))
@@ -162,10 +164,12 @@ impl Handle<SkPixmap> {
     // TODO: addr8(), addr16(), addr32(), addr64(), addrF16(),
     //       addr8_at(), addr16_at(), addr32_at(), addr64_at(), addrF16_at()
 
+    #[allow(clippy::clippy::missing_safety_doc)]
     pub unsafe fn writable_addr(&self) -> *mut c_void {
         self.addr() as _
     }
 
+    #[allow(clippy::clippy::missing_safety_doc)]
     pub unsafe fn writable_addr_at(&self, p: impl Into<IPoint>) -> *mut c_void {
         self.addr_at(p) as _
     }

--- a/skia-safe/src/core/yuva_info.rs
+++ b/skia-safe/src/core/yuva_info.rs
@@ -33,15 +33,15 @@ impl YUVAInfo {
     /// oriented to how the image is displayed as indicated by `origin`).
     pub fn new(
         dimensions: impl Into<ISize>,
-        config: yuva_info::PlanarConfig,
+        config: PlanarConfig,
         color_space: image_info::YUVColorSpace,
         origin: impl Into<Option<EncodedOrigin>>,
-        siting: impl Into<Option<(yuva_info::Siting, yuva_info::Siting)>>,
+        siting: impl Into<Option<(Siting, Siting)>>,
     ) -> Self {
         let origin = origin.into().unwrap_or(EncodedOrigin::TopLeft);
         let (siting_x, siting_y) = siting
             .into()
-            .unwrap_or((yuva_info::Siting::Centered, yuva_info::Siting::Centered));
+            .unwrap_or((Siting::Centered, Siting::Centered));
 
         Self::from_native_c(unsafe {
             SkYUVAInfo::new(
@@ -55,7 +55,7 @@ impl YUVAInfo {
         })
     }
 
-    pub fn planar_config(&self) -> yuva_info::PlanarConfig {
+    pub fn planar_config(&self) -> PlanarConfig {
         return self.native().fPlanarConfig;
     }
 
@@ -77,11 +77,11 @@ impl YUVAInfo {
         self.native().fYUVColorSpace
     }
 
-    pub fn siting_x(&self) -> yuva_info::Siting {
+    pub fn siting_x(&self) -> Siting {
         self.native().fSitingX
     }
 
-    pub fn siting_y(&self) -> yuva_info::Siting {
+    pub fn siting_y(&self) -> Siting {
         self.native().fSitingY
     }
 
@@ -90,14 +90,14 @@ impl YUVAInfo {
     }
 
     pub fn has_alpha(&self) -> bool {
-        yuva_info::has_alpha(self.planar_config())
+        has_alpha(self.planar_config())
     }
 
-    /// Returns the number of planes and initializes `planeDimensions[0]`..`planeDimensions[<ret>]` to
+    /// Returns the number of planes and initializes `plane_dimensions[0]`..`plane_dimensions[<ret>]` to
     /// the expected dimensions for each plane. Dimensions are as stored in memory, before
     /// transformation to image display space as indicated by [origin(&self)].
     pub fn plane_dimensions(&self, plane_dimensions: &mut [ISize; Self::MAX_PLANES]) -> usize {
-        yuva_info::plane_dimensions(
+        self::plane_dimensions(
             self.dimensions(),
             self.planar_config(),
             self.origin(),
@@ -124,87 +124,81 @@ impl YUVAInfo {
     }
 
     pub fn num_planes(&self) -> usize {
-        yuva_info::num_planes(self.planar_config())
+        num_planes(self.planar_config())
     }
 
     pub fn num_channels_in_plane(&self, i: usize) -> Option<usize> {
-        yuva_info::num_channels_in_plane(self.planar_config(), i)
+        num_channels_in_plane(self.planar_config(), i)
     }
 }
 
-pub mod yuva_info {
-    use crate::{prelude::*, EncodedOrigin, ISize, YUVAInfo};
-    use skia_bindings as sb;
-    use skia_bindings::SkYUVAInfo;
+/// Specifies how YUV (and optionally A) are divided among planes. Planes are separated by
+/// underscores in the enum value names. Within each plane the pixmap/texture channels are
+/// mapped to the YUVA channels in the order specified, e.g. for kY_UV Y is in channel 0 of plane
+/// 0, U is in channel 0 of plane 1, and V is in channel 1 of plane 1. Channel ordering
+/// within a pixmap/texture given the channels it contains:
+/// A:               0:A
+/// Luminance/Gray:  0:Gray
+/// RG               0:R,    1:G
+/// RGB              0:R,    1:G, 2:B
+/// RGBA             0:R,    1:G, 2:B, 3:A
+///
+/// UV subsampling is also specified in the enum value names using J:a:b notation (e.g. 4:2:0 is
+/// 1/2 horizontal and 1/2 vertical resolution for U and V). A fourth number is added if alpha
+/// is present (always 4 as only full resolution alpha is supported).
+///
+/// Currently this only has three-plane formats but more will be added as usage and testing of
+///  this expands.
+pub use sb::SkYUVAInfo_PlanarConfig as PlanarConfig;
 
-    /// Specifies how YUV (and optionally A) are divided among planes. Planes are separated by
-    /// underscores in the enum value names. Within each plane the pixmap/texture channels are
-    /// mapped to the YUVA channels in the order specified, e.g. for kY_UV Y is in channel 0 of plane
-    /// 0, U is in channel 0 of plane 1, and V is in channel 1 of plane 1. Channel ordering
-    /// within a pixmap/texture given the channels it contains:
-    /// A:               0:A
-    /// Luminance/Gray:  0:Gray
-    /// RG               0:R,    1:G
-    /// RGB              0:R,    1:G, 2:B
-    /// RGBA             0:R,    1:G, 2:B, 3:A
-    ///
-    /// UV subsampling is also specified in the enum value names using J:a:b notation (e.g. 4:2:0 is
-    /// 1/2 horizontal and 1/2 vertical resolution for U and V). A fourth number is added if alpha
-    /// is present (always 4 as only full resolution alpha is supported).
-    ///
-    /// Currently this only has three-plane formats but more will be added as usage and testing of
-    ///  this expands.
-    pub use sb::SkYUVAInfo_PlanarConfig as PlanarConfig;
+/// Describes how subsampled chroma values are sited relative to luma values.
+///
+/// Currently only centered siting is supported but will expand to support additional sitings.
+pub use sb::SkYUVAInfo_Siting as Siting;
 
-    /// Describes how subsampled chroma values are sited relative to luma values.
-    ///
-    /// Currently only centered siting is supported but will expand to support additional sitings.
-    pub use sb::SkYUVAInfo_Siting as Siting;
+/// Given image dimensions, a planar configuration, and origin, determine the expected size of
+/// each plane. Returns the number of expected planes. `planeDimensions[0]` through
+/// `planeDimensons[<ret>]` are written. The input image dimensions are as displayed (after the
+/// planes have been transformed to the intended display orientation). The plane dimensions
+/// are output as stored in memory.
+pub fn plane_dimensions(
+    image_dimensions: impl Into<ISize>,
+    config: PlanarConfig,
+    origin: EncodedOrigin,
+    plane_dimensions: &mut [ISize; YUVAInfo::MAX_PLANES],
+) -> usize {
+    unsafe {
+        SkYUVAInfo::PlaneDimensions(
+            image_dimensions.into().into_native(),
+            config,
+            origin.into_native(),
+            plane_dimensions.native_mut().as_mut_ptr(),
+        )
+    }
+    .try_into()
+    .unwrap()
+}
 
-    /// Given image dimensions, a planar configuration, and origin, determine the expected size of
-    /// each plane. Returns the number of expected planes. `planeDimensions[0]` through
-    /// `planeDimensons[<ret>]` are written. The input image dimensions are as displayed (after the
-    /// planes have been transformed to the intended display orientation). The plane dimensions
-    /// are output as stored in memory.
-    pub fn plane_dimensions(
-        image_dimensions: impl Into<ISize>,
-        config: PlanarConfig,
-        origin: EncodedOrigin,
-        plane_dimensions: &mut [ISize; YUVAInfo::MAX_PLANES],
-    ) -> usize {
-        unsafe {
-            SkYUVAInfo::PlaneDimensions(
-                image_dimensions.into().into_native(),
-                config,
-                origin.into_native(),
-                plane_dimensions.native_mut().as_mut_ptr(),
-            )
-        }
+/// Number of planes for a given [PlanarConfig].
+pub fn num_planes(config: PlanarConfig) -> usize {
+    unsafe { sb::C_SkYUVAInfo_NumPlanes(config) }
         .try_into()
         .unwrap()
-    }
+}
 
-    /// Number of planes for a given [PlanarConfig].
-    pub fn num_planes(config: PlanarConfig) -> usize {
-        unsafe { sb::C_SkYUVAInfo_NumPlanes(config) }
+/// Number of Y, U, V, A channels in the ith plane for a given [PlanarConfig] (or [None] if i is
+/// invalid).
+pub fn num_channels_in_plane(config: PlanarConfig, i: usize) -> Option<usize> {
+    (i < num_planes(config)).if_true_then_some(|| {
+        unsafe { sb::C_SkYUVAInfo_NumChannelsInPlane(config, i.try_into().unwrap()) }
             .try_into()
             .unwrap()
-    }
+    })
+}
 
-    /// Number of Y, U, V, A channels in the ith plane for a given [PlanarConfig] (or [None] if i is
-    /// invalid).
-    pub fn num_channels_in_plane(config: PlanarConfig, i: usize) -> Option<usize> {
-        (i < num_planes(config)).if_true_then_some(|| {
-            unsafe { sb::C_SkYUVAInfo_NumChannelsInPlane(config, i.try_into().unwrap()) }
-                .try_into()
-                .unwrap()
-        })
-    }
-
-    /// Does the [PlanarConfig] have alpha values?
-    pub fn has_alpha(config: PlanarConfig) -> bool {
-        unsafe { sb::SkYUVAInfo_HasAlpha(config) }
-    }
+/// Does the [PlanarConfig] have alpha values?
+pub fn has_alpha(config: PlanarConfig) -> bool {
+    unsafe { sb::SkYUVAInfo_HasAlpha(config) }
 }
 
 #[cfg(test)]

--- a/skia-safe/src/core/yuva_info_.rs
+++ b/skia-safe/src/core/yuva_info_.rs
@@ -29,8 +29,8 @@ impl NativePartialEq for YUVAInfo {
 impl YUVAInfo {
     pub const MAX_PLANES: usize = sb::SkYUVAInfo_kMaxPlanes as _;
 
-    /// 'dimensions' should specify the size of the full resolution image (after planes have been
-    /// oriented to how the image is displayed as indicated by 'origin').
+    /// `dimensions` should specify the size of the full resolution image (after planes have been
+    /// oriented to how the image is displayed as indicated by `origin`).
     pub fn new(
         dimensions: impl Into<ISize>,
         config: yuva_info::PlanarConfig,
@@ -93,9 +93,9 @@ impl YUVAInfo {
         yuva_info::has_alpha(self.planar_config())
     }
 
-    /// Returns the number of planes and initializes planeDimensions[0]..planeDimensions[<ret>] to
+    /// Returns the number of planes and initializes `planeDimensions[0]`..`planeDimensions[<ret>]` to
     /// the expected dimensions for each plane. Dimensions are as stored in memory, before
-    /// transformation to image display space as indicated by origin().
+    /// transformation to image display space as indicated by [origin(&self)].
     pub fn plane_dimensions(&self, plane_dimensions: &mut [ISize; Self::MAX_PLANES]) -> usize {
         yuva_info::plane_dimensions(
             self.dimensions(),
@@ -106,8 +106,8 @@ impl YUVAInfo {
     }
 
     /// Given a per-plane row bytes, determine size to allocate for all planes. Optionally retrieves
-    /// the per-plane byte sizes in planeSizes if not null. If total size overflows will return
-    /// SIZE_MAX and set all planeSizes to SIZE_MAX.
+    /// the per-plane byte sizes in planeSizes if not [None]. If total size overflows will return
+    /// `SIZE_MAX` and set all planeSizes to `SIZE_MAX`.
     pub fn compute_total_bytes(
         &self,
         row_bytes: &[usize; Self::MAX_PLANES],
@@ -162,8 +162,8 @@ pub mod yuva_info {
     pub use sb::SkYUVAInfo_Siting as Siting;
 
     /// Given image dimensions, a planar configuration, and origin, determine the expected size of
-    /// each plane. Returns the number of expected planes. planeDimensions[0] through
-    /// planeDimensons[<ret>] are written. The input image dimensions are as displayed (after the
+    /// each plane. Returns the number of expected planes. `planeDimensions[0]` through
+    /// `planeDimensons[<ret>]` are written. The input image dimensions are as displayed (after the
     /// planes have been transformed to the intended display orientation). The plane dimensions
     /// are output as stored in memory.
     pub fn plane_dimensions(
@@ -184,14 +184,14 @@ pub mod yuva_info {
         .unwrap()
     }
 
-    /// Number of planes for a given PlanarConfig.
+    /// Number of planes for a given [PlanarConfig].
     pub fn num_planes(config: PlanarConfig) -> usize {
         unsafe { sb::C_SkYUVAInfo_NumPlanes(config) }
             .try_into()
             .unwrap()
     }
 
-    /// Number of Y, U, V, A channels in the ith plane for a given PlanarConfig (or `None` if i is
+    /// Number of Y, U, V, A channels in the ith plane for a given [PlanarConfig] (or [None] if i is
     /// invalid).
     pub fn num_channels_in_plane(config: PlanarConfig, i: usize) -> Option<usize> {
         (i < num_planes(config)).if_true_then_some(|| {
@@ -201,14 +201,13 @@ pub mod yuva_info {
         })
     }
 
-    /// Does the PlanarConfig have alpha values?
+    /// Does the [PlanarConfig] have alpha values?
     pub fn has_alpha(config: PlanarConfig) -> bool {
         unsafe { sb::SkYUVAInfo_HasAlpha(config) }
     }
 }
 
 #[cfg(test)]
-
 mod tests {
     use crate::yuva_info;
 

--- a/skia-safe/src/core/yuva_info_.rs
+++ b/skia-safe/src/core/yuva_info_.rs
@@ -1,0 +1,219 @@
+use super::image_info;
+use crate::{prelude::*, EncodedOrigin, ISize};
+use skia_bindings as sb;
+use skia_bindings::SkYUVAInfo;
+use std::ptr;
+
+/// Specifies the structure of planes for a YUV image with optional alpha. The actual planar data
+/// is not part of this structure and depending on usage is in external textures or pixmaps.
+pub type YUVAInfo = Handle<SkYUVAInfo>;
+
+impl NativeDrop for SkYUVAInfo {
+    fn drop(&mut self) {
+        unsafe { sb::C_SkYUVAInfo_destruct(self) }
+    }
+}
+
+impl Default for YUVAInfo {
+    fn default() -> Self {
+        Self::construct(|yi| unsafe { sb::C_SkYUVAInfo_Construct(yi) })
+    }
+}
+
+impl NativePartialEq for YUVAInfo {
+    fn eq(&self, rhs: &Self) -> bool {
+        unsafe { sb::C_SkYUVAInfo_equals(self.native(), rhs.native()) }
+    }
+}
+
+impl YUVAInfo {
+    pub const MAX_PLANES: usize = sb::SkYUVAInfo_kMaxPlanes as _;
+
+    /// 'dimensions' should specify the size of the full resolution image (after planes have been
+    /// oriented to how the image is displayed as indicated by 'origin').
+    pub fn new(
+        dimensions: impl Into<ISize>,
+        config: yuva_info::PlanarConfig,
+        color_space: image_info::YUVColorSpace,
+        origin: impl Into<Option<EncodedOrigin>>,
+        siting: impl Into<Option<(yuva_info::Siting, yuva_info::Siting)>>,
+    ) -> Self {
+        let origin = origin.into().unwrap_or(EncodedOrigin::TopLeft);
+        let (siting_x, siting_y) = siting
+            .into()
+            .unwrap_or((yuva_info::Siting::Centered, yuva_info::Siting::Centered));
+
+        Self::from_native_c(unsafe {
+            SkYUVAInfo::new(
+                dimensions.into().into_native(),
+                config,
+                color_space,
+                origin.into_native(),
+                siting_x,
+                siting_y,
+            )
+        })
+    }
+
+    pub fn planar_config(&self) -> yuva_info::PlanarConfig {
+        return self.native().fPlanarConfig;
+    }
+
+    /// Dimensions of the full resolution image (after planes have been oriented to how the image
+    /// is displayed as indicated by fOrigin).
+    pub fn dimensions(&self) -> ISize {
+        ISize::from_native_c(self.native().fDimensions)
+    }
+
+    pub fn width(&self) -> i32 {
+        self.dimensions().width
+    }
+
+    pub fn height(&self) -> i32 {
+        self.dimensions().height
+    }
+
+    pub fn yuv_color_space(&self) -> image_info::YUVColorSpace {
+        self.native().fYUVColorSpace
+    }
+
+    pub fn siting_x(&self) -> yuva_info::Siting {
+        self.native().fSitingX
+    }
+
+    pub fn siting_y(&self) -> yuva_info::Siting {
+        self.native().fSitingY
+    }
+
+    pub fn origin(&self) -> EncodedOrigin {
+        EncodedOrigin::from_native_c(self.native().fOrigin)
+    }
+
+    pub fn has_alpha(&self) -> bool {
+        yuva_info::has_alpha(self.planar_config())
+    }
+
+    /// Returns the number of planes and initializes planeDimensions[0]..planeDimensions[<ret>] to
+    /// the expected dimensions for each plane. Dimensions are as stored in memory, before
+    /// transformation to image display space as indicated by origin().
+    pub fn plane_dimensions(&self, plane_dimensions: &mut [ISize; Self::MAX_PLANES]) -> usize {
+        yuva_info::plane_dimensions(
+            self.dimensions(),
+            self.planar_config(),
+            self.origin(),
+            plane_dimensions,
+        )
+    }
+
+    /// Given a per-plane row bytes, determine size to allocate for all planes. Optionally retrieves
+    /// the per-plane byte sizes in planeSizes if not null. If total size overflows will return
+    /// SIZE_MAX and set all planeSizes to SIZE_MAX.
+    pub fn compute_total_bytes(
+        &self,
+        row_bytes: &[usize; Self::MAX_PLANES],
+        plane_sizes: Option<&mut [usize; Self::MAX_PLANES]>,
+    ) -> usize {
+        unsafe {
+            self.native().computeTotalBytes(
+                row_bytes.as_ptr(),
+                plane_sizes
+                    .map(|v| v.as_mut_ptr())
+                    .unwrap_or(ptr::null_mut()),
+            )
+        }
+    }
+
+    pub fn num_planes(&self) -> usize {
+        yuva_info::num_planes(self.planar_config())
+    }
+
+    pub fn num_channels_in_plane(&self, i: usize) -> usize {
+        yuva_info::num_channels_in_plane(self.planar_config(), i)
+    }
+}
+
+pub trait HasAlpha {
+    fn has_alpha(&self) -> bool;
+}
+
+pub mod yuva_info {
+    use crate::{prelude::*, EncodedOrigin, ISize, YUVAInfo};
+    use skia_bindings as sb;
+    use skia_bindings::SkYUVAInfo;
+
+    /// Specifies how YUV (and optionally A) are divided among planes. Planes are separated by
+    /// underscores in the enum value names. Within each plane the pixmap/texture channels are
+    /// mapped to the YUVA channels in the order specified, e.g. for kY_UV Y is in channel 0 of plane
+    /// 0, U is in channel 0 of plane 1, and V is in channel 1 of plane 1. Channel ordering
+    /// within a pixmap/texture given the channels it contains:
+    /// A:               0:A
+    /// Luminance/Gray:  0:Gray
+    /// RG               0:R,    1:G
+    /// RGB              0:R,    1:G, 2:B
+    /// RGBA             0:R,    1:G, 2:B, 3:A
+    ///
+    /// UV subsampling is also specified in the enum value names using J:a:b notation (e.g. 4:2:0 is
+    /// 1/2 horizontal and 1/2 vertical resolution for U and V). A fourth number is added if alpha
+    /// is present (always 4 as only full resolution alpha is supported).
+    ///
+    /// Currently this only has three-plane formats but more will be added as usage and testing of
+    ///  this expands.
+    pub use sb::SkYUVAInfo_PlanarConfig as PlanarConfig;
+    #[test]
+    fn test_planar_config_naming() {
+        let _ = PlanarConfig::Y_U_V_410;
+    }
+
+    /// Describes how subsampled chroma values are sited relative to luma values.
+    ///
+    /// Currently only centered siting is supported but will expand to support additional sitings.
+    pub use sb::SkYUVAInfo_Siting as Siting;
+
+    #[test]
+    fn test_siting_naming() {
+        let _ = Siting::Centered;
+    }
+
+    /// Given image dimensions, a planar configuration, and origin, determine the expected size of
+    /// each plane. Returns the number of expected planes. planeDimensions[0] through
+    /// planeDimensons[<ret>] are written. The input image dimensions are as displayed (after the
+    /// planes have been transformed to the intended display orientation). The plane dimensions
+    // are output as stored in memory.
+    pub fn plane_dimensions(
+        image_dimensions: impl Into<ISize>,
+        config: PlanarConfig,
+        origin: EncodedOrigin,
+        plane_dimensions: &mut [ISize; YUVAInfo::MAX_PLANES],
+    ) -> usize {
+        unsafe {
+            SkYUVAInfo::PlaneDimensions(
+                image_dimensions.into().into_native(),
+                config,
+                origin.into_native(),
+                plane_dimensions.native_mut().as_mut_ptr(),
+            )
+        }
+        .try_into()
+        .unwrap()
+    }
+
+    /// Number of planes for a given PlanarConfig.
+    pub fn num_planes(config: PlanarConfig) -> usize {
+        unsafe { sb::C_SkYUVAInfo_NumPlanes(config) }
+            .try_into()
+            .unwrap()
+    }
+
+    /// Number of Y, U, V, A channels in the ith plane for a given PlanarConfig (or 0 if i is
+    /// invalid).
+    pub fn num_channels_in_plane(config: PlanarConfig, i: usize) -> usize {
+        unsafe { sb::C_SkYUVAInfo_NumChannelsInPlane(config, i.try_into().unwrap()) }
+            .try_into()
+            .unwrap()
+    }
+
+    /// Does the PlanarConfig have alpha values?
+    pub fn has_alpha(config: PlanarConfig) -> bool {
+        unsafe { sb::SkYUVAInfo_HasAlpha(config) }
+    }
+}

--- a/skia-safe/src/core/yuva_pixmaps.rs
+++ b/skia-safe/src/core/yuva_pixmaps.rs
@@ -5,10 +5,241 @@ use crate::{
 use skia_bindings as sb;
 use skia_bindings::{SkYUVAPixmapInfo, SkYUVAPixmaps};
 use std::{ffi::c_void, ptr, slice};
+use yuva_pixmap_info::{DataType, SupportedDataTypes};
 
-/// `YUVAInfo` combined with per-plane `ColorType`s and row bytes. Fully specifies the `Pixmap`s
+/// [YUVAInfo] combined with per-plane [ColorType]s and row bytes. Fully specifies the [Pixmap]`s
 /// for a YUVA image without the actual pixel memory and data.
 pub type YUVAPixmapInfo = Handle<SkYUVAPixmapInfo>;
+
+impl NativeDrop for SkYUVAPixmapInfo {
+    fn drop(&mut self) {
+        unsafe { sb::C_SkYUVAPixmapInfo_destruct(self) }
+    }
+}
+
+impl NativePartialEq for SkYUVAPixmapInfo {
+    fn eq(&self, rhs: &Self) -> bool {
+        unsafe { sb::C_SkYUVAPixmapInfo_equals(self, rhs) }
+    }
+}
+
+impl YUVAPixmapInfo {
+    pub const MAX_PLANES: usize = sb::SkYUVAInfo_kMaxPlanes as _;
+    pub const DATA_TYPE_CNT: usize = DataType::Last as _;
+
+    /// Initializes the [YUVAPixmapInfo] from a [YUVAInfo] with per-plane color types and row bytes.
+    /// This will return [None] if the colorTypes aren't compatible with the [YUVAInfo] or if a
+    /// rowBytes entry is not valid for the plane dimensions and color type. Color type and
+    /// row byte values beyond the number of planes in [YUVAInfo] are ignored. All [ColorType]s
+    /// must have the same [DataType] or this will return [None].
+    ///
+    /// If `rowBytes` is [None] then bpp*width is assumed for each plane.
+    pub fn new(
+        info: &YUVAInfo,
+        color_types: &[ColorType; Self::MAX_PLANES],
+        row_bytes: Option<&[usize; Self::MAX_PLANES]>,
+    ) -> Option<Self> {
+        let info = unsafe {
+            SkYUVAPixmapInfo::new(
+                info.native(),
+                color_types.native().as_ptr(),
+                row_bytes.map(|rb| rb.as_ptr()).unwrap_or(ptr::null()),
+            )
+        };
+        Self::native_is_valid(&info).if_true_then_some(|| Self::from_native_c(info))
+    }
+
+    /// Like above but uses [yuva_pixmap_info::default_color_type_for_data_type] to determine each plane's [ColorType]. If
+    /// `rowBytes` is [None] then bpp*width is assumed for each plane.
+    pub fn from_data_type(
+        info: &YUVAInfo,
+        data_type: DataType,
+        row_bytes: Option<&[usize; Self::MAX_PLANES]>,
+    ) -> Option<Self> {
+        let info = unsafe {
+            SkYUVAPixmapInfo::new1(
+                info.native(),
+                data_type,
+                row_bytes.map(|rb| rb.as_ptr()).unwrap_or(ptr::null()),
+            )
+        };
+        Self::native_is_valid(&info).if_true_then_some(|| Self::from_native_c(info))
+    }
+
+    pub fn yuva_info(&self) -> &YUVAInfo {
+        YUVAInfo::from_native_ref(&self.native().fYUVAInfo)
+    }
+
+    pub fn yuv_color_space(&self) -> YUVColorSpace {
+        self.yuva_info().yuv_color_space()
+    }
+
+    /// The number of [Pixmap] planes.
+    pub fn num_planes(&self) -> usize {
+        self.yuva_info().num_planes()
+    }
+
+    /// The per-YUV`[A]` channel data type.
+    pub fn data_type(&self) -> DataType {
+        self.native().fDataType
+    }
+
+    /// Row bytes for the ith plane. Returns [None] if `i` >= [numPlanes(&self)] or this [YUVAPixmapInfo] is
+    /// invalid.
+    pub fn row_bytes(&self, i: usize) -> Option<usize> {
+        (i < self.num_planes()).if_true_then_some(|| unsafe {
+            sb::C_SkYUVAPixmapInfo_rowBytes(self.native(), i.try_into().unwrap())
+        })
+    }
+
+    /// Image info for the ith plane, or [None] if `i` >= [numPlanes(&self)]
+    pub fn plane_info(&self, i: usize) -> Option<&ImageInfo> {
+        (i < self.num_planes()).if_true_then_some(|| {
+            ImageInfo::from_native_ref(unsafe {
+                &*sb::C_SkYUVAPixmapInfo_planeInfo(self.native(), i.try_into().unwrap())
+            })
+        })
+    }
+
+    /// Determine size to allocate for all planes. Optionally retrieves the per-plane sizes in
+    /// planeSizes if not [None]. If total size overflows will return SIZE_MAX and set all `plane_sizes`
+    /// to SIZE_MAX.
+    pub fn compute_total_bytes(
+        &self,
+        plane_sizes: Option<&mut [usize; Self::MAX_PLANES]>,
+    ) -> usize {
+        unsafe {
+            self.native().computeTotalBytes(
+                plane_sizes
+                    .map(|ps| ps.as_mut_ptr())
+                    .unwrap_or(ptr::null_mut()),
+            )
+        }
+    }
+
+    /// Takes an allocation that is assumed to be at least [compute_total_bytes(&self)] in size and configures
+    /// the first [numPlanes(&self)] entries in pixmaps array to point into that memory. The remaining
+    /// entries of pixmaps are default initialized. Returns [None] if this [YUVAPixmapInfo] not valid.
+    #[allow(clippy::clippy::missing_safety_doc)]
+    pub unsafe fn init_pixmaps_from_single_allocation(
+        &self,
+        memory: *mut c_void,
+    ) -> Option<[Pixmap; Self::MAX_PLANES]> {
+        let mut pixmaps: [Pixmap; Self::MAX_PLANES] = Default::default();
+        self.native()
+            .initPixmapsFromSingleAllocation(memory, pixmaps.native_mut().as_mut_ptr())
+            .if_true_some(pixmaps)
+    }
+
+    /// Returns `true` if this has been configured with a non-empty dimensioned [YUVAInfo] with
+    /// compatible color types and row bytes.
+    fn native_is_valid(info: *const SkYUVAPixmapInfo) -> bool {
+        unsafe { sb::C_SkYUVAPixmapInfo_isValid(info) }
+    }
+
+    /// Is this valid and does it use color types allowed by the passed [SupportedDataTypes]?
+    pub fn is_supported(&self, data_types: &SupportedDataTypes) -> bool {
+        unsafe { self.native().isSupported(data_types.native()) }
+    }
+}
+
+/// Helper to store [Pixmap] planes as described by a [YUVAPixmapInfo]. Can be responsible for
+/// allocating/freeing memory for pixmaps or use external memory.
+pub type YUVAPixmaps = Handle<SkYUVAPixmaps>;
+
+impl NativeDrop for SkYUVAPixmaps {
+    fn drop(&mut self) {
+        unsafe { sb::C_SkYUVAPixmaps_destruct(self) }
+    }
+}
+
+impl YUVAPixmaps {
+    pub const MAX_PLANES: usize = YUVAPixmapInfo::MAX_PLANES;
+
+    /// Allocate space for pixmaps' pixels in the [YUVAPixmaps].
+    pub fn allocate(info: &YUVAPixmapInfo) -> Option<Self> {
+        Self::try_construct(|pixmaps| unsafe {
+            sb::C_SkYUVAPixmaps_Allocate(pixmaps, info.native());
+            Self::native_is_valid(pixmaps)
+        })
+    }
+
+    /// Use storage in [Data] as backing store for pixmaps' pixels. [Data] is retained by the
+    /// [YUVAPixmaps].
+    pub fn from_data(info: &YUVAPixmapInfo, data: impl Into<Data>) -> Option<Self> {
+        Self::try_construct(|pixmaps| unsafe {
+            sb::C_SkYUVAPixmaps_FromData(pixmaps, info.native(), data.into().into_ptr());
+            Self::native_is_valid(pixmaps)
+        })
+    }
+
+    /// Use passed in memory as backing store for pixmaps' pixels. Caller must ensure memory remains
+    /// allocated while pixmaps are in use. There must be at least
+    /// [YUVAPixmapInfo::computeTotalBytes(&self)] allocated starting at memory.
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe fn from_external_memory(info: &YUVAPixmapInfo, memory: *mut c_void) -> Option<Self> {
+        Self::try_construct(|pixmaps| {
+            sb::C_SkYUVAPixmaps_FromExternalMemory(pixmaps, info.native(), memory);
+            Self::native_is_valid(pixmaps)
+        })
+    }
+
+    /// Wraps existing `Pixmap`s. The [YUVAPixmaps] will have no ownership of the [Pixmap]s' pixel
+    /// memory so the caller must ensure it remains valid. Will return [None] if
+    /// the [YUVAInfo] isn't compatible with the [Pixmap] array (number of planes, plane dimensions,
+    /// sufficient color channels in planes, ...).
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe fn from_external_pixmaps(
+        info: &YUVAInfo,
+        x_pixmaps: &[Pixmap; Self::MAX_PLANES],
+    ) -> Option<Self> {
+        Self::try_construct(|pixmaps| {
+            sb::C_SkYUVAPixmaps_FromExternalPixmaps(
+                pixmaps,
+                info.native(),
+                x_pixmaps.native().as_ptr(),
+            );
+            Self::native_is_valid(pixmaps)
+        })
+    }
+
+    pub fn yuva_info(&self) -> &YUVAInfo {
+        YUVAInfo::from_native_ref(&self.native().fYUVAInfo)
+    }
+
+    /// Number of pixmap planes.
+    pub fn num_planes(&self) -> usize {
+        self.yuva_info().num_planes()
+    }
+
+    /// Access the [Pixmap] planes.
+    pub fn planes(&self) -> &[Pixmap] {
+        unsafe {
+            let planes = Pixmap::from_native_ref(&*sb::C_SkYUVAPixmaps_planes(self.native()));
+            slice::from_raw_parts(planes, self.num_planes())
+        }
+    }
+
+    /// Get the ith [Pixmap] plane. `Pixmap` will be default initialized if i >= numPlanes.
+    pub fn plane(&self, i: usize) -> &Pixmap {
+        &self.planes()[i]
+    }
+
+    /// Conversion to legacy YUVA data structures.
+    pub fn to_legacy(&self) -> Option<(YUVASizeInfo, [YUVAIndex; 4])> {
+        let mut info = YUVASizeInfo::default();
+        let mut index = [YUVAIndex::default(); 4];
+        unsafe {
+            self.native()
+                .toLegacy(info.native_mut(), &mut index.native_mut()[0])
+        }
+        .if_true_some((info, index))
+    }
+
+    fn native_is_valid(pixmaps: *const SkYUVAPixmaps) -> bool {
+        unsafe { sb::C_SkYUVAPixmaps_isValid(pixmaps) }
+    }
+}
 
 pub mod yuva_pixmap_info {
     use crate::{prelude::*, ColorType};
@@ -49,19 +280,19 @@ pub mod yuva_pixmap_info {
             })
         }
 
-        /// All legal combinations of PlanarConfig and DataType are supported.
+        /// All legal combinations of [PlanarConfig] and [DataType] are supported.
         pub fn all() -> Self {
             Handle::construct(|sdt| unsafe { sb::C_SkYUVAPixmapInfo_SupportedDataTypes_All(sdt) })
         }
 
         /// Checks whether there is a supported combination of color types for planes structured
-        /// as indicated by PlanarConfig with channel data types as indicated by DataType.
+        /// as indicated by [PlanarConfig] with channel data types as indicated by [DataType].
         pub fn supported(&self, pc: PlanarConfig, dt: DataType) -> bool {
             unsafe { sb::C_SkYUVAPixmapInfo_SupportedDataTypes_supported(self.native(), pc, dt) }
         }
 
-        /// Update to add support for pixmaps with numChannel channels where each channel is
-        /// represented as DataType.
+        /// Update to add support for pixmaps with `num_channels` channels where each channel is
+        /// represented as [DataType].
         pub fn enable_data_type(&mut self, dt: DataType, num_channels: usize) {
             unsafe {
                 self.native_mut()
@@ -70,267 +301,24 @@ pub mod yuva_pixmap_info {
         }
     }
 
-    /// Gets the default SkColorType to use with numChannels channels, each represented as DataType.
-    /// Returns `ColorType::Unknown` if no such color type.
+    /// Gets the default [ColorType] to use with `num_channels` channels, each represented as [DataType].
+    /// Returns [ColorType::Unknown] if no such color type.
     pub fn default_color_type_for_data_type(dt: DataType, num_channels: usize) -> ColorType {
         ColorType::from_native_c(unsafe {
             sb::C_SkYUVAPixmapInfo_DefaultColorTypeForDataType(dt, num_channels.try_into().unwrap())
         })
     }
 
-    /// If the `ColorType` is supported for YUVA pixmaps this will return the number of YUVA channels
-    /// that can be stored in a plane of this color type and what the `DataType` is of those channels.
-    /// If the `ColorType` is not supported as a YUVA plane the number of channels is reported as 0
-    /// and the `DataType` returned should be ignored.
+    /// If the [ColorType] is supported for YUVA pixmaps this will return the number of YUVA channels
+    /// that can be stored in a plane of this color type and what the [DataType] is of those channels.
+    /// If the [ColorType] is not supported as a YUVA plane the number of channels is reported as 0
+    /// and the [DataType] returned should be ignored.
     pub fn num_channels_and_data_type(color_type: ColorType) -> (usize, DataType) {
         let mut data_type = DataType::Float16;
         let channels = unsafe {
             sb::C_SkYUVAPixmapInfo_NumChannelsAndDataType(color_type.into_native(), &mut data_type)
         };
         (channels.try_into().unwrap(), data_type)
-    }
-}
-
-impl NativeDrop for SkYUVAPixmapInfo {
-    fn drop(&mut self) {
-        unsafe { sb::C_SkYUVAPixmapInfo_destruct(self) }
-    }
-}
-
-/* Don't see the value of an invalid YUVAPixmapInfo if it is basically immutable.
-   TODO: If this gets removed, remove `C_SkYUVAPixmapInfo_Construct`, too.
-impl Default for YUVAPixmapInfo {
-    /// Default `YUVAPixmapInfo` is invalid.
-    fn default() -> Self {
-        Self::construct(|pi| unsafe { sb::C_SkYUVAPixmapInfo_Construct(pi) })
-    }
-}
-*/
-
-impl NativePartialEq for SkYUVAPixmapInfo {
-    fn eq(&self, rhs: &Self) -> bool {
-        unsafe { sb::C_SkYUVAPixmapInfo_equals(self, rhs) }
-    }
-}
-
-/// `YUVAInfo` combined with per-plane `ColorTypes` and row bytes. Fully specifies the `Pixmap`s
-/// for a YUVA image without the actual pixel memory and data.
-impl YUVAPixmapInfo {
-    pub const MAX_PLANES: usize = sb::SkYUVAInfo_kMaxPlanes as _;
-    pub const DATA_TYPE_CNT: usize = yuva_pixmap_info::DataType::Last as _;
-
-    /// Initializes the `YUVAPixmapInfo` from a `YUVAInfo` with per-plane color types and row bytes.
-    /// This will return `None` if the colorTypes aren't compatible with the `YUVAInfo` or if a
-    /// rowBytes entry is not valid for the plane dimensions and color type. Color type and
-    /// row byte values beyond the number of planes in `YUVAInfo` are ignored. All `ColorType`s
-    /// must have the same `DataType` or this will return `None`.
-    ///
-    /// If `rowBytes` is `None` then bpp*width is assumed for each plane.
-    pub fn new(
-        info: &YUVAInfo,
-        color_types: &[ColorType; Self::MAX_PLANES],
-        row_bytes: Option<&[usize; Self::MAX_PLANES]>,
-    ) -> Option<Self> {
-        let info = unsafe {
-            SkYUVAPixmapInfo::new(
-                info.native(),
-                color_types.native().as_ptr(),
-                row_bytes.map(|rb| rb.as_ptr()).unwrap_or(ptr::null()),
-            )
-        };
-        Self::native_is_valid(&info).if_true_then_some(|| Self::from_native_c(info))
-    }
-
-    /// Like above but uses DefaultColorTypeForDataType to determine each plane's `ColorType`. If
-    /// `rowBytes` is `None` then bpp*width is assumed for each plane.
-    pub fn from_data_type(
-        info: &YUVAInfo,
-        data_type: yuva_pixmap_info::DataType,
-        row_bytes: Option<&[usize; Self::MAX_PLANES]>,
-    ) -> Option<Self> {
-        let info = unsafe {
-            SkYUVAPixmapInfo::new1(
-                info.native(),
-                data_type,
-                row_bytes.map(|rb| rb.as_ptr()).unwrap_or(ptr::null()),
-            )
-        };
-        Self::native_is_valid(&info).if_true_then_some(|| Self::from_native_c(info))
-    }
-
-    pub fn yuva_info(&self) -> &YUVAInfo {
-        YUVAInfo::from_native_ref(&self.native().fYUVAInfo)
-    }
-
-    pub fn yuv_color_space(&self) -> YUVColorSpace {
-        self.yuva_info().yuv_color_space()
-    }
-
-    /// The number of `Pixmap` planes.
-    pub fn num_planes(&self) -> usize {
-        self.yuva_info().num_planes()
-    }
-
-    /// The per-YUV[A] channel data type.
-    pub fn data_type(&self) -> yuva_pixmap_info::DataType {
-        self.native().fDataType
-    }
-
-    /// Row bytes for the ith plane. Returns `None` if `i` >= `numPlanes()` or this `YUVAPixmapInfo` is
-    /// invalid.
-    pub fn row_bytes(&self, i: usize) -> Option<usize> {
-        (i < self.num_planes()).if_true_then_some(|| unsafe {
-            sb::C_SkYUVAPixmapInfo_rowBytes(self.native(), i.try_into().unwrap())
-        })
-    }
-
-    /// Image info for the ith plane, or `None` if `i` >= `numPlanes()`
-    pub fn plane_info(&self, i: usize) -> Option<&ImageInfo> {
-        (i < self.num_planes()).if_true_then_some(|| {
-            ImageInfo::from_native_ref(unsafe {
-                &*sb::C_SkYUVAPixmapInfo_planeInfo(self.native(), i.try_into().unwrap())
-            })
-        })
-    }
-
-    /// Determine size to allocate for all planes. Optionally retrieves the per-plane sizes in
-    /// planeSizes if not `None`. If total size overflows will return SIZE_MAX and set all planeSizes
-    /// to SIZE_MAX.
-    pub fn compute_total_bytes(
-        &self,
-        plane_sizes: Option<&mut [usize; Self::MAX_PLANES]>,
-    ) -> usize {
-        unsafe {
-            self.native().computeTotalBytes(
-                plane_sizes
-                    .map(|ps| ps.as_mut_ptr())
-                    .unwrap_or(ptr::null_mut()),
-            )
-        }
-    }
-
-    /// Takes an allocation that is assumed to be at least `computeTotalBytes()` in size and configures
-    /// the first `numPlanes()` entries in pixmaps array to point into that memory. The remaining
-    /// entries of pixmaps are default initialized. Returns `None` if this `YUVAPixmapInfo` not valid.
-    #[allow(clippy::clippy::missing_safety_doc)]
-    pub unsafe fn init_pixmaps_from_single_allocation(
-        &self,
-        memory: *mut c_void,
-    ) -> Option<[Pixmap; Self::MAX_PLANES]> {
-        let mut pixmaps: [Pixmap; Self::MAX_PLANES] = Default::default();
-        self.native()
-            .initPixmapsFromSingleAllocation(memory, pixmaps.native_mut().as_mut_ptr())
-            .if_true_some(pixmaps)
-    }
-
-    /// Returns `true` if this has been configured with a non-empty dimensioned `YUVAInfo` with
-    /// compatible color types and row bytes.
-    fn native_is_valid(info: *const SkYUVAPixmapInfo) -> bool {
-        unsafe { sb::C_SkYUVAPixmapInfo_isValid(info) }
-    }
-
-    /// Is this valid and does it use color types allowed by the passed SupportedDataTypes?
-    pub fn is_supported(&self, data_types: &yuva_pixmap_info::SupportedDataTypes) -> bool {
-        unsafe { self.native().isSupported(data_types.native()) }
-    }
-}
-
-/// Helper to store `Pixmap` planes as described by a `YUVAPixmapInfo`. Can be responsible for
-/// allocating/freeing memory for pixmaps or use external memory.
-pub type YUVAPixmaps = Handle<SkYUVAPixmaps>;
-
-impl NativeDrop for SkYUVAPixmaps {
-    fn drop(&mut self) {
-        unsafe { sb::C_SkYUVAPixmaps_destruct(self) }
-    }
-}
-
-impl YUVAPixmaps {
-    pub const MAX_PLANES: usize = YUVAPixmapInfo::MAX_PLANES;
-
-    /// Allocate space for pixmaps' pixels in the `YUVAPixmaps`.
-    pub fn allocate(info: &YUVAPixmapInfo) -> Option<Self> {
-        Self::try_construct(|pixmaps| unsafe {
-            sb::C_SkYUVAPixmaps_Allocate(pixmaps, info.native());
-            Self::native_is_valid(pixmaps)
-        })
-    }
-
-    /// Use storage in `Data` as backing store for pixmaps' pixels. `Data` is retained by the
-    /// `YUVAPixmaps`.
-    pub fn from_data(info: &YUVAPixmapInfo, data: impl Into<Data>) -> Option<Self> {
-        Self::try_construct(|pixmaps| unsafe {
-            sb::C_SkYUVAPixmaps_FromData(pixmaps, info.native(), data.into().into_ptr());
-            Self::native_is_valid(pixmaps)
-        })
-    }
-
-    /// Use passed in memory as backing store for pixmaps' pixels. Caller must ensure memory remains
-    /// allocated while pixmaps are in use. There must be at least
-    /// `YUVAPixmapInfo::computeTotalBytes()` allocated starting at memory.
-    #[allow(clippy::missing_safety_doc)]
-    pub unsafe fn from_external_memory(info: &YUVAPixmapInfo, memory: *mut c_void) -> Option<Self> {
-        Self::try_construct(|pixmaps| {
-            sb::C_SkYUVAPixmaps_FromExternalMemory(pixmaps, info.native(), memory);
-            Self::native_is_valid(pixmaps)
-        })
-    }
-
-    /// Wraps existing `Pixmap`s. The `YUVAPixmaps` will have no ownership of the `Pixmap`s' pixel
-    /// memory so the caller must ensure it remains valid. Will return `None` if
-    /// the YUVAInfo isn't compatible with the `Pixmap` array (number of planes, plane dimensions,
-    /// sufficient color channels in planes, ...).
-    #[allow(clippy::missing_safety_doc)]
-    pub unsafe fn from_external_pixmaps(
-        info: &YUVAInfo,
-        x_pixmaps: &[Pixmap; Self::MAX_PLANES],
-    ) -> Option<Self> {
-        Self::try_construct(|pixmaps| {
-            sb::C_SkYUVAPixmaps_FromExternalPixmaps(
-                pixmaps,
-                info.native(),
-                x_pixmaps.native().as_ptr(),
-            );
-            Self::native_is_valid(pixmaps)
-        })
-    }
-
-    pub fn yuva_info(&self) -> &YUVAInfo {
-        YUVAInfo::from_native_ref(&self.native().fYUVAInfo)
-    }
-
-    /// Number of pixmap planes.
-    pub fn num_planes(&self) -> usize {
-        self.yuva_info().num_planes()
-    }
-
-    /// Access the `Pixmap` planes.
-    pub fn planes(&self) -> &[Pixmap] {
-        unsafe {
-            let planes = Pixmap::from_native_ref(&*sb::C_SkYUVAPixmaps_planes(self.native()));
-            slice::from_raw_parts(planes, self.num_planes())
-        }
-    }
-
-    /// Get the ith `Pixmap` plane. `Pixmap` will be default initialized if i >= numPlanes or this
-    /// `YUVAPixmap`s is invalid.
-    pub fn plane(&self, i: usize) -> &Pixmap {
-        &self.planes()[i]
-    }
-
-    /// Conversion to legacy SkYUVA data structures.
-    pub fn to_legacy(&self) -> Option<(YUVASizeInfo, [YUVAIndex; 4])> {
-        let mut info = YUVASizeInfo::default();
-        let mut index = [YUVAIndex::default(); 4];
-        unsafe {
-            self.native()
-                .toLegacy(info.native_mut(), &mut index.native_mut()[0])
-        }
-        .if_true_some((info, index))
-    }
-
-    fn native_is_valid(pixmaps: *const SkYUVAPixmaps) -> bool {
-        unsafe { sb::C_SkYUVAPixmaps_isValid(pixmaps) }
     }
 }
 

--- a/skia-safe/src/core/yuva_pixmaps.rs
+++ b/skia-safe/src/core/yuva_pixmaps.rs
@@ -1,0 +1,238 @@
+use crate::{prelude::*, ColorType, ImageInfo, Pixmap};
+use crate::{YUVAInfo, YUVColorSpace};
+use skia_bindings as sb;
+use skia_bindings::SkYUVAPixmapInfo;
+use std::{ffi::c_void, ptr};
+
+pub type YUVAPixmapInfo = Handle<SkYUVAPixmapInfo>;
+
+impl NativeDrop for SkYUVAPixmapInfo {
+    fn drop(&mut self) {
+        unsafe { sb::C_SkYUVAPixmapInfo_destruct(self) }
+    }
+}
+
+impl Default for YUVAPixmapInfo {
+    /// Default SkYUVAPixmapInfo is invalid.
+    fn default() -> Self {
+        Self::construct(|pi| unsafe { sb::C_SkYUVAPixmapInfo_construct(pi) })
+    }
+}
+
+impl NativePartialEq for SkYUVAPixmapInfo {
+    fn eq(&self, rhs: &Self) -> bool {
+        unsafe { sb::C_SkYUVAPixmapInfo_equals(self, rhs) }
+    }
+}
+
+/// `YUVAInfo` combined with per-plane `ColorTypes` and row bytes. Fully specifies the `Pixmap`s
+/// for a YUVA image without the actual pixel memory and data.
+impl YUVAPixmapInfo {
+    pub const MAX_PLANES: usize = sb::SkYUVAInfo_kMaxPlanes as _;
+    pub const DATA_TYPE_CNT: usize = yuva_pixmap_info::DataType::Last as _;
+
+    /// Initializes the `YUVAPixmapInfo` from a `YUVAInfo` with per-plane color types and row bytes.
+    /// This will be invalid if the colorTypes aren't compatible with the `YUVAInfo` or if a
+    /// rowBytes entry is not valid for the plane dimensions and color type. Color type and
+    /// row byte values beyond the number of planes in `YUVAInfo` are ignored. All `ColorType`s
+    /// must have the same `DataType` or this will be invalid.
+    ///
+    /// If `rowBytes` is `None` then bpp*width is assumed for each plane.
+    pub fn new(
+        info: &YUVAInfo,
+        color_types: &[ColorType; Self::MAX_PLANES],
+        row_bytes: Option<&[usize; Self::MAX_PLANES]>,
+    ) -> Self {
+        Self::from_native_c(unsafe {
+            SkYUVAPixmapInfo::new(
+                info.native(),
+                color_types.native().as_ptr(),
+                row_bytes.map(|rb| rb.as_ptr()).unwrap_or(ptr::null()),
+            )
+        })
+    }
+
+    /// Like above but uses DefaultColorTypeForDataType to determine each plane's `ColorType`. If
+    /// `rowBytes` is `None` then bpp*width is assumed for each plane.
+    pub fn from_data_type(
+        info: &YUVAInfo,
+        data_type: yuva_pixmap_info::DataType,
+        row_bytes: Option<&[usize; Self::MAX_PLANES]>,
+    ) -> Self {
+        Self::from_native_c(unsafe {
+            SkYUVAPixmapInfo::new1(
+                info.native(),
+                data_type,
+                row_bytes.map(|rb| rb.as_ptr()).unwrap_or(ptr::null()),
+            )
+        })
+    }
+
+    pub fn yuva_info(&self) -> &YUVAInfo {
+        YUVAInfo::from_native_ref(&self.native().fYUVAInfo)
+    }
+
+    pub fn yuv_color_space(&self) -> YUVColorSpace {
+        self.yuva_info().yuv_color_space()
+    }
+
+    /// The number of `Pixmap` planes, `None` if this `YUVAPixmapInfo` is invalid.
+    pub fn num_planes(&self) -> Option<usize> {
+        self.is_valid()
+            .if_true_then_some(|| self.yuva_info().num_planes())
+    }
+
+    /// The per-YUV[A] channel data type.
+    pub fn data_type(&self) -> yuva_pixmap_info::DataType {
+        self.native().fDataType
+    }
+
+    /// Row bytes for the ith plane. Returns `None` if `i` >= `numPlanes()` or this `YUVAPixmapInfo` is
+    /// invalid.
+    pub fn row_bytes(&self, i: usize) -> Option<usize> {
+        self.num_planes()
+            .filter(|planes| i < *planes)
+            .map(|_| unsafe {
+                sb::C_SkYUVAPixmapInfo_rowBytes(self.native(), i.try_into().unwrap())
+            })
+    }
+
+    /// Image info for the ith plane, or `None` if `i` >= `numPlanes()`
+    pub fn plane_info(&self, i: usize) -> Option<&ImageInfo> {
+        self.num_planes().filter(|planes| i < *planes).map(|_| {
+            ImageInfo::from_native_ref(unsafe {
+                &*sb::C_SkYUVAPixmapInfo_planeInfo(self.native(), i.try_into().unwrap())
+            })
+        })
+    }
+
+    /// Determine size to allocate for all planes. Optionally retrieves the per-plane sizes in
+    /// planeSizes if not `None`. If total size overflows will return SIZE_MAX and set all planeSizes
+    /// to SIZE_MAX. Returns `None` if this `YUVAPixmapInfo` is not valid.
+    pub fn compute_total_bytes(
+        &self,
+        plane_sizes: Option<&mut [usize; Self::MAX_PLANES]>,
+    ) -> Option<usize> {
+        if self.is_valid() {
+            Some(unsafe {
+                self.native().computeTotalBytes(
+                    plane_sizes
+                        .map(|ps| ps.as_mut_ptr())
+                        .unwrap_or(ptr::null_mut()),
+                )
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Takes an allocation that is assumed to be at least `computeTotalBytes()` in size and configures
+    /// the first `numPlanes()` entries in pixmaps array to point into that memory. The remaining
+    /// entries of pixmaps are default initialized. Returns `None` if this `YUVAPixmapInfo` not valid.
+    pub unsafe fn init_pixmaps_from_single_allocation(
+        &self,
+        memory: *mut c_void,
+    ) -> Option<[Pixmap; Self::MAX_PLANES]> {
+        let mut pixmaps: [Pixmap; Self::MAX_PLANES] = Default::default();
+        self.native()
+            .initPixmapsFromSingleAllocation(memory, pixmaps.native_mut().as_mut_ptr())
+            .if_true_some(pixmaps)
+    }
+
+    /// Returns `true` if this has been configured with a non-empty dimensioned `YUVAInfo` with
+    /// compatible color types and row bytes.
+    pub fn is_valid(&self) -> bool {
+        unsafe { sb::C_SkYUVAPixmapInfo_isValid(self.native()) }
+    }
+
+    /// Is this valid and does it use color types allowed by the passed SupportedDataTypes?
+    pub fn is_supported(&self, data_types: &yuva_pixmap_info::SupportedDataTypes) -> bool {
+        unsafe { self.native().isSupported(data_types.native()) }
+    }
+}
+
+pub mod yuva_pixmap_info {
+    use crate::{prelude::*, ColorType};
+    use skia_bindings as sb;
+    use skia_bindings::SkYUVAPixmapInfo_SupportedDataTypes;
+
+    pub use crate::yuva_info::PlanarConfig;
+
+    /// Data type for Y, U, V, and possibly A channels independent of how values are packed into
+    /// planes.
+    pub use skia_bindings::SkYUVAPixmapInfo_DataType as DataType;
+
+    #[test]
+    fn test_data_type_naming() {
+        let _ = DataType::Float16;
+    }
+
+    pub type SupportedDataTypes = Handle<SkYUVAPixmapInfo_SupportedDataTypes>;
+
+    impl NativeDrop for SkYUVAPixmapInfo_SupportedDataTypes {
+        fn drop(&mut self) {
+            unsafe { sb::C_SkYUVAPixmapInfo_SupportedDataTypes_destruct(self) }
+        }
+    }
+
+    impl Default for SupportedDataTypes {
+        /// Defaults to nothing supported.
+        fn default() -> Self {
+            Self::construct(|sdt| unsafe {
+                sb::C_SkYUVAPixmapInfo_SupportedDataTypes_Construct(sdt)
+            })
+        }
+    }
+
+    impl SupportedDataTypes {
+        #[cfg(feature = "gpu")]
+        /// Init based on texture formats supported by the context.
+        pub fn from_context(context: &crate::gpu::RecordingContext) -> Self {
+            Handle::from_native_c(unsafe {
+                sb::SkYUVAPixmapInfo_SupportedDataTypes::new(
+                    context.native() as *const _ as *const sb::GrImageContext
+                )
+            })
+        }
+
+        /// All legal combinations of PlanarConfig and DataType are supported.
+        pub fn all() -> Self {
+            Handle::construct(|sdt| unsafe { sb::C_SkYUVAPixmapInfo_SupportedDataTypes_All(sdt) })
+        }
+
+        /// Checks whether there is a supported combination of color types for planes structured
+        /// as indicated by PlanarConfig with channel data types as indicated by DataType.
+        pub fn supported(&self, pc: PlanarConfig, dt: DataType) -> bool {
+            unsafe { sb::C_SkYUVAPixmapInfo_SupportedDataTypes_supported(self.native(), pc, dt) }
+        }
+
+        /// Update to add support for pixmaps with numChannel channels where each channel is
+        /// represented as DataType.
+        pub fn enable_data_type(&mut self, dt: DataType, num_channels: usize) {
+            unsafe {
+                self.native_mut()
+                    .enableDataType(dt, num_channels.try_into().unwrap())
+            }
+        }
+    }
+
+    /// Gets the default SkColorType to use with numChannels channels, each represented as DataType.
+    /// Returns `ColorType::Unknown` if no such color type.
+    pub fn default_color_type_for_data_type(dt: DataType, num_channels: usize) -> ColorType {
+        ColorType::from_native_c(unsafe {
+            sb::C_SkYUVAPixmapInfo_DefaultColorTypeForDataType(dt, num_channels.try_into().unwrap())
+        })
+    }
+
+    /// If the `ColorType` is supported for YUVA pixmaps this will return the number of YUVA channels
+    /// that can be stored in a plane of this color type and what the `DataType` is of those channels.
+    /// If the `ColorType` is not supported as a YUVA plane the number of channels is reported as 0
+    /// and the `DataType` returned should be ignored.
+    pub fn num_channels_and_data_type(color_type: ColorType) -> (usize, DataType) {
+        let mut data_type = DataType::Float16;
+        let channels = unsafe {
+            sb::C_SkYUVAPixmapInfo_NumChannelsAndDataType(color_type.into_native(), &mut data_type)
+        };
+        (channels.try_into().unwrap(), data_type)
+    }
+}

--- a/skia-safe/src/core/yuva_pixmaps.rs
+++ b/skia-safe/src/core/yuva_pixmaps.rs
@@ -212,6 +212,7 @@ impl YUVAPixmapInfo {
     /// Takes an allocation that is assumed to be at least `computeTotalBytes()` in size and configures
     /// the first `numPlanes()` entries in pixmaps array to point into that memory. The remaining
     /// entries of pixmaps are default initialized. Returns `None` if this `YUVAPixmapInfo` not valid.
+    #[allow(clippy::clippy::missing_safety_doc)]
     pub unsafe fn init_pixmaps_from_single_allocation(
         &self,
         memory: *mut c_void,
@@ -267,6 +268,7 @@ impl YUVAPixmaps {
     /// Use passed in memory as backing store for pixmaps' pixels. Caller must ensure memory remains
     /// allocated while pixmaps are in use. There must be at least
     /// `YUVAPixmapInfo::computeTotalBytes()` allocated starting at memory.
+    #[allow(clippy::missing_safety_doc)]
     pub unsafe fn from_external_memory(info: &YUVAPixmapInfo, memory: *mut c_void) -> Option<Self> {
         Self::try_construct(|pixmaps| {
             sb::C_SkYUVAPixmaps_FromExternalMemory(pixmaps, info.native(), memory);
@@ -278,6 +280,7 @@ impl YUVAPixmaps {
     /// memory so the caller must ensure it remains valid. Will return `None` if
     /// the YUVAInfo isn't compatible with the `Pixmap` array (number of planes, plane dimensions,
     /// sufficient color channels in planes, ...).
+    #[allow(clippy::missing_safety_doc)]
     pub unsafe fn from_external_pixmaps(
         info: &YUVAInfo,
         x_pixmaps: &[Pixmap; Self::MAX_PLANES],

--- a/skia-safe/src/interop/string.rs
+++ b/skia-safe/src/interop/string.rs
@@ -34,6 +34,7 @@ impl Default for Handle<SkString> {
 }
 
 impl Handle<SkString> {
+    #[allow(clippy::clippy::should_implement_trait)]
     pub fn from_str(str: impl AsRef<str>) -> String {
         let bytes = str.as_ref().as_bytes();
         Handle::from_native_c(unsafe { SkString::new3(bytes.as_ptr() as _, bytes.len()) })

--- a/skia-safe/src/lib.rs
+++ b/skia-safe/src/lib.rs
@@ -25,7 +25,7 @@ extern crate bitflags;
 extern crate lazy_static;
 
 // Prelude re-exports
-pub use crate::prelude::{Borrows, ConditionallySend, Sendable};
+pub use crate::prelude::{Borrows, ConditionallySend, Handle, RCHandle, RefHandle, Sendable};
 
 /// All Sk* types are accessible via skia_safe::
 pub use crate::core::*;


### PR DESCRIPTION
In M87 YUVAPixmapInfo and YUVAInfo were introduced, this MR adds the wrappers for them. 

- [x] Wrappers.
- [ ] Add tests.
- [x] Verify documentation links.
- [ ] Bump version.
- [ ] Review.