### PR TITLE
Copy library binaries in local build instead of using the search path…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,9 +98,9 @@ workflows:
 #
 # https://github.com/rust-skia/rust-skia/pull/527
 
-local-build-features=gl,vulkan,webp
+local-build-features=gl,vulkan,webp,textlayout
 
-.PHONY: test-local-build build-local-build prepare-local-build
+.PHONY: test-local-build prepare-local-build build-local-build
 test-local-build: prepare-local-build build-local-build
 
 prepare-local-build:
@@ -108,12 +108,13 @@ prepare-local-build:
 	cargo build --release --features ${local-build-features}
 	rm -rf tmp/
 	mkdir -p tmp/
-	find target -name "libskia*.a" -type f -exec cp {} tmp/ \;
+	find target -name "libsk*.a" -type f -exec cp {} tmp/ \;
 	find target -name "skia-defines.txt" -type f -exec cp {} tmp/ \;
 	# Windows
-	find target -name "skia.lib" -type f -exec cp {} tmp/ \;
+	find target -name "sk*.lib" -type f -exec cp {} tmp/ \;
+	find target -name "icudtl.dat" -type f -exec cp {} tmp/ \;
 
 build-local-build:
 	cargo clean
-	SKIA_SOURCE_DIR=$(shell pwd)/skia-bindings/skia SKIA_BUILD_DEFINES=`cat tmp/skia-defines.txt` SKIA_LIBRARY_SEARCH_PATH=tmp cargo build --release --no-default-features -vv --features ${local-build-features}
+	SKIA_SOURCE_DIR=$(shell pwd)/skia-bindings/skia SKIA_BUILD_DEFINES=`cat tmp/skia-defines.txt` SKIA_LIBRARY_SEARCH_PATH=$(shell pwd)/tmp cargo build --release --no-default-features -vv --features ${local-build-features}
 

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,8 @@ prepare-local-build:
 	# Windows
 	find target -name "sk*.lib" -type f -exec cp {} tmp/ \;
 	find target -name "icudtl.dat" -type f -exec cp {} tmp/ \;
+	# The bindings are expected to be regenerated in a local build.
+	rm tmp/*-bindings.*
 
 build-local-build:
 	cargo clean

--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -1,5 +1,6 @@
-mod build_support;
 use build_support::{binaries_config, cargo, features, skia, skia_bindgen};
+
+mod build_support;
 
 /// Environment variables used by this build script.
 mod env {
@@ -52,7 +53,7 @@ fn generate_bindings(
 ) {
     // Emit the ninja definitions, to help debug build consistency.
     skia_bindgen::definitions::save_definitions(&definitions, &binaries_config.output_directory)
-        .expect("failed to write ninja defines");
+        .expect("failed to write Skia defines");
 
     let bindings_config = skia_bindgen::FinalBuildConfiguration::from_build_configuration(
         features,
@@ -84,7 +85,7 @@ fn main() {
         if let Some(search_path) = env::skia_lib_search_path() {
             println!("STARTING BIND AGAINST SYSTEM SKIA");
 
-            cargo::add_link_search(&search_path.to_str().unwrap());
+            binaries_config.import(&search_path).unwrap();
 
             let definitions = skia_bindgen::definitions::from_env();
             generate_bindings(&features, definitions, &binaries_config, &source_dir);

--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -85,7 +85,7 @@ fn main() {
         if let Some(search_path) = env::skia_lib_search_path() {
             println!("STARTING BIND AGAINST SYSTEM SKIA");
 
-            binaries_config.import(&search_path).unwrap();
+            binaries_config.import(&search_path, false).unwrap();
 
             let definitions = skia_bindgen::definitions::from_env();
             generate_bindings(&features, definitions, &binaries_config, &source_dir);

--- a/skia-bindings/build_support.rs
+++ b/skia-bindings/build_support.rs
@@ -2,6 +2,8 @@
 
 pub mod android;
 pub mod binaries_config;
+#[cfg(feature = "binary-cache")]
+pub mod binary_cache;
 pub mod cargo;
 pub mod clang;
 pub mod features;
@@ -9,6 +11,3 @@ pub mod ios;
 pub mod skia;
 pub mod skia_bindgen;
 pub mod xcode;
-
-#[cfg(feature = "binary-cache")]
-pub mod binary_cache;

--- a/skia-bindings/build_support/binary_cache/binaries.rs
+++ b/skia-bindings/build_support/binary_cache/binaries.rs
@@ -19,7 +19,8 @@ pub fn should_export() -> Option<PathBuf> {
 
 /// Export the binaries to a target directory.
 ///
-/// `source_files` are additional files from below skia-bindings/ that are copied to the target directory.
+/// `source_files` are additional files from below skia-bindings/ that are copied to the target
+/// directory.
 pub fn export(
     config: &binaries_config::BinariesConfiguration,
     source_files: &[(&str, &str)],
@@ -35,20 +36,7 @@ pub fn export(
         fs::copy(PathBuf::from(src), export_dir.join(PathBuf::from(dst)))?;
     }
 
-    let output_directory = &config.output_directory;
-
-    let target = cargo::target();
-
-    for lib in config.built_libraries() {
-        let filename = &target.library_to_filename(lib);
-        fs::copy(output_directory.join(filename), export_dir.join(filename))?;
-    }
-
-    for file in &config.additional_files {
-        fs::copy(output_directory.join(file), export_dir.join(file))?;
-    }
-
-    Ok(())
+    config.export(&export_dir)
 }
 
 /// Prepares the binaries directory and sets the tag.txt and key.txt


### PR DESCRIPTION
Instead of just adding the search path set in local builds to cargo, this PR copies the libraries to the output directory. The intention here is to be sure early on that all the files to link a binary are existing.

This PR is meant to supersede #532