### PR TITLE
Allow jpeg-turbo as a -sys library

### DIFF
--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -48,11 +48,15 @@ textlayout = []
 webp = ["webp-encode", "webp-decode"]
 webp-encode = []
 webp-decode = []
+# sys libraries
+use-system-jpeg-turbo = ["mozjpeg-sys"]
 # deprecated since 0.25.0
 svg = []
 shaper = ["textlayout"]
 
 [dependencies]
+
+mozjpeg-sys = { version = "0", features=["with_simd"], optional=true }
 
 [build-dependencies]
 cc = "1.0.37"

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -295,7 +295,10 @@ impl FinalBuildConfiguration {
                 cflags.extend(jpeg_sys_cflags.iter().map(|x| -> &str { x.as_ref() }));
                 args.push(("skia_use_system_libjpeg_turbo", yes()));
             } else {
-                args.push(("skia_use_system_libjpeg_turbo", no()));
+                args.push((
+                    "skia_use_system_libjpeg_turbo",
+                    yes_if(use_system_libraries),
+                ));
             }
 
             if let Some(opt_level) = &build.opt_level {

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -505,7 +505,9 @@ impl BinariesConfiguration {
         let feature_ids = features.ids();
 
         if features.text_layout {
-            additional_files.push(ICUDTL_DAT.into());
+            if target.is_windows() {
+                additional_files.push(ICUDTL_DAT.into());
+            }
             built_libraries.push(lib::SK_PARAGRAPH.into());
             built_libraries.push(lib::SK_SHAPER.into());
         }

--- a/skia-bindings/build_support/skia.rs
+++ b/skia-bindings/build_support/skia.rs
@@ -216,10 +216,6 @@ impl FinalBuildConfiguration {
                 ("skia_use_gl", yes_if(features.gl)),
                 ("skia_use_egl", yes_if(features.egl)),
                 ("skia_use_x11", yes_if(features.x11)),
-                (
-                    "skia_use_system_libjpeg_turbo",
-                    yes_if(use_system_libraries),
-                ),
                 ("skia_use_system_libpng", yes_if(use_system_libraries)),
                 ("skia_use_libwebp_encode", yes_if(features.webp_encode)),
                 ("skia_use_libwebp_decode", yes_if(features.webp_decode)),
@@ -288,6 +284,18 @@ impl FinalBuildConfiguration {
             if let Some(sysroot) = cargo::env_var("SDKROOT") {
                 sysroot_arg = format!("--sysroot={}", sysroot);
                 cflags.push(&sysroot_arg);
+            }
+
+            let jpeg_sys_cflags: Vec<String>;
+            if cfg!(feature = "use-system-jpeg-turbo") {
+                let paths = cargo::env_var("DEP_JPEG_INCLUDE").expect("mozjpeg-sys include path");
+                jpeg_sys_cflags = std::env::split_paths(&paths)
+                    .map(|arg| format!("-I{}", arg.display()))
+                    .collect();
+                cflags.extend(jpeg_sys_cflags.iter().map(|x| -> &str { x.as_ref() }));
+                args.push(("skia_use_system_libjpeg_turbo", yes()));
+            } else {
+                args.push(("skia_use_system_libjpeg_turbo", no()));
             }
 
             if let Some(opt_level) = &build.opt_level {
@@ -691,7 +699,13 @@ pub fn build_skia(
     config: &BinariesConfiguration,
     ninja_command: &Path,
 ) {
+    // Libraries we explicitly want ninja to build.
+    let ninja_built_libraries = config
+        .built_libraries
+        .iter()
+        .filter(|x| *x != lib::SKIA_BINDINGS);
     let ninja_status = Command::new(ninja_command)
+        .args(ninja_built_libraries)
         .args(&["-C", config.output_directory.to_str().unwrap()])
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())

--- a/skia-bindings/src/lib.rs
+++ b/skia-bindings/src/lib.rs
@@ -13,3 +13,7 @@ pub use impls::*;
 
 #[cfg(feature = "textlayout")]
 pub mod icu;
+
+#[doc(hidden)]
+#[cfg(feature = "use-system-jpeg-turbo")]
+use mozjpeg_sys;


### PR DESCRIPTION
Hey,

I was having some issues where I had two `-sys` libraries which were both linking `-ljpeg`, leading to duplicate symbol linker errors. I think that `rust-skia` normally detects the problem if `build.rs` has `cargo:rustc-link-lib=jpeg`, but I'm not sure.

Anyway, I think I fixed the issue and I think it's a nicer solution. It fixes it by adding a libjpeg sys crate, and allowing skia to use it instead. I think this is a good solution as it avoids unnecessary compilation, and allows you to interoperate with the same libjpeg library.

I think it'd be really nice if all the skia third-party dependencies in this repo were slowly moved over to a similar system.

Please let me know if you have any questions, or want any changes (I'm also happy if it's easier for you to make small tweaks to get it merge ready).

**note: I had some azure related issues, so I thought I'd check if this change is desired before trying to fix them**

Thank you!