### PR TITLE
Experiment: remove Skia patch that comments out GR_TEST_UTILS=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m90 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m90-0.38.3...google:chrome/m90
-[skia-ours]: https://github.com/google/skia/compare/chrome/m90...rust-skia:m90-0.38.3
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m90-0.38.4...google:chrome/m90
+[skia-ours]: https://github.com/google/skia/compare/chrome/m90...rust-skia:m90-0.38.4
 
 ## Goals
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m90-0.38.3"
+skia = "m90-0.38.4"
 depot_tools = "a110bf6"
 
 [features]


### PR DESCRIPTION
Since #512, `skia-bindings/build.rs` invokes  `ninja` with an explicit target list of the libraries to build. This should make at least one or two of the [rust-skia specific Skia modifications](https://github.com/google/skia/compare/chrome/m90...rust-skia:m90-0.38.3) redundant. 

This PR tries to find out which of them can be removed.
