### PR TITLE
Milestone 96

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m96 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m96-0.44.0...google:chrome/m96
-[skia-ours]: https://github.com/google/skia/compare/chrome/m96...rust-skia:m96-0.44.0
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m96-0.44.1...google:chrome/m96
+[skia-ours]: https://github.com/google/skia/compare/chrome/m96...rust-skia:m96-0.44.1
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![Windows QA](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml) [![Linux QA](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml) [![macOS QA](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml)
 
-Skia Submodule Status: chrome/m95 ([upstream changes][skia-upstream], [our changes][skia-ours]).
+Skia Submodule Status: chrome/m96 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m95-0.43.3...google:chrome/m95
-[skia-ours]: https://github.com/google/skia/compare/chrome/m95...rust-skia:m95-0.43.3
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m96-0.44.0...google:chrome/m96
+[skia-ours]: https://github.com/google/skia/compare/chrome/m96...rust-skia:m96-0.44.0
 
 ## Goals
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.44.0"
+version = "0.45.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m96-0.44.0"
+skia = "m96-0.44.1"
 depot_tools = "fade894"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m95-0.43.3"
+skia = "m96-0.44.0"
 depot_tools = "fade894"
 
 [features]

--- a/skia-bindings/src/d3d.cpp
+++ b/skia-bindings/src/d3d.cpp
@@ -10,6 +10,9 @@
 #include "include/gpu/GrDirectContext.h"
 #include "include/gpu/d3d/GrD3DBackendContext.h"
 
+// Additional types not yet referenced.
+extern "C" void C_GrD3DTypes(GrD3DSurfaceInfo *) {};
+
 //
 // gpu/d3d/GrD3DTypes.h
 //

--- a/skia-bindings/src/gl.cpp
+++ b/skia-bindings/src/gl.cpp
@@ -13,6 +13,9 @@
 #include "include/gpu/gl/GrGLAssembleInterface.h"
 #include "src/gpu/gl/GrGLDefines.h"
 
+// Additional types not yet referenced.
+extern "C" void C_GrGLTypes(GrGLSurfaceInfo *) {};
+
 // core/SurfaceCharacterization.h
 
 extern "C" void C_SkSurfaceCharacterization_createFBO0(

--- a/skia-bindings/src/metal.cpp
+++ b/skia-bindings/src/metal.cpp
@@ -8,6 +8,8 @@
 #include "include/gpu/mtl/GrMtlBackendContext.h"
 #include "include/gpu/GrDirectContext.h"
 
+extern "C" void C_GrMtlTypes(GrMTLTextureUsage*, GrMtlSurfaceInfo *) {};
+
 //
 // core/SkSurface.h
 //

--- a/skia-bindings/src/vulkan.cpp
+++ b/skia-bindings/src/vulkan.cpp
@@ -10,6 +10,9 @@
 #include "include/gpu/vk/GrVkBackendContext.h"
 #include "include/gpu/vk/GrVkExtensions.h"
 
+// Additional types not yet referenced.
+extern "C" void C_GrVkTypes(GrVkSurfaceInfo *) {};
+
 extern "C" void C_GrBackendFormat_ConstructVk(GrBackendFormat* uninitialized, VkFormat format) {
     new(uninitialized)GrBackendFormat(GrBackendFormat::MakeVk(format));
 }

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.44.0"
+version = "0.45.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -46,7 +46,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 [dependencies]
 bitflags = "1.2"
 lazy_static = "1.4"
-skia-bindings = { version = "=0.44.0", path = "../skia-bindings", default-features = false }
+skia-bindings = { version = "=0.45.0", path = "../skia-bindings", default-features = false }
 # for d3d types
 winapi = { version = "0.3.9", features = ["d3d12", "dxgi"], optional = true }
 # for ComPtr

--- a/skia-safe/src/core/milestone.rs
+++ b/skia-safe/src/core/milestone.rs
@@ -1,1 +1,1 @@
-pub const MILESTONE: usize = 95;
+pub const MILESTONE: usize = 96;

--- a/skia-safe/src/gpu/d3d/types.rs
+++ b/skia-safe/src/gpu/d3d/types.rs
@@ -124,9 +124,12 @@ pub struct SurfaceInfo {
     pub sample_count: u32,
     pub level_count: u32,
     pub protected: gpu::Protected,
+
     pub format: DXGI_FORMAT,
     pub sample_quality_pattern: c_uint,
 }
+
+native_transmutable!(GrD3DSurfaceInfo, SurfaceInfo, surface_info_layout);
 
 impl Default for SurfaceInfo {
     fn default() -> Self {
@@ -139,5 +142,3 @@ impl Default for SurfaceInfo {
         }
     }
 }
-
-native_transmutable!(GrD3DSurfaceInfo, SurfaceInfo, surface_info_layout);

--- a/skia-safe/src/gpu/d3d/types.rs
+++ b/skia-safe/src/gpu/d3d/types.rs
@@ -1,10 +1,12 @@
 use super::{ID3D12Resource, D3D12_RESOURCE_STATES, DXGI_FORMAT};
 use crate::{gpu, prelude::*};
-use skia_bindings::{GrD3DAlloc, GrD3DMemoryAllocator, GrD3DTextureResourceInfo, SkRefCntBase};
-use std::fmt;
+use skia_bindings::{
+    GrD3DAlloc, GrD3DMemoryAllocator, GrD3DSurfaceInfo, GrD3DTextureResourceInfo, SkRefCntBase,
+};
+use std::{fmt, os::raw::c_uint};
 use winapi::{
     shared::dxgiformat,
-    shared::dxgitype,
+    shared::{dxgiformat::DXGI_FORMAT_UNKNOWN, dxgitype},
     um::{d3d12, unknwnbase::IUnknown},
 };
 
@@ -115,3 +117,27 @@ pub struct FenceInfo {
 }
 
 unsafe_send_sync!(FenceInfo);
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[repr(C)]
+pub struct SurfaceInfo {
+    pub sample_count: u32,
+    pub level_count: u32,
+    pub protected: gpu::Protected,
+    pub format: DXGI_FORMAT,
+    pub sample_quality_pattern: c_uint,
+}
+
+impl Default for SurfaceInfo {
+    fn default() -> Self {
+        Self {
+            sample_count: 1,
+            level_count: 0,
+            protected: gpu::Protected::No,
+            format: DXGI_FORMAT_UNKNOWN,
+            sample_quality_pattern: dxgitype::DXGI_STANDARD_MULTISAMPLE_QUALITY_PATTERN,
+        }
+    }
+}
+
+native_transmutable!(GrD3DSurfaceInfo, SurfaceInfo, surface_info_layout);

--- a/skia-safe/src/gpu/gl/types.rs
+++ b/skia-safe/src/gpu/gl/types.rs
@@ -60,6 +60,7 @@ pub struct SurfaceInfo {
     pub sample_count: u32,
     pub level_count: u32,
     pub protected: gpu::Protected,
+
     pub target: Enum,
     pub format: Enum,
 }

--- a/skia-safe/src/gpu/gl/types.rs
+++ b/skia-safe/src/gpu/gl/types.rs
@@ -1,5 +1,6 @@
+use crate::gpu;
 use crate::prelude::*;
-use skia_bindings::{self as sb, GrGLFramebufferInfo, GrGLTextureInfo};
+use skia_bindings::{self as sb, GrGLFramebufferInfo, GrGLSurfaceInfo, GrGLTextureInfo};
 
 pub use skia_bindings::GrGLFormat as Format;
 variant_name!(Format::ALPHA8, format_naming);
@@ -52,6 +53,18 @@ impl FramebufferInfo {
         Self { fboid, format: 0 }
     }
 }
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[repr(C)]
+pub struct SurfaceInfo {
+    pub sample_count: u32,
+    pub level_count: u32,
+    pub protected: gpu::Protected,
+    pub target: Enum,
+    pub format: Enum,
+}
+
+native_transmutable!(GrGLSurfaceInfo, SurfaceInfo, surface_info_layout);
 
 bitflags! {
     pub struct BackendState: u32 {

--- a/skia-safe/src/gpu/gl/types.rs
+++ b/skia-safe/src/gpu/gl/types.rs
@@ -66,6 +66,18 @@ pub struct SurfaceInfo {
 
 native_transmutable!(GrGLSurfaceInfo, SurfaceInfo, surface_info_layout);
 
+impl Default for SurfaceInfo {
+    fn default() -> Self {
+        Self {
+            sample_count: 1,
+            level_count: 0,
+            protected: gpu::Protected::No,
+            target: 0,
+            format: 0,
+        }
+    }
+}
+
 bitflags! {
     pub struct BackendState: u32 {
         const RENDER_TARGET = sb::GrGLBackendState_kRenderTarget_GrGLBackendState as _;

--- a/skia-safe/src/gpu/mtl/types.rs
+++ b/skia-safe/src/gpu/mtl/types.rs
@@ -1,9 +1,14 @@
-use crate::prelude::{self, NativeAccess, NativeDrop, NativePartialEq};
-use skia_bindings::{self as sb, GrMtlTextureInfo};
+use crate::{
+    gpu,
+    prelude::{self, NativeAccess, NativeDrop, NativePartialEq},
+};
+use skia_bindings::{self as sb, GrMtlSurfaceInfo, GrMtlTextureInfo};
 use std::{fmt, ptr};
 
 pub use skia_bindings::GrMTLHandle as Handle;
 pub use skia_bindings::GrMTLPixelFormat as PixelFormat;
+pub use skia_bindings::GrMTLStorageMode as StorageMode;
+pub use skia_bindings::GrMTLTextureUsage as TextureUsage;
 
 pub type TextureInfo = prelude::Handle<GrMtlTextureInfo>;
 unsafe_send_sync!(TextureInfo);
@@ -47,6 +52,33 @@ impl TextureInfo {
 
     pub fn texture(&self) -> Handle {
         self.native().fTexture.fObject
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[repr(C)]
+pub struct SurfaceInfo {
+    pub sample_count: u32,
+    pub level_count: u32,
+    pub protected: gpu::Protected,
+
+    pub format: PixelFormat,
+    pub usage: TextureUsage,
+    pub storage_mode: StorageMode,
+}
+
+native_transmutable!(GrMtlSurfaceInfo, SurfaceInfo, surface_info_layout);
+
+impl Default for SurfaceInfo {
+    fn default() -> Self {
+        Self {
+            sample_count: 1,
+            level_count: 0,
+            protected: gpu::Protected::No,
+            format: 0,
+            usage: 0,
+            storage_mode: 0,
+        }
     }
 }
 

--- a/skia-safe/src/gpu/vk/types.rs
+++ b/skia-safe/src/gpu/vk/types.rs
@@ -1,9 +1,9 @@
 use crate::{
-    gpu::{vk, Protected},
+    gpu::{self, vk, Protected},
     prelude::*,
 };
 use skia_bindings::{
-    self as sb, GrVkAlloc, GrVkBackendMemory, GrVkDrawableInfo, GrVkImageInfo,
+    self as sb, GrVkAlloc, GrVkBackendMemory, GrVkDrawableInfo, GrVkImageInfo, GrVkSurfaceInfo,
     GrVkYcbcrConversionInfo,
 };
 use std::{ffi::CStr, os::raw, ptr};
@@ -47,6 +47,7 @@ bitflags! {
     pub struct AllocFlag : u32 {
         const NONCOHERENT = sb::GrVkAlloc_Flag_kNoncoherent_Flag as _;
         const MAPPABLE = sb::GrVkAlloc_Flag_kMappable_Flag as _;
+        const LAZILY_ALLOCATED = sb::GrVkAlloc_Flag_kLazilyAllocated_Flag as _;
     }
 }
 
@@ -70,7 +71,7 @@ impl Alloc {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Eq, Debug)]
 #[repr(C)]
 pub struct YcbcrConversionInfo {
     pub format: vk::Format,
@@ -321,6 +322,8 @@ pub struct DrawableInfo {
     pub draw_bounds: *mut vk::Rect2D,
     pub image: vk::Image,
 }
+
+native_transmutable!(GrVkDrawableInfo, DrawableInfo, drawable_info_layout);
 unsafe_send_sync!(DrawableInfo);
 
 impl Default for DrawableInfo {
@@ -336,4 +339,32 @@ impl Default for DrawableInfo {
     }
 }
 
-native_transmutable!(GrVkDrawableInfo, DrawableInfo, drawable_info_layout);
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[repr(C)]
+pub struct SurfaceInfo {
+    pub sample_count: u32,
+    pub level_count: u32,
+    pub protected: gpu::Protected,
+    pub image_tiling: vk::ImageTiling,
+    pub format: vk::Format,
+    pub image_usage_flags: vk::ImageUsageFlags,
+    pub ycbcr_conversion_info: vk::YcbcrConversionInfo,
+    pub sharing_mode: vk::SharingMode,
+}
+
+native_transmutable!(GrVkSurfaceInfo, SurfaceInfo, surface_info_layout);
+
+impl Default for SurfaceInfo {
+    fn default() -> Self {
+        Self {
+            sample_count: 1,
+            level_count: 0,
+            protected: Protected::No,
+            image_tiling: vk::ImageTiling::OPTIMAL,
+            format: vk::Format::UNDEFINED,
+            image_usage_flags: 0,
+            ycbcr_conversion_info: Default::default(),
+            sharing_mode: vk::SharingMode::EXCLUSIVE,
+        }
+    }
+}

--- a/skia-safe/src/gpu/vk/types.rs
+++ b/skia-safe/src/gpu/vk/types.rs
@@ -345,6 +345,7 @@ pub struct SurfaceInfo {
     pub sample_count: u32,
     pub level_count: u32,
     pub protected: gpu::Protected,
+
     pub image_tiling: vk::ImageTiling,
     pub format: vk::Format,
     pub image_usage_flags: vk::ImageUsageFlags,

--- a/skia-safe/tests/send_sync.rs
+++ b/skia-safe/tests/send_sync.rs
@@ -178,6 +178,7 @@ mod gpu {
         assert_not_impl_any!(Interface: Send, Sync);
         assert_impl_all!(TextureInfo: Send, Sync);
         assert_impl_all!(FramebufferInfo: Send, Sync);
+        assert_impl_all!(SurfaceInfo: Send, Sync);
     }
 
     #[cfg(feature = "metal")]
@@ -185,6 +186,7 @@ mod gpu {
         use skia_safe::gpu::mtl::*;
         use static_assertions::*;
         assert_impl_all!(TextureInfo: Send, Sync);
+        assert_impl_all!(SurfaceInfo: Send, Sync);
         assert_impl_all!(BackendContext: Send, Sync);
     }
 
@@ -203,6 +205,7 @@ mod gpu {
         // GetProc could be Send & Sync , but does it make sense (it's already Copy & Clone)
         assert_not_impl_any!(GetProcOf: Send, Sync);
         assert_impl_all!(DrawableInfo: Send, Sync);
+        assert_impl_all!(SurfaceInfo: Send, Sync);
         assert_impl_all!(BackendDrawableInfo: Send, Sync);
         // Note that we can't make most of vk.rs re-export of native Vulkan types Send nor Sync,
         // because they are just re-exports of simple pointers, which already implement
@@ -218,6 +221,7 @@ mod gpu {
         assert_not_impl_any!(BackendContext: Sync);
         assert_impl_all!(TextureResourceInfo: Send, Sync);
         assert_impl_all!(FenceInfo: Send, Sync);
+        assert_impl_all!(SurfaceInfo: Send, Sync);
         assert_impl_all!(Alloc: Send, Sync);
         assert_impl_all!(MemoryAllocator: Send, Sync);
     }


### PR DESCRIPTION
This PR updates rust-skia to support Skia's `chrome/m96` branch.

- [x] Update `README.md` ([rendered](https://github.com/pragmatrix/rust-skia/blob/m96/README.md))  
  > Most important here is to change the Skia branch name and the current Skia submodule tag at the top of the `README.md` file.
- [x] Diff the the following files to see if the build organization has changed significantly:
  - [x] `/BUILD.gn`
  - [x] `/modules/skshaper/BUILD.gn`
  - [x] `/modules/paragraph/BUILD.gn`
- [x] Skia builds ([release notes](https://github.com/google/skia/blob/chrome/m96/RELEASE_NOTES.txt)).
- [x] `/skia-bindings` builds.
- [x] `/skia-safe`: Update & add new wrappers by diffing include files.  
  > Add TODOs for everything that can not be updated right now, and attempt to stay compatible with previous versions of skia-safe without trying too hard before version 1.0. Use `deprecated` attributes if needed.
  - [x] `codec/`
  - [x] `core/`
  - [x] `docs/`
  - [x] `effects/`
  - [x] `gpu/`
    - [x] `d3d/`
    - [x] `gl/`
    - [x] `mtl/`
    - [x] `vk/`
  - [x] `modules/`
    - [x] `paragraph/`
    - [x] `shaper/`
  - [x] `pathops/`
  - [x] `svg/`
  - [x] `utils/`
- [x] Review `Send` & `Sync` implementations for new wrappers.
- [x] Review `Debug` implementation for new wrapper types and functions.
- [x] Any pending changes in the Skia `chrome/m96` branch that aren't synchronized yet?
- [x] Rebase on or merge with master.
- [x] Do the `rust-skia:` commits in the `skia-bindinngs/skia` subdirectory match with `master`.
- [x] Update versions of `skia-bindings/Cargo.toml` and `skia-safe/Cargo.toml` and also add the version to the new `deprecated` attributes.
- [x] Do the tags/hashes in `skia-bindings/Cargo.toml` under `[package.metadata]` match the submodules `depot_tools` and `skia`?
- [x] Test builds we don't do on the CI:
  - [x] Compiles to Catalyst targets on macOS (#548).
    ```zsh
    make macos-qa
    ```
- [x] Do one final review of all the changes.
- [x] Run `cargo doc` with all features and fix all warnings.

