### PR TITLE
Simple fix that replaces an array with the `vec![]` macro. 

### DIFF
--- a/skia-bindings/build_support/ios.rs
+++ b/skia-bindings/build_support/ios.rs
@@ -93,7 +93,7 @@ pub(crate) fn link_libraries(abi: Option<&str>, features: &Features) -> Vec<&'st
     ];
 
     if abi != Some("macabi") {
-        libs.extend(["framework=MobileCoreServices", "framework=UIKit"]);
+        libs.extend(vec!["framework=MobileCoreServices", "framework=UIKit"]);
     }
 
     if features.metal {


### PR DESCRIPTION
Simple fix that replaces an array with the `vec![]` macro (to get Rust analyzer to chill). 

Rust analyzer keeps complaining that `libs.extend(["framework=MobileCoreServices", "framework=UIKit"]);` is not an iterator. 

Replaced such with `libs.extend(vec!["framework=MobileCoreServices", "framework=UIKit"]);`.

Thanks! 
Colbyn