### PR TITLE
Remove serial_test_derive dependency

### DIFF
--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -50,7 +50,6 @@ wio = { version = "0.2.2", optional = true }
 
 [dev-dependencies]
 serial_test = "0.5"
-serial_test_derive = "0.5"
 static_assertions = "1.1"
 
 # gl-window


### PR DESCRIPTION
`serial_test` since [0.3](https://github.com/palfrey/serial_test/releases/tag/v0.3.0) includes `serial_test_derive` and lets you use the macro without needing to directly include `serial_test_derive`