### PR TITLE
Clippy fixes 1.51

### DIFF
--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -59,10 +59,12 @@ jobs:
           features: 'gl,vulkan,textlayout,webp'
           exampleArgs: ''
           skia_debug: '1'
-        beta-all-features:
-          toolchain: beta
-          features: 'gl,vulkan,textlayout,webp'
-          exampleArgs: ''
+# Disabled since 1.51 beta.1 because of a unresolvable conflict between stable and beta lints.
+# Reenable when 1.51 gets stable.
+#        beta-all-features:
+#          toolchain: beta
+#          features: 'gl,vulkan,textlayout,webp'
+#          exampleArgs: ''
 
   variables:
     platform: ${{ parameters.platform }}

--- a/skia-safe/src/core/matrix44.rs
+++ b/skia-safe/src/core/matrix44.rs
@@ -104,10 +104,10 @@ impl Default for Matrix44 {
     }
 }
 
-impl Into<Matrix> for Matrix44 {
-    fn into(self) -> Matrix {
+impl From<Matrix44> for Matrix {
+    fn from(m44: Matrix44) -> Self {
         let mut m = Matrix::new_identity();
-        unsafe { sb::C_SkMatrix44_SkMatrix(self.native(), m.native_mut()) };
+        unsafe { sb::C_SkMatrix44_SkMatrix(m44.native(), m.native_mut()) };
         m
     }
 }


### PR DESCRIPTION
This MR disables the beta clippy warnings on the CI because of a conflict between the current stable 1.50 and beta 1.51 clippy warnings.