### PR TITLE
Milestone 94

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m94 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m94-0.42.0...google:chrome/m94
-[skia-ours]: https://github.com/google/skia/compare/chrome/m94...rust-skia:m94-0.42.0
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m94-0.42.1...google:chrome/m94
+[skia-ours]: https://github.com/google/skia/compare/chrome/m94...rust-skia:m94-0.42.1
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![Windows QA](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml) [![Linux QA](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml) [![macOS QA](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml)
 
-Skia Submodule Status: chrome/m93 ([upstream changes][skia-upstream], [our changes][skia-ours]).
+Skia Submodule Status: chrome/m94 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m93-0.42.0...google:chrome/m93
-[skia-ours]: https://github.com/google/skia/compare/chrome/m93...rust-skia:m93-0.42.0
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m94-0.42.0...google:chrome/m94
+[skia-ours]: https://github.com/google/skia/compare/chrome/m94...rust-skia:m94-0.42.0
 
 ## Goals
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m93-0.42.0"
+skia = "m94-0.42.0"
 depot_tools = "fade894"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m94-0.42.0"
+skia = "m94-0.42.1"
 depot_tools = "fade894"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.42.0"
+version = "0.43.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"

--- a/skia-bindings/Makefile
+++ b/skia-bindings/Makefile
@@ -24,3 +24,8 @@ unused_dirs=\
 .PHONY: rm-unused
 rm-unused:
 	cd skia && git rm -r ${unused_dirs}
+
+.PHONY: rm-externals
+rm-externals:
+	rm -rf skia/third_party/externals/*
+

--- a/skia-bindings/build_support/binaries_config.rs
+++ b/skia-bindings/build_support/binaries_config.rs
@@ -10,7 +10,7 @@ pub mod lib {
     pub const SKIA_BINDINGS: &str = "skia-bindings";
     pub const SK_SHAPER: &str = "skshaper";
     pub const SK_PARAGRAPH: &str = "skparagraph";
-    pub const ICU: &str = "icu";
+    pub const SK_UNICODE: &str = "skunicode";
 }
 
 /// The configuration of the resulting binaries.
@@ -59,8 +59,8 @@ impl BinariesConfiguration {
             }
             ninja_built_libraries.push(lib::SK_PARAGRAPH.into());
             ninja_built_libraries.push(lib::SK_SHAPER.into());
-            // Since M93, we have to link against ICU, too, it's not anymore embedded in skia.lib.
-            ninja_built_libraries.push(lib::ICU.into());
+            // Since M94, icu sources are embedded in skunicode
+            ninja_built_libraries.push(lib::SK_UNICODE.into());
         }
 
         let mut link_libraries = Vec::new();

--- a/skia-bindings/build_support/skia_bindgen.rs
+++ b/skia-bindings/build_support/skia_bindgen.rs
@@ -531,7 +531,7 @@ const ENUM_TABLE: &[EnumEntry] = &[
     ("Op", rewrite::k_xxx_name_opt),
     // SkRRect_*
     // TODO: remove kLastType?
-    // SkRuntimeEffect_Variable_Type
+    // SkRuntimeEffect_Uniform_Type
     ("Type", rewrite::k_xxx_name_opt),
     ("Corner", rewrite::k_xxx_name),
     // SkShader_GradientType
@@ -617,6 +617,8 @@ const ENUM_TABLE: &[EnumEntry] = &[
     // m89, SkImageFilters::Dither
     ("Dither", rewrite::k_xxx),
     ("SkScanlineOrder", rewrite::k_xxx_name),
+    // m94: SkRuntimeEffect::ChildType
+    ("ChildType", rewrite::k_xxx_name_opt),
 ];
 
 pub(crate) mod rewrite {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1890,8 +1890,8 @@ extern "C" SkShader* C_SkShaders_Color2(const SkColor4f* color, SkColorSpace* co
     return SkShaders::Color(*color, sp(colorSpace)).release();
 }
 
-extern "C" SkShader* C_SkShaders_Blend(SkBlendMode mode, SkShader* dst, SkShader* src) {
-    return SkShaders::Blend(mode, sp(dst), sp(src)).release();
+extern "C" SkShader* C_SkShaders_Blend(SkBlender* blender, SkShader* dst, SkShader* src) {
+    return SkShaders::Blend(sp(blender), sp(dst), sp(src)).release();
 }
 
 extern "C" SkShader* C_SkShader_Deserialize(const void* data, size_t length) {
@@ -2329,7 +2329,6 @@ SkImage *C_SkRuntimeEffect_makeImage(
     const SkMatrix *localMatrix,
     const SkImageInfo *resultInfo,
     bool mipmapped) {
-    auto childrenSPs = reinterpret_cast<sk_sp<SkShader> *>(children);
     return self->makeImage(
         context,
         sp(uniforms),
@@ -2341,6 +2340,12 @@ SkColorFilter *C_SkRuntimeEffect_makeColorFilter(
     const SkRuntimeEffect *self, SkData *inputs, SkRuntimeEffect::ChildPtr *children, size_t childCount)
 {
     return self->makeColorFilter(sp(inputs), SkSpan<SkRuntimeEffect::ChildPtr>(children, childCount)).release();
+}
+
+SkBlender *C_SkRuntimeEffect_makeBlender(
+    const SkRuntimeEffect *self, SkData *uniforms, SkRuntimeEffect::ChildPtr *children, size_t childCount)
+{
+    return self->makeBlender(sp(uniforms), SkSpan<SkRuntimeEffect::ChildPtr>(children, childCount)).release();
 }
 
 const unsigned char* C_SkRuntimeEffect_source(const SkRuntimeEffect *self, size_t* len) {
@@ -2419,12 +2424,12 @@ SkImageFilter *C_SkImageFilters_Arithmetic(float k1, float k2, float k3, float k
                                       sp(foreground), *cropRect).release();
 }
 
-SkImageFilter *C_SkImageFilters_Blend(SkBlendMode mode,
+SkImageFilter *C_SkImageFilters_Blend(SkBlender *blender,
                                       SkImageFilter *background,
                                       SkImageFilter *foreground,
                                       const SkImageFilters::CropRect *cropRect)
 {
-    return SkImageFilters::Blend(mode, sp(background),
+    return SkImageFilters::Blend(sp(blender), sp(background),
                                  sp(foreground), *cropRect)
         .release();
 }

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1899,7 +1899,7 @@ extern "C" SkShader* C_SkShader_Deserialize(const void* data, size_t length) {
     // https://github.com/rust-skia/rust-skia/issues/146
     // "typeinfo for SkShader", referenced from:
     //      _C_SkShader_Deserialize in libcanvasnative.a(bindings.o)
-    return (SkShader*)(SkShader::Deserialize(SkFlattenable::Type::kSkShaderBase_Type, data, length).release());
+    return (SkShader*)(SkShader::Deserialize(SkFlattenable::Type::kSkShader_Type, data, length).release());
 }
 
 //
@@ -2325,7 +2325,7 @@ SkImage *C_SkRuntimeEffect_makeImage(
     const SkRuntimeEffect *self,
     GrRecordingContext* context,
     SkData *uniforms,
-    SkShader **children, size_t childCount,
+    SkRuntimeEffect::ChildPtr *children, size_t childCount,
     const SkMatrix *localMatrix,
     const SkImageInfo *resultInfo,
     bool mipmapped) {
@@ -2333,7 +2333,7 @@ SkImage *C_SkRuntimeEffect_makeImage(
     return self->makeImage(
         context,
         sp(uniforms),
-        childrenSPs, childCount,
+        SkSpan<SkRuntimeEffect::ChildPtr>(children, childCount),
         localMatrix, *resultInfo, mipmapped).release();
 }
 

--- a/skia-bindings/src/shaper.cpp
+++ b/skia-bindings/src/shaper.cpp
@@ -1,6 +1,9 @@
 #ifndef SK_SHAPER_HARFBUZZ_AVAILABLE
     #define SK_SHAPER_HARFBUZZ_AVAILABLE
 #endif
+#ifndef SK_USING_THIRD_PARTY_ICU
+    #define SK_USING_THIRD_PARTY_ICU
+#endif
 
 #include "bindings.h"
 

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.42.0"
+version = "0.43.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -45,7 +45,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 [dependencies]
 bitflags = "1.2"
 lazy_static = "1.4"
-skia-bindings = { version = "=0.42.0", path = "../skia-bindings", default-features = false }
+skia-bindings = { version = "=0.43.0", path = "../skia-bindings", default-features = false }
 # for d3d types
 winapi = { version = "0.3.9", features = ["d3d12", "dxgi"], optional = true }
 # for ComPtr

--- a/skia-safe/src/core.rs
+++ b/skia-safe/src/core.rs
@@ -64,9 +64,6 @@ pub use encoded_image_format::*;
 // unsupported, because it's used in experimental APIs only.
 // mod executor;
 
-mod filter_quality;
-pub use filter_quality::*;
-
 mod flattenable;
 pub use flattenable::*;
 

--- a/skia-safe/src/core/blender.rs
+++ b/skia-safe/src/core/blender.rs
@@ -12,6 +12,8 @@ impl NativeRefCountedBase for SkBlender {
     type Base = SkRefCntBase;
 }
 
+impl NativeBase<SkFlattenable> for SkBlender {}
+
 impl Blender {
     /// Create a blender that implements the specified [`BlendMode`].
     pub fn mode(mode: BlendMode) -> Blender {

--- a/skia-safe/src/core/blender.rs
+++ b/skia-safe/src/core/blender.rs
@@ -34,3 +34,9 @@ impl NativeFlattenable for SkBlender {
         unsafe { sb::C_SkBlender_Deserialize(data.as_ptr() as _, data.len()) }
     }
 }
+
+impl From<BlendMode> for Blender {
+    fn from(mode: BlendMode) -> Self {
+        Blender::mode(mode)
+    }
+}

--- a/skia-safe/src/core/filter_quality.rs
+++ b/skia-safe/src/core/filter_quality.rs
@@ -1,2 +1,0 @@
-pub use skia_bindings::SkFilterQuality as FilterQuality;
-variant_name!(FilterQuality::High, filter_quality_naming);

--- a/skia-safe/src/core/milestone.rs
+++ b/skia-safe/src/core/milestone.rs
@@ -1,1 +1,1 @@
-pub const MILESTONE: usize = 93;
+pub const MILESTONE: usize = 94;

--- a/skia-safe/src/core/sampling_options.rs
+++ b/skia-safe/src/core/sampling_options.rs
@@ -1,5 +1,4 @@
-use crate::{prelude::*, FilterQuality};
-use skia_bindings::{SkCubicResampler, SkSamplingOptions, SkSamplingOptions_MediumBehavior};
+use skia_bindings::{SkCubicResampler, SkSamplingOptions};
 
 pub use skia_bindings::SkFilterMode as FilterMode;
 variant_name!(FilterMode::Linear, filter_mode_naming);
@@ -56,19 +55,6 @@ pub struct FilterOptions {
     pub mipmap: MipmapMode,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
-#[repr(i32)]
-pub enum MediumBehavior {
-    AsMipmapNearest = SkSamplingOptions_MediumBehavior::kMedium_asMipmapNearest as _,
-    AsMipmapLinear = SkSamplingOptions_MediumBehavior::kMedium_asMipmapLinear as _,
-}
-
-native_transmutable!(
-    SkSamplingOptions_MediumBehavior,
-    MediumBehavior,
-    medium_behavior_layout
-);
-
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[allow(deprecated)]
@@ -100,21 +86,6 @@ impl SamplingOptions {
             mipmap: mm,
             ..Default::default()
         }
-    }
-
-    pub fn from_filter_quality(
-        filter_quality: FilterQuality,
-        medium_behavior: impl Into<Option<MediumBehavior>>,
-    ) -> Self {
-        Self::from_native_c(unsafe {
-            SkSamplingOptions::new(
-                filter_quality,
-                medium_behavior
-                    .into()
-                    .unwrap_or(MediumBehavior::AsMipmapNearest)
-                    .into_native(),
-            )
-        })
     }
 }
 
@@ -149,11 +120,5 @@ impl From<CubicResampler> for SamplingOptions {
             cubic,
             ..Default::default()
         }
-    }
-}
-
-impl From<FilterQuality> for SamplingOptions {
-    fn from(quality: FilterQuality) -> Self {
-        Self::from_filter_quality(quality, None)
     }
 }

--- a/skia-safe/src/core/shader.rs
+++ b/skia-safe/src/core/shader.rs
@@ -106,7 +106,7 @@ impl Shader {
 }
 
 pub mod shaders {
-    use crate::{prelude::*, BlendMode, Color, Color4f, ColorSpace, Shader};
+    use crate::{prelude::*, BlendMode, Blender, Color, Color4f, ColorSpace, Shader};
     use skia_bindings as sb;
 
     pub fn empty() -> Shader {
@@ -125,9 +125,17 @@ pub mod shaders {
         .unwrap()
     }
 
-    pub fn blend(mode: BlendMode, dst: impl Into<Shader>, src: impl Into<Shader>) -> Shader {
+    pub fn blend(
+        blender: impl Into<Blender>,
+        dst: impl Into<Shader>,
+        src: impl Into<Shader>,
+    ) -> Shader {
         Shader::from_ptr(unsafe {
-            sb::C_SkShaders_Blend(mode, dst.into().into_ptr(), src.into().into_ptr())
+            sb::C_SkShaders_Blend(
+                blender.into().into_ptr(),
+                dst.into().into_ptr(),
+                src.into().into_ptr(),
+            )
         })
         .unwrap()
     }

--- a/skia-safe/src/core/shader.rs
+++ b/skia-safe/src/core/shader.rs
@@ -106,7 +106,7 @@ impl Shader {
 }
 
 pub mod shaders {
-    use crate::{prelude::*, BlendMode, Blender, Color, Color4f, ColorSpace, Shader};
+    use crate::{prelude::*, Blender, Color, Color4f, ColorSpace, Shader};
     use skia_bindings as sb;
 
     pub fn empty() -> Shader {

--- a/skia-safe/src/effects/image_filters.rs
+++ b/skia-safe/src/effects/image_filters.rs
@@ -1,5 +1,5 @@
 use crate::{
-    prelude::*, scalar, BlendMode, Color, ColorChannel, ColorFilter, CubicResampler, IPoint, IRect,
+    prelude::*, scalar, Blender, Color, ColorChannel, ColorFilter, CubicResampler, IPoint, IRect,
     ISize, Image, ImageFilter, Matrix, Paint, Picture, Point3, Rect, Region, SamplingOptions,
     Shader, TileMode, Vector,
 };
@@ -114,14 +114,14 @@ pub fn arithmetic(
 }
 
 pub fn blend(
-    mode: BlendMode,
+    mode: impl Into<Blender>,
     background: impl Into<Option<ImageFilter>>,
     foreground: impl Into<Option<ImageFilter>>,
     crop_rect: impl Into<CropRect>,
 ) -> Option<ImageFilter> {
     ImageFilter::from_ptr(unsafe {
         sb::C_SkImageFilters_Blend(
-            mode,
+            mode.into().into_ptr(),
             background.into().into_ptr_or_null(),
             foreground.into().into_ptr_or_null(),
             crop_rect.into().native(),

--- a/skia-safe/src/prelude.rs
+++ b/skia-safe/src/prelude.rs
@@ -544,6 +544,7 @@ impl<N: NativeRefCounted> RCHandle<N> {
     }
 
     /// Returns the pointer to the handle.
+    #[allow(unused)]
     pub(crate) fn as_ptr(&self) -> &NonNull<N> {
         &self.0
     }

--- a/skia-safe/tests/send_sync.rs
+++ b/skia-safe/tests/send_sync.rs
@@ -110,7 +110,6 @@ mod core {
     // core/sampling_options.rs
     assert_impl_all!(CubicResampler: Send, Sync);
     assert_impl_all!(FilterMode: Send, Sync);
-    assert_impl_all!(sampling_options::MediumBehavior: Send, Sync);
     assert_impl_all!(SamplingOptions: Send, Sync);
     // core/yuva_info.rs
     assert_impl_all!(YUVAInfo: Send, Sync);


### PR DESCRIPTION
This PR updates rust-skia to support Skia's `chrome/m94` branch.

- [x] Update `README.md` ([rendered](https://github.com/pragmatrix/rust-skia/blob/m94/README.md))  
  > Most important here is to change the Skia branch name and the current Skia submodule tag at the top of the `README.md` file.
- [x] Diff the the following files to see if the build organization has changed significantly:
  - [x] `/BUILD.gn`
  - [x] `/modules/skshaper/BUILD.gn`
  - [x] `/modules/paragraph/BUILD.gn`
- [x] Skia builds ([release notes](https://github.com/google/skia/blob/chrome/m94/RELEASE_NOTES.txt)).
- [x] `/skia-bindings` builds.
- [x] `/skia-safe`: Update & add new wrappers by diffing include files.  
  > Add TODOs for everything that can not be updated right now, and attempt to stay compatible with previous versions of skia-safe without trying too hard before version 1.0. Use `deprecated` attributes if needed.
  - [x] `codec/`
  - [x] `core/`
  - [x] `docs/`
  - [x] `effects/`
  - [x] `gpu/`
    - [x] `d3d/`
    - [x] `gl/`
    - [x] `mtl/`
    - [x] `vk/`
  - [x] `modules/`
    - [x] `paragraph/`
    - [x] `shaper/`
  - [x] `pathops/`
  - [x] `svg/`
  - [x] `utils/`
- [x] Review `Send` & `Sync` implementations for new wrappers.
- [x] Review `Debug` implementation for new wrapper types and functions.
- [x] Any pending changes in the Skia `chrome/m94` branch that aren't synchronized yet?
- [x] Rebase on or merge with master.
- [x] Do the `rust-skia:` commits in the `skia-bindinngs/skia` subdirectory match with `master`.
- [x] Update versions of `skia-bindings/Cargo.toml` and `skia-safe/Cargo.toml` and also add the version to the new `deprecated` attributes.
- [x] Do the tags/hashes in `skia-bindings/Cargo.toml` under `[package.metadata]` match the submodules `depot_tools` and `skia`?
- [x] Test builds we don't do on the CI:
  - [x] Compiles to Catalyst targets on macOS (#548).
    ```zsh
    make macos-qa
    ```
- [x] Do one final review of all the changes.
- [x] Run `cargo doc` with all features and fix all warnings.

