### PR TITLE
Move Android installation to the container in Azure Linux builds.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,8 +26,9 @@ stages:
     parameters:
       platform: 'Linux'
       platformTarget: 'x86_64-unknown-linux-gnu'
-      androidHost: 'linux-x86_64'
-      androidNDK: 'r21d'
+      # The container we use has Android pre-installed.
+      # androidHost: 'linux-x86_64'
+      # androidNDK: 'r21d'
       androidAPILevel: '26'
       androidBinExt: ''
       vmImage: 'ubuntu-16.04'


### PR DESCRIPTION
This PR moves the Android installation part of the Linux Azure builds to the Linux container (corresponding PR in the container repository: https://github.com/pragmatrix/rust-skia-containers/pull/3)