### PR TITLE
Chrome Milestone 91

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m91 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m91-0.39.1...google:chrome/m91
-[skia-ours]: https://github.com/google/skia/compare/chrome/m91...rust-skia:m91-0.39.1
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m91-0.39.2...google:chrome/m91
+[skia-ours]: https://github.com/google/skia/compare/chrome/m91...rust-skia:m91-0.39.2
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![Build Status](https://dev.azure.com/pragmatrix-github/rust-skia/_apis/build/status/rust-skia.rust-skia?branchName=master)](https://dev.azure.com/pragmatrix-github/rust-skia/_build/latest?definitionId=2&branchName=master)
 
-Skia Submodule Status: chrome/m90 ([upstream changes][skia-upstream], [our changes][skia-ours]).
+Skia Submodule Status: chrome/m91 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m90-0.38.3...google:chrome/m90
-[skia-ours]: https://github.com/google/skia/compare/chrome/m90...rust-skia:m90-0.38.3
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m91-0.39.0...google:chrome/m91
+[skia-ours]: https://github.com/google/skia/compare/chrome/m91...rust-skia:m91-0.39.0
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m91 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m91-0.39.0...google:chrome/m91
-[skia-ours]: https://github.com/google/skia/compare/chrome/m91...rust-skia:m91-0.39.0
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m91-0.39.1...google:chrome/m91
+[skia-ours]: https://github.com/google/skia/compare/chrome/m91...rust-skia:m91-0.39.1
 
 ## Goals
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m90-0.38.3"
+skia = "m91-0.39.0"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m91-0.39.1"
+skia = "m91-0.39.2"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m91-0.39.0"
+skia = "m91-0.39.1"
 depot_tools = "a110bf6"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.39.2"
+version = "0.40.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -759,12 +759,14 @@ fn generate_bindings(build: &FinalBuildConfiguration, output_directory: &Path) {
         .blocklist_type("GrImageContextPriv")
         .raw_line("pub enum GrContextThreadSafeProxy {}")
         .blocklist_type("GrContextThreadSafeProxy")
-        .raw_line("pub enum GrContextThreadSafeProxyPriv {}")
         .blocklist_type("GrContextThreadSafeProxyPriv")
-        .raw_line("pub enum GrRecordingContextPriv {}")
+        .raw_line("pub enum GrContextThreadSafeProxyPriv {}")
         .blocklist_type("GrRecordingContextPriv")
-        .raw_line("pub enum GrContextPriv {}")
+        .raw_line("pub enum GrRecordingContextPriv {}")
+        .blocklist_function("GrRecordingContext_priv.*")
+        .blocklist_function("GrDirectContext_priv.*")
         .blocklist_type("GrContextPriv")
+        .raw_line("pub enum GrContextPriv {}")
         .blocklist_function("GrContext_priv.*")
         .blocklist_function("SkDeferredDisplayList_priv.*")
         .raw_line("pub enum SkVerticesPriv {}")
@@ -774,7 +776,9 @@ fn generate_bindings(build: &FinalBuildConfiguration, output_directory: &Path) {
         // Vulkan reexports that got swallowed by making them opaque.
         // (these can not be allowlisted by a extern "C" function)
         .allowlist_type("VkPhysicalDeviceFeatures")
-        .allowlist_type("VkPhysicalDeviceFeatures2")
+        .allowlist_type("VkPhysicalDeviceFeatures2").
+        // m91: These functions are not actually implemented.
+        blocklist_function("SkCustomTypefaceBuilder_setGlyph[123].*")
         // misc
         .allowlist_var("SK_Color.*")
         .allowlist_var("kAll_GrBackendState")

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -2294,14 +2294,14 @@ SkRuntimeEffect *C_SkRuntimeEffect_Make(
     return r.effect.release();
 }
 
-SkShader *C_SkRuntimeEffect_makeShader(SkRuntimeEffect *self, SkData *uniforms, SkShader **children, size_t childCount,
+SkShader *C_SkRuntimeEffect_makeShader(const SkRuntimeEffect *self, SkData *uniforms, SkShader **children, size_t childCount,
                                        const SkMatrix *localMatrix, bool isOpaque) {
     auto childrenSPs = reinterpret_cast<sk_sp<SkShader> *>(children);
     return self->makeShader(sp(uniforms), childrenSPs, childCount, localMatrix, isOpaque).release();
 }
 
 SkImage *C_SkRuntimeEffect_makeImage(
-    SkRuntimeEffect *self,
+    const SkRuntimeEffect *self,
     GrRecordingContext* context,
     SkData *uniforms,
     SkShader **children, size_t childCount,
@@ -2316,7 +2316,7 @@ SkImage *C_SkRuntimeEffect_makeImage(
         localMatrix, *resultInfo, mipmapped).release();
 }
 
-SkColorFilter* C_SkRuntimeEffect_makeColorFilter(SkRuntimeEffect* self, SkData* inputs) {
+SkColorFilter* C_SkRuntimeEffect_makeColorFilter(const SkRuntimeEffect* self, SkData* inputs) {
     return self->makeColorFilter(sp(inputs)).release();
 }
 

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -829,7 +829,6 @@ extern "C" SkColorSpace* C_SkColorSpace_Deserialize(const void* data, size_t len
 // SkM44
 //
 
-
 extern "C" void C_SkM44_Types(SkV2 *) {};
 
 extern "C" bool C_SkM44_equals(const SkM44 *self, const SkM44 *other) {
@@ -844,13 +843,17 @@ extern "C" SkV4 C_SkM44_map(const SkM44* self, float x, float y, float z, float 
     return self->map(x, y, z, w);
 }
 
+/*
 extern "C" void C_Sk3LookAt(const SkV3* eye, const SkV3* center, const SkV3* up, SkM44* uninitialized) {
     new(uninitialized) SkM44(Sk3LookAt(*eye, *center, *up));
 }
+*/
 
+/*
 extern "C" void C_Sk3Perspective(float near, float far, float angle, SkM44* uninitialized) {
     new(uninitialized) SkM44(Sk3Perspective(near, far, angle));
 }
+*/
 
 //
 // SkMatrix44
@@ -1139,7 +1142,6 @@ extern "C" int C_SkFontStyle_width(const SkFontStyle* self) {
 extern "C" SkFontStyle::Slant C_SkFontStyle_slant(const SkFontStyle* self) {
     return self->slant();
 }
-
 
 //
 // SkTextBlob

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -414,10 +414,6 @@ extern "C" bool C_SkPaint_Equals(const SkPaint* lhs, const SkPaint* rhs) {
     return *lhs == *rhs;
 }
 
-extern "C" SkFilterQuality C_SkPaint_getFilterQuality(const SkPaint* self) {
-    return self->getFilterQuality();
-}
-
 extern "C" SkPaint::Style C_SkPaint_getStyle(const SkPaint* self) {
     return self->getStyle();
 }

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -831,6 +831,14 @@ extern "C" bool C_SkM44_equals(const SkM44 *self, const SkM44 *other) {
     return *self == *other;
 }
 
+extern "C" void C_SkM44_LookAt(const SkV3* eye, const SkV3* center, const SkV3* up, SkM44* uninitialized) {
+    new(uninitialized) SkM44(SkM44::LookAt(*eye, *center, *up));
+}
+
+extern "C" void C_SkM44_Perspective(float near, float far, float angle, SkM44* uninitialized) {
+    new(uninitialized) SkM44(SkM44::Perspective(near, far, angle));
+}
+
 extern "C" void C_SkM44_transpose(const SkM44* self, SkM44* uninitialized) {
     new(uninitialized) SkM44(self->transpose());
 }
@@ -838,18 +846,6 @@ extern "C" void C_SkM44_transpose(const SkM44* self, SkM44* uninitialized) {
 extern "C" SkV4 C_SkM44_map(const SkM44* self, float x, float y, float z, float w) {
     return self->map(x, y, z, w);
 }
-
-/*
-extern "C" void C_Sk3LookAt(const SkV3* eye, const SkV3* center, const SkV3* up, SkM44* uninitialized) {
-    new(uninitialized) SkM44(Sk3LookAt(*eye, *center, *up));
-}
-*/
-
-/*
-extern "C" void C_Sk3Perspective(float near, float far, float angle, SkM44* uninitialized) {
-    new(uninitialized) SkM44(Sk3Perspective(near, far, angle));
-}
-*/
 
 //
 // SkMatrix44

--- a/skia-bindings/src/gpu.cpp
+++ b/skia-bindings/src/gpu.cpp
@@ -225,6 +225,10 @@ extern "C" void C_GrDirectContext_compressedBackendFormat(const GrDirectContext*
     *result = self->compressedBackendFormat(compression);
 }
 
+extern "C" void C_GrDirectContext_directContextId(const GrDirectContext* self, GrDirectContext::DirectContextID* r) {
+    *r = self->directContextID();
+}
+
 extern "C" void C_GrDirectContext_performDeferredCleanup(GrDirectContext* self, long msNotUsed) {
     self->performDeferredCleanup(std::chrono::milliseconds(msNotUsed));
 }

--- a/skia-bindings/src/paragraph.cpp
+++ b/skia-bindings/src/paragraph.cpp
@@ -73,6 +73,10 @@ extern "C" {
         self->setDefaultFontManager(spFromConst(fontManager), defaultFamilyName);
     }
 
+    void C_FontCollection_setDefaultFontManager3(FontCollection* self, const SkFontMgr* fontManager, const SkStrings* familyNames) {
+        self->setDefaultFontManager(spFromConst(fontManager), familyNames->strings);
+    }
+
     SkFontMgr* C_FontCollection_getFallbackManager(const FontCollection* self) {
         return self->getFallbackManager().release();
     }

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.39.2"
+version = "0.40.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -42,7 +42,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 [dependencies]
 bitflags = "1.2"
 lazy_static = "1.4"
-skia-bindings = { version = "=0.39.2", path = "../skia-bindings" }
+skia-bindings = { version = "=0.40.0", path = "../skia-bindings" }
 # for d3d types
 winapi = { version = "0.3.9", features = ["d3d12", "dxgi"], optional = true }
 # for ComPtr

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -141,13 +141,8 @@ fn test_canvas_point_mode_naming() {
 }
 
 /// [`SrcRectConstraint`] controls the behavior at the edge of source [`Rect`], provided to
-/// [`Canvas::draw_image_rect()`], trading off speed for precision.
-///
-/// [`crate::FilterQuality`] in [`Paint`] may sample multiple pixels in the image. Source [`Rect`]
-/// restricts the bounds of pixels that may be read. [`crate::FilterQuality`] may slow down if it
-/// cannot read outside the bounds, when sampling near the edge of source [`Rect`].
-/// [`SrcRectConstraint`] specifies whether an [`ImageFilter`] is allowed to read pixels outside
-/// source [`Rect`].
+/// [`Canvas::draw_image_rect()`] when there is any filtering. If kStrict is set, then extra code is
+/// used to ensure it nevers samples outside of the src-rect.
 pub use sb::SkCanvas_SrcRectConstraint as SrcRectConstraint;
 
 #[test]

--- a/skia-safe/src/core/color_filter.rs
+++ b/skia-safe/src/core/color_filter.rs
@@ -2,11 +2,13 @@ use crate::{prelude::*, scalar, BlendMode, Color, Color4f, ColorSpace, NativeFla
 use skia_bindings::{self as sb, SkColorFilter, SkFlattenable, SkRefCntBase};
 use std::fmt;
 
+/*
 bitflags! {
     pub struct Flags: u32 {
         const ALPHA_UNCHANGED = sb::SkColorFilter_Flags_kAlphaUnchanged_Flag as u32;
     }
 }
+*/
 
 pub type ColorFilter = RCHandle<SkColorFilter>;
 unsafe impl Send for ColorFilter {}
@@ -56,9 +58,11 @@ impl ColorFilter {
     // TODO: appendStages()
     // TODO: program()
 
+    /*
     pub fn flags(&self) -> self::Flags {
         Flags::from_bits_truncate(unsafe { self.native().getFlags() })
     }
+    */
 
     pub fn is_alpha_unchanged(&self) -> bool {
         unsafe { self.native().isAlphaUnchanged() }

--- a/skia-safe/src/core/color_filter.rs
+++ b/skia-safe/src/core/color_filter.rs
@@ -2,14 +2,6 @@ use crate::{prelude::*, scalar, BlendMode, Color, Color4f, ColorSpace, NativeFla
 use skia_bindings::{self as sb, SkColorFilter, SkFlattenable, SkRefCntBase};
 use std::fmt;
 
-/*
-bitflags! {
-    pub struct Flags: u32 {
-        const ALPHA_UNCHANGED = sb::SkColorFilter_Flags_kAlphaUnchanged_Flag as u32;
-    }
-}
-*/
-
 pub type ColorFilter = RCHandle<SkColorFilter>;
 unsafe impl Send for ColorFilter {}
 unsafe impl Sync for ColorFilter {}
@@ -37,7 +29,7 @@ impl fmt::Debug for ColorFilter {
         f.debug_struct("ColorFilter")
             .field("as_a_color_mode", &self.to_a_color_mode())
             .field("as_a_color_matrix", &self.to_a_color_matrix())
-            .field("flags", &self.flags())
+            .field("is_alpha_unchanged", &self.is_alpha_unchanged())
             .finish()
     }
 }
@@ -54,15 +46,6 @@ impl ColorFilter {
         let mut matrix: [scalar; 20] = Default::default();
         unsafe { self.native().asAColorMatrix(&mut matrix[0]) }.if_true_some(matrix)
     }
-
-    // TODO: appendStages()
-    // TODO: program()
-
-    /*
-    pub fn flags(&self) -> self::Flags {
-        Flags::from_bits_truncate(unsafe { self.native().getFlags() })
-    }
-    */
 
     pub fn is_alpha_unchanged(&self) -> bool {
         unsafe { self.native().isAlphaUnchanged() }
@@ -94,9 +77,6 @@ impl ColorFilter {
             sb::C_SkColorFilter_makeComposed(self.native(), inner.into().into_ptr())
         })
     }
-
-    // TODO: asFragmentProcessor()
-    // TODO: affectsTransparentBlack()
 }
 
 pub mod color_filters {

--- a/skia-safe/src/core/filter_quality.rs
+++ b/skia-safe/src/core/filter_quality.rs
@@ -1,6 +1,11 @@
 pub use skia_bindings::SkFilterQuality as FilterQuality;
 
-#[test]
-fn test_filter_quality_naming() {
-    let _ = FilterQuality::High;
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_filter_quality_naming() {
+        let _ = FilterQuality::High;
+    }
 }

--- a/skia-safe/src/core/graphics.rs
+++ b/skia-safe/src/core/graphics.rs
@@ -29,13 +29,17 @@ pub fn set_font_cache_count_limit(count: i32) -> i32 {
     unsafe { SkGraphics::SetFontCacheCountLimit(count) }
 }
 
+/*
 pub fn font_cache_point_size_limit() -> i32 {
     unsafe { SkGraphics::GetFontCachePointSizeLimit() }
 }
+*/
 
+/*
 pub fn set_font_cache_point_size_limit(max_point_size: i32) -> i32 {
     unsafe { SkGraphics::SetFontCachePointSizeLimit(max_point_size) }
 }
+*/
 
 pub fn purge_font_cache() {
     unsafe { SkGraphics::PurgeFontCache() }

--- a/skia-safe/src/core/graphics.rs
+++ b/skia-safe/src/core/graphics.rs
@@ -29,18 +29,6 @@ pub fn set_font_cache_count_limit(count: i32) -> i32 {
     unsafe { SkGraphics::SetFontCacheCountLimit(count) }
 }
 
-/*
-pub fn font_cache_point_size_limit() -> i32 {
-    unsafe { SkGraphics::GetFontCachePointSizeLimit() }
-}
-*/
-
-/*
-pub fn set_font_cache_point_size_limit(max_point_size: i32) -> i32 {
-    unsafe { SkGraphics::SetFontCachePointSizeLimit(max_point_size) }
-}
-*/
-
 pub fn purge_font_cache() {
     unsafe { SkGraphics::PurgeFontCache() }
 }

--- a/skia-safe/src/core/m44.rs
+++ b/skia-safe/src/core/m44.rs
@@ -757,15 +757,19 @@ impl M44 {
         self
     }
 
+    /*
     pub fn look_at(eye: &V3, center: &V3, up: &V3) -> Self {
         Self::construct(|m| unsafe {
             sb::C_Sk3LookAt(eye.native(), center.native(), up.native(), m)
         })
     }
+    */
 
+    /*
     pub fn perspective(near: f32, far: f32, angle: f32) -> Self {
         Self::construct(|m| unsafe { sb::C_Sk3Perspective(near, far, angle, m) })
     }
+    */
 
     // helper
 

--- a/skia-safe/src/core/m44.rs
+++ b/skia-safe/src/core/m44.rs
@@ -520,6 +520,16 @@ impl M44 {
         m
     }
 
+    pub fn look_at(eye: &V3, center: &V3, up: &V3) -> Self {
+        Self::construct(|m| unsafe {
+            sb::C_SkM44_LookAt(eye.native(), center.native(), up.native(), m)
+        })
+    }
+
+    pub fn perspective(near: f32, far: f32, angle: f32) -> Self {
+        Self::construct(|m| unsafe { sb::C_SkM44_Perspective(near, far, angle, m) })
+    }
+
     pub fn get_col_major(&self, v: &mut [scalar; Self::COMPONENTS]) {
         v.copy_from_slice(&self.mat)
     }
@@ -756,20 +766,6 @@ impl M44 {
         unsafe { self.native_mut().preScale(x, y) };
         self
     }
-
-    /*
-    pub fn look_at(eye: &V3, center: &V3, up: &V3) -> Self {
-        Self::construct(|m| unsafe {
-            sb::C_Sk3LookAt(eye.native(), center.native(), up.native(), m)
-        })
-    }
-    */
-
-    /*
-    pub fn perspective(near: f32, far: f32, angle: f32) -> Self {
-        Self::construct(|m| unsafe { sb::C_Sk3Perspective(near, far, angle, m) })
-    }
-    */
 
     // helper
 

--- a/skia-safe/src/core/milestone.rs
+++ b/skia-safe/src/core/milestone.rs
@@ -1,1 +1,1 @@
-pub const MILESTONE: usize = 90;
+pub const MILESTONE: usize = 91;

--- a/skia-safe/src/core/paint.rs
+++ b/skia-safe/src/core/paint.rs
@@ -131,11 +131,13 @@ impl Paint {
         unsafe { sb::C_SkPaint_getFilterQuality(self.native()) }
     }
 
-    #[deprecated(since = "0.38.0")]
-    pub fn set_filter_quality(&mut self, quality: FilterQuality) -> &mut Self {
-        unsafe { self.native_mut().setFilterQuality(quality) }
-        self
-    }
+    /*
+        #[deprecated(since = "0.38.0")]
+        pub fn set_filter_quality(&mut self, quality: FilterQuality) -> &mut Self {
+            unsafe { self.native_mut().setFilterQuality(quality) }
+            self
+        }
+    */
 
     pub fn style(&self) -> Style {
         unsafe { sb::C_SkPaint_getStyle(self.native()) }

--- a/skia-safe/src/core/paint.rs
+++ b/skia-safe/src/core/paint.rs
@@ -1,6 +1,6 @@
 use crate::{
-    prelude::*, scalar, BlendMode, Color, Color4f, ColorFilter, ColorSpace, FilterQuality,
-    ImageFilter, MaskFilter, Path, PathEffect, Rect, Shader,
+    prelude::*, scalar, BlendMode, Color, Color4f, ColorFilter, ColorSpace, ImageFilter,
+    MaskFilter, Path, PathEffect, Rect, Shader,
 };
 use core::fmt;
 use skia_bindings::{self as sb, SkPaint};
@@ -64,7 +64,6 @@ impl fmt::Debug for Paint {
         f.debug_struct("Paint")
             .field("is_anti_alias", &self.is_anti_alias())
             .field("is_dither", &self.is_dither())
-            .field("filter_quality", &self.filter_quality())
             .field("style", &self.style())
             .field("color", &self.color4f())
             .field("stroke_width", &self.stroke_width())
@@ -126,18 +125,6 @@ impl Paint {
         }
         self
     }
-
-    pub fn filter_quality(&self) -> FilterQuality {
-        unsafe { sb::C_SkPaint_getFilterQuality(self.native()) }
-    }
-
-    /*
-        #[deprecated(since = "0.38.0")]
-        pub fn set_filter_quality(&mut self, quality: FilterQuality) -> &mut Self {
-            unsafe { self.native_mut().setFilterQuality(quality) }
-            self
-        }
-    */
 
     pub fn style(&self) -> Style {
         unsafe { sb::C_SkPaint_getStyle(self.native()) }

--- a/skia-safe/src/core/text_blob.rs
+++ b/skia-safe/src/core/text_blob.rs
@@ -177,14 +177,14 @@ impl TextBlobBuilder {
     ) -> &mut [GlyphId] {
         let offset = offset.into();
         unsafe {
-            let buffer = self.native_mut().allocRun(
+            let buffer = &*self.native_mut().allocRun(
                 font.native(),
                 count.try_into().unwrap(),
                 offset.x,
                 offset.y,
                 bounds.native_ptr_or_null(),
             );
-            safer::from_raw_parts_mut((*buffer).glyphs, count)
+            safer::from_raw_parts_mut(buffer.glyphs, count)
         }
     }
 
@@ -196,15 +196,15 @@ impl TextBlobBuilder {
         bounds: Option<&Rect>,
     ) -> (&mut [GlyphId], &mut [scalar]) {
         unsafe {
-            let buffer = self.native_mut().allocRunPosH(
+            let buffer = &*self.native_mut().allocRunPosH(
                 font.native(),
                 count.try_into().unwrap(),
                 y,
                 bounds.native_ptr_or_null(),
             );
             (
-                safer::from_raw_parts_mut((*buffer).glyphs, count),
-                safer::from_raw_parts_mut((*buffer).pos, count),
+                safer::from_raw_parts_mut(buffer.glyphs, count),
+                safer::from_raw_parts_mut(buffer.pos, count),
             )
         }
     }
@@ -216,14 +216,14 @@ impl TextBlobBuilder {
         bounds: Option<&Rect>,
     ) -> (&mut [GlyphId], &mut [Point]) {
         unsafe {
-            let buffer = self.native_mut().allocRunPos(
+            let buffer = &*self.native_mut().allocRunPos(
                 font.native(),
                 count.try_into().unwrap(),
                 bounds.native_ptr_or_null(),
             );
             (
-                safer::from_raw_parts_mut((*buffer).glyphs, count),
-                safer::from_raw_parts_mut((*buffer).pos as *mut Point, count),
+                safer::from_raw_parts_mut(buffer.glyphs, count),
+                safer::from_raw_parts_mut(buffer.pos as *mut Point, count),
             )
         }
     }
@@ -234,17 +234,112 @@ impl TextBlobBuilder {
         count: usize,
     ) -> (&mut [GlyphId], &mut [RSXform]) {
         unsafe {
-            let buffer = self
+            let buffer = &*self
                 .native_mut()
                 .allocRunRSXform(font.native(), count.try_into().unwrap());
             (
-                safer::from_raw_parts_mut((*buffer).glyphs, count),
-                safer::from_raw_parts_mut((*buffer).pos as *mut RSXform, count),
+                safer::from_raw_parts_mut(buffer.glyphs, count),
+                safer::from_raw_parts_mut(buffer.pos as *mut RSXform, count),
             )
         }
     }
 
-    // TODO: allocRunText, allocRunTextPosH, allocRunTextPos, allocRunTextRSXform
+    pub fn alloc_run_text(
+        &mut self,
+        font: &Font,
+        count: usize,
+        offset: impl Into<Point>,
+        text_byte_count: usize,
+        bounds: Option<&Rect>,
+    ) -> (&mut [GlyphId], &mut [u8], &mut [u32]) {
+        let offset = offset.into();
+        unsafe {
+            let buffer = &*self.native_mut().allocRunText(
+                font.native(),
+                count.try_into().unwrap(),
+                offset.x,
+                offset.y,
+                text_byte_count.try_into().unwrap(),
+                bounds.native_ptr_or_null(),
+            );
+            (
+                safer::from_raw_parts_mut(buffer.glyphs, count),
+                safer::from_raw_parts_mut(buffer.utf8text as *mut u8, text_byte_count),
+                safer::from_raw_parts_mut(buffer.clusters, count),
+            )
+        }
+    }
+
+    pub fn alloc_run_text_pos_h(
+        &mut self,
+        font: &Font,
+        count: usize,
+        y: scalar,
+        text_byte_count: usize,
+        bounds: Option<&Rect>,
+    ) -> (&mut [GlyphId], &mut [scalar], &mut [u8], &mut [u32]) {
+        unsafe {
+            let buffer = &*self.native_mut().allocRunTextPosH(
+                font.native(),
+                count.try_into().unwrap(),
+                y,
+                text_byte_count.try_into().unwrap(),
+                bounds.native_ptr_or_null(),
+            );
+            (
+                safer::from_raw_parts_mut(buffer.glyphs, count),
+                safer::from_raw_parts_mut(buffer.pos, count),
+                safer::from_raw_parts_mut(buffer.utf8text as *mut u8, text_byte_count),
+                safer::from_raw_parts_mut(buffer.clusters, count),
+            )
+        }
+    }
+
+    pub fn alloc_run_text_pos(
+        &mut self,
+        font: &Font,
+        count: usize,
+        text_byte_count: usize,
+        bounds: Option<&Rect>,
+    ) -> (&mut [GlyphId], &mut [Point], &mut [u8], &mut [u32]) {
+        unsafe {
+            let buffer = &*self.native_mut().allocRunTextPos(
+                font.native(),
+                count.try_into().unwrap(),
+                text_byte_count.try_into().unwrap(),
+                bounds.native_ptr_or_null(),
+            );
+            (
+                safer::from_raw_parts_mut(buffer.glyphs, count),
+                safer::from_raw_parts_mut(buffer.pos as *mut Point, count),
+                safer::from_raw_parts_mut(buffer.utf8text as *mut u8, text_byte_count),
+                safer::from_raw_parts_mut(buffer.clusters, count),
+            )
+        }
+    }
+
+    pub fn alloc_run_text_rsxform(
+        &mut self,
+        font: &Font,
+        count: usize,
+        text_byte_count: usize,
+        bounds: Option<&Rect>,
+    ) -> (&mut [GlyphId], &mut [RSXform], &mut [u8], &mut [u32]) {
+        unsafe {
+            let buffer = &*self.native_mut().allocRunTextPos(
+                font.native(),
+                count.try_into().unwrap(),
+                text_byte_count.try_into().unwrap(),
+                bounds.native_ptr_or_null(),
+            );
+            (
+                safer::from_raw_parts_mut(buffer.glyphs, count),
+                safer::from_raw_parts_mut(buffer.pos as *mut RSXform, count),
+                safer::from_raw_parts_mut(buffer.utf8text as *mut u8, text_byte_count),
+                safer::from_raw_parts_mut(buffer.clusters, count),
+            )
+        }
+    }
 }
 
 pub type TextBlobIter<'a> = Borrows<'a, Handle<SkTextBlob_Iter>>;

--- a/skia-safe/src/effects/runtime_effect.rs
+++ b/skia-safe/src/effects/runtime_effect.rs
@@ -117,9 +117,10 @@ impl NativeRefCountedBase for SkRuntimeEffect {
     type Base = SkRefCntBase;
 }
 
+#[repr(C)]
 #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
 pub struct Options {
-    pub inline_threshold: i32,
+    pub force_no_inline: bool,
 }
 
 impl NativeTransmutable<SkRuntimeEffect_Options> for Options {}
@@ -153,7 +154,7 @@ impl fmt::Debug for RuntimeEffect {
 
 impl RuntimeEffect {
     pub fn make_shader<'a>(
-        &mut self,
+        &self,
         uniforms: impl Into<Data>,
         children: impl IntoIterator<Item = Shader>,
         local_matrix: impl Into<Option<&'a Matrix>>,
@@ -165,7 +166,7 @@ impl RuntimeEffect {
             .collect();
         Shader::from_ptr(unsafe {
             sb::C_SkRuntimeEffect_makeShader(
-                self.native_mut(),
+                self.native(),
                 uniforms.into().into_ptr(),
                 children.as_mut_ptr(),
                 children.len(),
@@ -177,7 +178,7 @@ impl RuntimeEffect {
 
     #[cfg(feature = "gpu")]
     pub fn make_image<'a>(
-        &mut self,
+        &self,
         context: &mut crate::gpu::RecordingContext,
         uniforms: impl Into<Data>,
         children: impl IntoIterator<Item = Shader>,
@@ -192,7 +193,7 @@ impl RuntimeEffect {
 
         crate::Image::from_ptr(unsafe {
             sb::C_SkRuntimeEffect_makeImage(
-                self.native_mut(),
+                self.native(),
                 context.native_mut(),
                 uniforms.into().into_ptr(),
                 children.as_mut_ptr(),
@@ -204,28 +205,14 @@ impl RuntimeEffect {
         })
     }
 
-    #[deprecated(since = "0.33.0", note = "removed without replacement")]
-    pub fn make_color_filter_with_children(
-        &mut self,
-        _inputs: impl Into<Data>,
-        _children: impl IntoIterator<Item = ColorFilter>,
-    ) -> ! {
-        panic!("removed without replacement")
-    }
-
-    pub fn make_color_filter(&mut self, inputs: impl Into<Data>) -> Option<ColorFilter> {
+    pub fn make_color_filter(&self, inputs: impl Into<Data>) -> Option<ColorFilter> {
         ColorFilter::from_ptr(unsafe {
-            sb::C_SkRuntimeEffect_makeColorFilter(self.native_mut(), inputs.into().into_ptr())
+            sb::C_SkRuntimeEffect_makeColorFilter(self.native(), inputs.into().into_ptr())
         })
     }
 
     pub fn source(&self) -> &str {
         unsafe { (*sb::C_SkRuntimeEffect_source(self.native())).as_str() }
-    }
-
-    #[deprecated(since = "0.29.0", note = "removed without replacement")]
-    pub fn index(&self) -> ! {
-        unimplemented!("removed without replacement")
     }
 
     #[deprecated(since = "0.35.0", note = "Use uniform_size() instead")]
@@ -288,7 +275,7 @@ impl RuntimeEffect {
     }
 }
 
-// TODO: wrap SkRuntimeShaderBuilder
+// TODO: wrap SkRuntimeEffectBuilder, SkRuntimeShaderBuilder
 
 #[cfg(test)]
 mod tests {

--- a/skia-safe/src/gpu/context_options.rs
+++ b/skia-safe/src/gpu/context_options.rs
@@ -36,6 +36,7 @@ pub struct ContextOptions {
     pub max_cached_vulkan_secondary_command_buffers: raw::c_int,
     pub suppress_mipmap_support: bool,
     pub driver_bug_workarounds: DriverBugWorkarounds,
+    pub enable_experimental_hardware_tessellation: bool,
 }
 unsafe impl Send for ContextOptions {}
 unsafe impl Sync for ContextOptions {}

--- a/skia-safe/src/gpu/direct_context.rs
+++ b/skia-safe/src/gpu/direct_context.rs
@@ -9,13 +9,21 @@ use super::{
     FlushInfo, RecordingContext, SemaphoresSubmitted,
 };
 use crate::{image, prelude::*, Data};
-use skia_bindings::{self as sb, GrDirectContext, SkRefCntBase};
+use skia_bindings::{self as sb, GrDirectContext, GrDirectContext_DirectContextID, SkRefCntBase};
 use std::{
     fmt,
     ops::{Deref, DerefMut},
     ptr,
     time::Duration,
 };
+
+#[repr(C)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct DirectContextId {
+    id: u32,
+}
+
+impl NativeTransmutable<GrDirectContext_DirectContextID> for DirectContextId {}
 
 pub type DirectContext = RCHandle<GrDirectContext>;
 
@@ -373,5 +381,21 @@ impl DirectContext {
             self.native_mut()
                 .precompileShader(key.native(), data.native())
         }
+    }
+
+    pub fn id(&self) -> DirectContextId {
+        let mut id = DirectContextId { id: 0 };
+        unsafe { sb::C_GrDirectContext_directContextId(self.native(), id.native_mut()) }
+        id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_direct_context_id_layout() {
+        DirectContextId::test_layout();
     }
 }

--- a/skia-safe/src/gpu/gl/types.rs
+++ b/skia-safe/src/gpu/gl/types.rs
@@ -80,7 +80,6 @@ bitflags! {
         const PROGRAM = sb::GrGLBackendState_kProgram_GrGLBackendState as _;
         const FIXED_FUNCTION = sb::GrGLBackendState_kFixedFunction_GrGLBackendState as _;
         const MISC = sb::GrGLBackendState_kMisc_GrGLBackendState as _;
-        // const PATH_RENDERING = sb::GrGLBackendState_kPathRendering_GrGLBackendState as _;
     }
 }
 

--- a/skia-safe/src/gpu/gl/types.rs
+++ b/skia-safe/src/gpu/gl/types.rs
@@ -80,7 +80,7 @@ bitflags! {
         const PROGRAM = sb::GrGLBackendState_kProgram_GrGLBackendState as _;
         const FIXED_FUNCTION = sb::GrGLBackendState_kFixedFunction_GrGLBackendState as _;
         const MISC = sb::GrGLBackendState_kMisc_GrGLBackendState as _;
-        const PATH_RENDERING = sb::GrGLBackendState_kPathRendering_GrGLBackendState as _;
+        // const PATH_RENDERING = sb::GrGLBackendState_kPathRendering_GrGLBackendState as _;
     }
 }
 

--- a/skia-safe/src/modules/paragraph/font_collection.rs
+++ b/skia-safe/src/modules/paragraph/font_collection.rs
@@ -68,12 +68,12 @@ impl FontCollection {
         let font_manager = font_manager.into();
         unsafe {
             match default_family_name.into() {
-                Some(fname) => {
-                    let fname = ffi::CString::new(fname).unwrap();
+                Some(name) => {
+                    let name = ffi::CString::new(name).unwrap();
                     sb::C_FontCollection_setDefaultFontManager2(
                         self.native_mut(),
                         font_manager.into_ptr_or_null(),
-                        fname.as_ptr(),
+                        name.as_ptr(),
                     )
                 }
                 None => sb::C_FontCollection_setDefaultFontManager(
@@ -81,6 +81,22 @@ impl FontCollection {
                     font_manager.into_ptr_or_null(),
                 ),
             }
+        }
+    }
+
+    pub fn set_default_font_manager_and_family_names(
+        &mut self,
+        font_manager: impl Into<Option<FontMgr>>,
+        family_names: &[impl AsRef<str>],
+    ) {
+        let font_manager = font_manager.into();
+        let family_names = interop::Strings::from_strs(family_names);
+        unsafe {
+            sb::C_FontCollection_setDefaultFontManager3(
+                self.native_mut(),
+                font_manager.into_ptr_or_null(),
+                family_names.native(),
+            )
         }
     }
 

--- a/skia-safe/tests/send_sync.rs
+++ b/skia-safe/tests/send_sync.rs
@@ -161,6 +161,7 @@ mod gpu {
     // can be supported.
     // If RC is 1, it can be sent to other threads with `Sendable` / `ConditionallySend`.
     assert_not_impl_any!(DirectContext: Send, Sync);
+    assert_impl_all!(DirectContextId: Send, Sync);
     assert_not_impl_any!(RecordingContext: Send, Sync);
     // gpu/yuva_backend_textures.rs
     assert_impl_all!(YUVABackendTextureInfo: Send, Sync);


### PR DESCRIPTION
This PR updates rust-skia to support Skia's `chrome/m91` branch.

- [x] Update `README.md` ([rendered](https://github.com/pragmatrix/rust-skia/blob/m91/README.md))  
  > Most important here is to change the Skia branch name and the current Skia submodule tag at the top of the `README.md` file.
- [x] Diff the the following files to see if the build organization has changed significantly:
  - [x] `/BUILD.gn`
  - [x] `/modules/skshaper/BUILD.gn`
  - [x] `/modules/paragraph/BUILD.gn`
- [x] Skia builds ([release notes](https://github.com/google/skia/blob/chrome/m91/RELEASE_NOTES.txt)).
- [x] `/skia-bindings` builds.
- [x] `/skia-safe`: Update & add new wrappers by diffing include files.  
  > Add TODOs for everything that can not be updated right now, and attempt to stay compatible with previous versions of skia-safe without trying too hard before version 1.0. Use `deprecated` attributes if needed.
  - [x] `codec/`
  - [x] `core/`
  - [x] `docs/`
  - [x] `effects/`
  - [x] `gpu/`
    - [x] `d3d/`
    - [x] `gl/`
    - [x] `mtl/`
    - [x] `vk/`
  - [x] `modules/`
    - [x] `paragraph/`
    - [x] `shaper/`
  - [x] `pathops/`
  - [x] `svg/`
  - [x] `utils/`
- [x] Review `Send` & `Sync` implementations for new wrappers.
- [x] Review `Debug` implementation for new wrapper types and functions.
- [x] Any pending changes in the Skia `chrome/m91` branch that aren't synchronized yet?
- [x] Rebase on or merge with master.
- [x] Update versions of `skia-bindings/Cargo.toml` and `skia-safe/Cargo.toml` and also add the version to the new `deprecated` attributes.
- [x] Do the tags/hashes in `skia-bindings/Cargo.toml` under `[package.metadata]` match the submodules `depot_tools` and `skia`?
- [x] Builds with `RUSTFLAGS=-Clink-dead-code` on Windows (#318):
  ```bash
  RUSTFLAGS=-Clink-dead-code cd skia-org && cargo build -vv --features gl,vulkan,d3d,textlayout,webp
  ```
- [x] Do one final review of all the changes.
