### PR TITLE
Support Windows i686 builds.

### DIFF
--- a/.github/workflows/supplemental-builds.yaml
+++ b/.github/workflows/supplemental-builds.yaml
@@ -84,3 +84,37 @@ jobs:
         cargo build --features gl,vulkan,d3d,textlayout,webp
       env:
         RUSTFLAGS: '-Clink-dead-code'
+
+  windows-x86:
+    runs-on: windows-2019
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Install Rust
+      uses: hecrj/setup-rust-action@master
+      with:
+        rust-version: nightly
+
+    - name: Setup Python 2
+      uses: actions/setup-python@v2
+      with:
+        python-version: '2.7.18'
+        architecture: 'x64'
+
+    - name: Python Version
+      run: python --version
+
+    - name: Install LLVM
+      run: choco install llvm
+
+    - name: 'Install Rust target i686-pc-windows-msvc'
+      shell: bash
+      run: |
+        rustup target add i686-pc-windows-msvc
+    
+    - name: 'Build target i686-pc-windows-msvc (#540)'
+      run: |
+        cargo build --features gl,vulkan,d3d,textlayout,webp --target i686-pc-windows-msvc

--- a/skia-bindings/src/lib.rs
+++ b/skia-bindings/src/lib.rs
@@ -1,3 +1,6 @@
+// 32-bit windows needs `thiscall` support.
+// https://github.com/rust-skia/rust-skia/issues/540
+#![cfg_attr(all(target_os = "windows", target_arch = "x86"), feature(abi_thiscall))]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]


### PR DESCRIPTION
This PR adds build support for Windows i686 / 32-bit platforms on nightly Rust compilers.

- [x] Build works locally.
- [x] Test if the build works on GitHub Actions.
- [ ] Add them to the list of binaries for the `release` branch.

Closes #540 