### PR TITLE
Remove the need to explicitly initialize ICU on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m93 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m93-0.41.1...google:chrome/m93
-[skia-ours]: https://github.com/google/skia/compare/chrome/m93...rust-skia:m93-0.41.1
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m93-0.42.0...google:chrome/m93
+[skia-ours]: https://github.com/google/skia/compare/chrome/m93...rust-skia:m93-0.42.0
 
 ## Goals
 

--- a/patch/all-features-macos.patch
+++ b/patch/all-features-macos.patch
@@ -6,8 +6,8 @@ index 078c8119..2d5f02b0 100644
  depot_tools = "fade894"
  
  [features]
--default = ["binary-cache"]
-+default = ["binary-cache", "gl", "vulkan", "metal", "textlayout", "webp"]
+-default = ["binary-cache", "embed-icudtl"]
++default = ["binary-cache", "embed-icudtl, "gl", "vulkan", "metal", "textlayout", "webp"]
  gl = []
  egl = []
  wayland = []
@@ -32,8 +32,8 @@ index 6ddd6479..cba4092e 100644
  doctest = false
  
  [features]
--default = ["binary-cache"]
-+default = ["binary-cache", "gl", "vulkan", "metal", "textlayout", "webp"]
+-default = ["binary-cache", "embed-icudtl"]
++default = ["binary-cache", "embed-icudtl", "gl", "vulkan", "metal", "textlayout", "webp"]
  gl = ["gpu", "skia-bindings/gl"]
  egl = ["gl", "skia-bindings/egl"]
  x11 = ["gl", "skia-bindings/x11"]

--- a/patch/all-features-windows.patch
+++ b/patch/all-features-windows.patch
@@ -6,8 +6,8 @@ index eca516a4..6a697344 100644
  depot_tools = "fade894"
  
  [features]
--default = ["binary-cache"]
-+default = ["binary-cache", "gl", "vulkan", "d3d", "textlayout", "webp"]
+-default = ["binary-cache", "embed-icudtl"]
++default = ["binary-cache", "embed-icudtl", "gl", "vulkan", "d3d", "textlayout", "webp"]
  gl = []
  egl = []
  wayland = []
@@ -32,8 +32,8 @@ index 6ddd6479..0f84729f 100644
  doctest = false
  
  [features]
--default = ["binary-cache"]
-+default = ["binary-cache", "gl", "vulkan", "d3d", "textlayout", "webp"]
+-default = ["binary-cache", "embed-icudtl"]
++default = ["binary-cache", "embed-icudtl", "gl", "vulkan", "d3d", "textlayout", "webp"]
  gl = ["gpu", "skia-bindings/gl"]
  egl = ["gl", "skia-bindings/egl"]
  x11 = ["gl", "skia-bindings/x11"]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -36,7 +36,7 @@ skia = "m93-0.42.0"
 depot_tools = "fade894"
 
 [features]
-default = ["binary-cache"]
+default = ["binary-cache", "embed-icudtl"]
 gl = []
 egl = []
 wayland = []
@@ -54,6 +54,7 @@ use-system-jpeg-turbo = ["mozjpeg-sys"]
 svg = []
 shaper = ["textlayout"]
 binary-cache = ["ureq", "flate2", "tar"]
+embed-icudtl = []
 
 [dependencies]
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m93-0.41.1"
+skia = "m93-0.42.0"
 depot_tools = "fade894"
 
 [features]

--- a/skia-bindings/build_support/binaries_config.rs
+++ b/skia-bindings/build_support/binaries_config.rs
@@ -54,7 +54,7 @@ impl BinariesConfiguration {
         let feature_ids = features.ids();
 
         if features.text_layout {
-            if target.is_windows() {
+            if target.is_windows() && !cfg!(feature = "embed-icudtl") {
                 additional_files.push(ICUDTL_DAT.into());
             }
             ninja_built_libraries.push(lib::SK_PARAGRAPH.into());

--- a/skia-bindings/src/icu.rs
+++ b/skia-bindings/src/icu.rs
@@ -1,18 +1,8 @@
 #[cfg(windows)]
 pub fn init() {
-    use std::{env, fs};
-
-    let path = env::current_exe()
-        .expect("failed to resolve the current executable's path")
-        .parent()
-        .expect("current executable's path does not point to a directory")
-        .join("icudtl.dat");
-    if path.exists() {
-        return;
-    };
-    let icu_dtl = include_bytes!(concat!(env!("OUT_DIR"), "/skia/icudtl.dat"));
-    fs::write(path, &icu_dtl[..])
-        .expect("failed to write icudtl.dat into the current executable's directory");
+    use std::env;
+    let icudtl = include_bytes!(concat!(env!("OUT_DIR"), "/skia/icudtl.dat"));
+    unsafe { crate::C_SetICU(&icudtl[0] as &'static u8 as *const u8 as _) };
 }
 
 #[cfg(not(windows))]

--- a/skia-bindings/src/icu.rs
+++ b/skia-bindings/src/icu.rs
@@ -2,7 +2,27 @@
 pub fn init() {
     use std::env;
     let icudtl = include_bytes!(concat!(env!("OUT_DIR"), "/skia/icudtl.dat"));
-    unsafe { crate::C_SetICU(&icudtl[0] as &'static u8 as *const u8 as _) };
+
+    #[cfg(feature = "embed-icudtl")]
+    {
+        unsafe { crate::C_SetICU(&icudtl[0] as &'static u8 as *const u8 as _) };
+    }
+
+    #[cfg(not(feature = "embed-icudtl"))]
+    {
+        use std::fs;
+
+        let path = env::current_exe()
+            .expect("failed to resolve the current executable's path")
+            .parent()
+            .expect("current executable's path does not point to a directory")
+            .join("icudtl.dat");
+        if path.exists() {
+            return;
+        };
+        fs::write(path, &icu_dtl[..])
+            .expect("failed to write icudtl.dat into the current executable's directory");
+    }
 }
 
 #[cfg(not(windows))]

--- a/skia-bindings/src/shaper.cpp
+++ b/skia-bindings/src/shaper.cpp
@@ -8,9 +8,7 @@
 #include "include/core/SkFontMgr.h"
 
 #if defined(_WIN32)
-
 #include "third_party/icu/SkLoadICU.h"
-
 #endif
 
 extern "C" SkShaper* C_SkShaper_MakePrimitive() {

--- a/skia-bindings/src/shaper.cpp
+++ b/skia-bindings/src/shaper.cpp
@@ -7,6 +7,12 @@
 #include "modules/skshaper/include/SkShaper.h"
 #include "include/core/SkFontMgr.h"
 
+#if defined(_WIN32)
+
+#include "third_party/icu/SkLoadICU.h"
+
+#endif
+
 extern "C" SkShaper* C_SkShaper_MakePrimitive() {
     return SkShaper::MakePrimitive().release();
 }

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2018"
 doctest = false
 
 [features]
-default = ["binary-cache"]
+default = ["binary-cache", "embed-icudtl"]
 gl = ["gpu", "skia-bindings/gl"]
 egl = ["gl", "skia-bindings/egl"]
 x11 = ["gl", "skia-bindings/x11"]
@@ -34,6 +34,7 @@ webp-encode = ["skia-bindings/webp-encode"]
 webp-decode = ["skia-bindings/webp-decode"]
 use-system-jpeg-turbo = ["skia-bindings/use-system-jpeg-turbo"]
 binary-cache = ["skia-bindings/binary-cache"]
+embed-icudtl = ["skia-bindings/embed-icudtl"]
 
 # implied only, do not use
 gpu = []

--- a/skia-safe/README.md
+++ b/skia-safe/README.md
@@ -88,17 +88,23 @@ The Cargo feature `textlayout` enables text shaping with Harfbuzz and ICU by pro
 
 The skshaper module can be accessed through `skia_safe::Shaper` and the Rust bindings for skparagraph are in the `skia_safe::textlayout` module. 
 
-On **Windows**, the file `icudtl.dat` must be available in your executable's directory. To provide the data file, either copy it from the build's output directory (shown when skia-bindings is compiled with `cargo build -vv | grep "ninja: Entering directory"`), or - if your executable directory is writable - invoke the function `skia_safe::icu::init()` before using the `skia_safe::Shaper` object or the `skia_safe::textlayout` module. 
-
-Simple examples of the skshaper and skparagraph module bindings can be found [in the skia-org example command line application](https://github.com/rust-skia/rust-skia/blob/master/skia-org/src/).
-
 ### `webp-encode`, `webp-decode`, `webp`
 
 `webp-encode` enables support for encoding Skia bitmaps and images to the [WEBP](https://en.wikipedia.org/wiki/WebP) image format, and `web-decode` enables support for decoding WEBP to Skia bitmaps and images. The `webp` feature can be used as a shorthand to enable the `webp-encode` and `webp-decode` features.
 
-### `binary-cache`
+### `binary-cache` (enabled by default)
 
-`binary-cache` enables download pre-built skia binaries instead of building them locally, it is enabled by default.
+`binary-cache` enables download pre-built skia binaries instead of building them locally.
+
+### `embed-icudtl` (enabled by default)
+
+Usually when Skia is used on **Windows**, the file `icudtl.dat` must be available in your executable's directory. But if this default feature is enabled, the `icudtl.dat` file is directly embedded in Rust and is automatically initialized before any of the `textlayout` features are used.
+
+If this feature is disabled, the `icudtl.dat` file needs to be copied from the build's output directory to the executable's directory. If your executable directory is writable, this can be done by calling the function `skia_safe::icu::init()` before the `skia_safe::textlayout` module is used.
+
+The output directory is displayed when skia-bindings is compiled with `cargo build -vv | grep "ninja: Entering directory"`, 
+
+Simple examples of how to use the `skshaper` and `skparagraph` module bindings can be found [in the skia-org example command line application](https://github.com/rust-skia/rust-skia/blob/master/skia-org/src/).
 
 ## Multithreading
 

--- a/skia-safe/src/docs/pdf_document.rs
+++ b/skia-safe/src/docs/pdf_document.rs
@@ -294,6 +294,10 @@ pub mod pdf {
             }
         }
 
+        // We enable harfbuzz font sub-setting in PDF documents if textlayout is enabled.
+        #[cfg(all(feature = "textlayout", feature = "embed-icudtl"))]
+        crate::icu::init();
+
         // we can't move the memory stream around anymore as soon it's referred by
         // the document.
         let mut memory_stream = Box::pin(DynamicMemoryWStream::new());

--- a/skia-safe/src/modules/paragraph/paragraph_builder.rs
+++ b/skia-safe/src/modules/paragraph/paragraph_builder.rs
@@ -64,6 +64,9 @@ impl ParagraphBuilder {
     }
 
     pub fn new(style: &ParagraphStyle, font_collection: impl Into<FontCollection>) -> Self {
+        #[cfg(feature = "embed-icudtl")]
+        crate::icu::init();
+
         Self::from_ptr(unsafe {
             sb::C_ParagraphBuilder_make(style.native(), font_collection.into().into_ptr())
         })

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -35,18 +35,27 @@ impl Shaper {
     }
 
     pub fn new_shaper_driven_wrapper(font_mgr: impl Into<Option<FontMgr>>) -> Option<Self> {
+        #[cfg(feature = "embed-icudtl")]
+        crate::icu::init();
+
         Self::from_ptr(unsafe {
             sb::C_SkShaper_MakeShaperDrivenWrapper(font_mgr.into().into_ptr_or_null())
         })
     }
 
     pub fn new_shape_then_wrap(font_mgr: impl Into<Option<FontMgr>>) -> Option<Self> {
+        #[cfg(feature = "embed-icudtl")]
+        crate::icu::init();
+
         Self::from_ptr(unsafe {
             sb::C_SkShaper_MakeShapeThenWrap(font_mgr.into().into_ptr_or_null())
         })
     }
 
     pub fn new_shape_dont_wrap_or_reorder(font_mgr: impl Into<Option<FontMgr>>) -> Option<Self> {
+        #[cfg(feature = "embed-icudtl")]
+        crate::icu::init();
+
         Self::from_ptr(unsafe {
             sb::C_SkShaper_MakeShapeDontWrapOrReorder(font_mgr.into().into_ptr_or_null())
         })
@@ -57,10 +66,16 @@ impl Shaper {
     }
 
     pub fn new_core_text() -> Option<Self> {
+        #[cfg(feature = "embed-icudtl")]
+        crate::icu::init();
+
         Self::from_ptr(unsafe { sb::C_SkShaper_MakeCoreText() })
     }
 
     pub fn new(font_mgr: impl Into<Option<FontMgr>>) -> Self {
+        #[cfg(feature = "embed-icudtl")]
+        crate::icu::init();
+
         Self::from_ptr(unsafe { sb::C_SkShaper_Make(font_mgr.into().into_ptr_or_null()) }).unwrap()
     }
 
@@ -712,27 +727,25 @@ impl Shaper {
 
 pub mod icu {
 
-    /// On Windows, this function writes the file `icudtl.dat` into the current
-    /// executable's directory making sure that it's available when text shaping is used in Skia.
+    /// On Windows, and if the default feature "embed-icudtl" is _not_ set, this function writes the
+    /// file `icudtl.dat` into the current executable's directory making sure that it's available
+    /// when text shaping is used in Skia.
     ///
     /// If your executable directory can not be written to, make sure that `icudtl.dat` is
     /// available.
     ///
     /// Note that it is currently not possible to load `icudtl.dat` from another location.
+    ///
+    /// If the default feature "embed-icudtl" is set, the `icudtl.dat` file is directly used from
+    /// memory, so no `icudtl.dat` file is needed.
     pub fn init() {
         skia_bindings::icu::init();
-
-        // Since m80, there is an initialization problem of icu in the module skparagraph,
-        // which we do not understand yet, but powering up an harfbuzz Shaper compensates
-        // for that.
-        #[cfg(all(windows, feature = "textlayout"))]
-        crate::Shaper::new(None);
     }
 
     #[test]
     #[serial_test::serial]
     fn test_text_blob_builder_run_handler() {
-        skia_bindings::icu::init();
+        init();
         let str = "العربية";
         let mut text_blob_builder_run_handler =
             crate::shaper::TextBlobBuilderRunHandler::new(str, crate::Point::default());
@@ -755,7 +768,7 @@ pub mod icu {
     #[test]
     #[serial_test::serial]
     fn icu_init_is_idempotent() {
-        skia_bindings::icu::init();
-        skia_bindings::icu::init();
+        init();
+        init();
     }
 }

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -751,4 +751,11 @@ pub mod icu {
         let bounds = blob.bounds();
         assert!(bounds.width() > 0.0 && bounds.height() > 0.0);
     }
+
+    #[test]
+    #[serial_test::serial]
+    fn icu_init_is_idempotent() {
+        skia_bindings::icu::init();
+        skia_bindings::icu::init();
+    }
 }


### PR DESCRIPTION
This PR attempts to completely remove the dependency on the `icudtl.dat` file in the current directory on Windows and the invocation of the `icu::init()` function in skia-safe.

Closes #557