### PR TITLE
Build macOS binaries for High Sierra and Mojave (>= 10.13)

### DIFF
--- a/.github/workflows/macos-qa.yaml
+++ b/.github/workflows/macos-qa.yaml
@@ -20,6 +20,7 @@ jobs:
     runs-on: macOS-10.15
     env: 
       SKIA_DEBUG: 0
+      MACOSX_DEPLOYMENT_TARGET: '10.13'
     
     steps:
     - uses: actions/checkout@v2
@@ -257,6 +258,7 @@ jobs:
     runs-on: macOS-10.15
     env: 
       SKIA_DEBUG: 1
+      MACOSX_DEPLOYMENT_TARGET: '10.13'
     
     steps:
     - uses: actions/checkout@v2
@@ -494,6 +496,7 @@ jobs:
     runs-on: macOS-10.15
     env: 
       SKIA_DEBUG: 0
+      MACOSX_DEPLOYMENT_TARGET: '10.13'
     
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/macos-qa.yaml
+++ b/.github/workflows/macos-qa.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: macOS-10.15
     env: 
       SKIA_DEBUG: 0
-      MACOSX_DEPLOYMENT_TARGET: '10.13'
+      MACOSX_DEPLOYMENT_TARGET: '10.14'
     
     steps:
     - uses: actions/checkout@v2
@@ -258,7 +258,7 @@ jobs:
     runs-on: macOS-10.15
     env: 
       SKIA_DEBUG: 1
-      MACOSX_DEPLOYMENT_TARGET: '10.13'
+      MACOSX_DEPLOYMENT_TARGET: '10.14'
     
     steps:
     - uses: actions/checkout@v2
@@ -496,7 +496,7 @@ jobs:
     runs-on: macOS-10.15
     env: 
       SKIA_DEBUG: 0
-      MACOSX_DEPLOYMENT_TARGET: '10.13'
+      MACOSX_DEPLOYMENT_TARGET: '10.14'
     
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/macos-release.yaml
+++ b/.github/workflows/macos-release.yaml
@@ -1681,7 +1681,7 @@ jobs:
     runs-on: macOS-10.15
     env: 
       SKIA_DEBUG: 0
-      MACOSX_DEPLOYMENT_TARGET: '10.13'
+      MACOSX_DEPLOYMENT_TARGET: '10.14'
     
     steps:
     - uses: actions/checkout@v2
@@ -1919,7 +1919,7 @@ jobs:
     runs-on: macOS-10.15
     env: 
       SKIA_DEBUG: 0
-      MACOSX_DEPLOYMENT_TARGET: '10.13'
+      MACOSX_DEPLOYMENT_TARGET: '10.14'
     
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/macos-release.yaml
+++ b/.github/workflows/macos-release.yaml
@@ -15,6 +15,7 @@ jobs:
     runs-on: macOS-10.15
     env: 
       SKIA_DEBUG: 0
+      MACOSX_DEPLOYMENT_TARGET: '10.13'
     
     steps:
     - uses: actions/checkout@v2
@@ -252,6 +253,7 @@ jobs:
     runs-on: macOS-10.15
     env: 
       SKIA_DEBUG: 0
+      MACOSX_DEPLOYMENT_TARGET: '10.13'
     
     steps:
     - uses: actions/checkout@v2
@@ -489,6 +491,7 @@ jobs:
     runs-on: macOS-10.15
     env: 
       SKIA_DEBUG: 0
+      MACOSX_DEPLOYMENT_TARGET: '10.13'
     
     steps:
     - uses: actions/checkout@v2
@@ -726,6 +729,7 @@ jobs:
     runs-on: macOS-10.15
     env: 
       SKIA_DEBUG: 0
+      MACOSX_DEPLOYMENT_TARGET: '10.13'
     
     steps:
     - uses: actions/checkout@v2
@@ -963,6 +967,7 @@ jobs:
     runs-on: macOS-10.15
     env: 
       SKIA_DEBUG: 0
+      MACOSX_DEPLOYMENT_TARGET: '10.13'
     
     steps:
     - uses: actions/checkout@v2
@@ -1200,6 +1205,7 @@ jobs:
     runs-on: macOS-10.15
     env: 
       SKIA_DEBUG: 0
+      MACOSX_DEPLOYMENT_TARGET: '10.13'
     
     steps:
     - uses: actions/checkout@v2
@@ -1437,6 +1443,7 @@ jobs:
     runs-on: macOS-10.15
     env: 
       SKIA_DEBUG: 0
+      MACOSX_DEPLOYMENT_TARGET: '10.13'
     
     steps:
     - uses: actions/checkout@v2
@@ -1674,6 +1681,7 @@ jobs:
     runs-on: macOS-10.15
     env: 
       SKIA_DEBUG: 0
+      MACOSX_DEPLOYMENT_TARGET: '10.13'
     
     steps:
     - uses: actions/checkout@v2
@@ -1911,6 +1919,7 @@ jobs:
     runs-on: macOS-10.15
     env: 
       SKIA_DEBUG: 0
+      MACOSX_DEPLOYMENT_TARGET: '10.13'
     
     steps:
     - uses: actions/checkout@v2

--- a/mk-workflows/src/main.rs
+++ b/mk-workflows/src/main.rs
@@ -97,7 +97,7 @@ fn build_workflow(workflow: &Workflow, jobs: &[Job]) {
         }
 
         {
-            let job_header = build_job(job_template, job).indented(2);
+            let job_header = build_job(workflow, job_template, job, targets).indented(2);
             parts.push(job_header);
         }
 
@@ -131,22 +131,46 @@ fn build_header(workflow_name: &str, workflow_kind: WorkflowKind) -> String {
     render_template(workflow, &replacements)
 }
 
-fn build_job(template: &str, job: &Job) -> String {
+fn build_job(workflow: &Workflow, template: &str, job: &Job, targets: &[Target]) -> String {
     let skia_debug = if job.skia_debug { "1" } else { "0" };
 
-    let replacements = [
+    let mut replacements = vec![
         ("rustToolchain".into(), job.toolchain.into()),
         ("skiaDebug".into(), skia_debug.into()),
     ];
+
+    if let Some(macosx_deployment_target) = macosx_deployment_target(workflow, job, targets) {
+        replacements.push((
+            "macosxDeploymentTarget".into(),
+            macosx_deployment_target.into(),
+        ))
+    }
+
     render_template(template, &replacements)
 }
 
-fn build_target(workflow: &Workflow, job: &Job, target: &Target) -> String {
-    let mut features = job.features.clone();
-    // if we are releasing binaries, we want the exact set of features specified.
-    if workflow.kind == WorkflowKind::QA {
-        features = features.join(&target.platform_features);
+fn macosx_deployment_target(
+    workflow: &Workflow,
+    job: &Job,
+    targets: &[Target],
+) -> Option<&'static str> {
+    if let HostOS::MacOS = workflow.host_os {
+        let metal = "metal".to_owned();
+        if targets
+            .iter()
+            .any(|target| effective_features(workflow, job, target).contains(&metal))
+        {
+            Some("10.14")
+        } else {
+            Some("10.13")
+        }
+    } else {
+        None
     }
+}
+
+fn build_target(workflow: &Workflow, job: &Job, target: &Target) -> String {
+    let features = effective_features(workflow, job, target);
     let native_target = workflow.host_target == target.target;
     let example_args = if native_target {
         job.example_args.clone()
@@ -177,6 +201,15 @@ fn build_target(workflow: &Workflow, job: &Job, target: &Target) -> String {
         .collect();
 
     render_template(TARGET_TEMPLATE, &replacements)
+}
+
+fn effective_features(workflow: &Workflow, job: &Job, target: &Target) -> Features {
+    let mut features = job.features.clone();
+    // if we are releasing binaries, we want the exact set of features specified.
+    if workflow.kind == WorkflowKind::QA {
+        features = features.join(&target.platform_features);
+    }
+    features
 }
 
 fn render_template(template: &str, replacements: &[(String, String)]) -> String {

--- a/mk-workflows/src/templates/macos-job.yaml
+++ b/mk-workflows/src/templates/macos-job.yaml
@@ -1,6 +1,7 @@
 runs-on: macOS-10.15
 env: 
   SKIA_DEBUG: $[[skiaDebug]]
+  MACOSX_DEPLOYMENT_TARGET: '10.13'
 
 steps:
 - uses: actions/checkout@v2

--- a/mk-workflows/src/templates/macos-job.yaml
+++ b/mk-workflows/src/templates/macos-job.yaml
@@ -1,7 +1,7 @@
 runs-on: macOS-10.15
 env: 
   SKIA_DEBUG: $[[skiaDebug]]
-  MACOSX_DEPLOYMENT_TARGET: '10.13'
+  MACOSX_DEPLOYMENT_TARGET: '$[[macosxDeploymentTarget]]'
 
 steps:
 - uses: actions/checkout@v2

--- a/skia-bindings/build_support/skia/config.rs
+++ b/skia-bindings/build_support/skia/config.rs
@@ -224,6 +224,9 @@ impl FinalBuildConfiguration {
                             // version. So we don't push another target `--target` that may
                             // conflict.
                             set_target = false;
+                            // Add macOS specific environment variables that affect the output of a
+                            // build.
+                            cargo::rerun_if_changed("MACOSX_DEPLOYMENT_TARGET");
                             "mac"
                         }
                         "windows" => "win",


### PR DESCRIPTION
This PR sets the environment variable `MACOSX_DEPLOYMENT_TARGET` to `10.13` in the GitHub Actions macOS workflows to see if we can build binaries that are compatible with High Sierra and Mojave.

Closes #538 
