### PR TITLE
Review icu::init

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,9 @@ members = [
     "skia-org",
     "mk-workflows"
 ]
+
+[profile.release]
+# We want to build skia-org with with lto="thin"
+# https://github.com/rust-skia/rust-skia/issues/565
+lto = "thin"
+

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -59,6 +59,7 @@ embed-freetype = []
 
 [dependencies]
 mozjpeg-sys = { version = "1", features = ["with_simd"], optional = true }
+lazy_static = "1.4.0"
 
 [build-dependencies]
 cc = "1.0.37"

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -58,19 +58,17 @@ embed-icudtl = []
 embed-freetype = []
 
 [dependencies]
-
-mozjpeg-sys = { version = "1", features=["with_simd"], optional=true }
+mozjpeg-sys = { version = "1", features = ["with_simd"], optional = true }
 
 [build-dependencies]
 cc = "1.0.37"
 bindgen = "0.59.0"
 
 # For enum variant name replacements.
-
 regex = "1.4.5"
 heck = "0.3.1"
 
-# for downloading and extracting prebuilt binaries and skia / depot_tools archives:
+# For downloading and extracting prebuilt binaries and skia / depot_tools archives:
 ureq = { version = "2.0.1", optional = true }
 flate2 = { version = "1.0.7", optional = true }
 tar = { version = "0.4.26", optional = true }
@@ -80,8 +78,8 @@ tar = { version = "0.4.26", optional = true }
 # https://github.com/KyleMayes/clang-sys/pull/118
 clang-sys = "=1.0.1"
 
-# for reading .cargo.vcs_info.json to get the repository sha1 that is used to download
+# For reading .cargo.vcs_info.json to get the repository sha1 that is used to download
 # the matching prebuilt binaries.
 serde_json = "1.0.39"
-# for reading Cargo.toml from within a package.
+# For reading Cargo.toml from within a package.
 toml = "0.5.1"

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -54,12 +54,12 @@ use-system-jpeg-turbo = ["mozjpeg-sys"]
 svg = []
 shaper = ["textlayout"]
 binary-cache = ["ureq", "flate2", "tar"]
-embed-icudtl = []
+embed-icudtl = ["lazy_static"]
 embed-freetype = []
 
 [dependencies]
 mozjpeg-sys = { version = "1", features = ["with_simd"], optional = true }
-lazy_static = "1.4.0"
+lazy_static = { version = "1.4.0", optional = true }
 
 [build-dependencies]
 cc = "1.0.37"

--- a/skia-bindings/src/icu.rs
+++ b/skia-bindings/src/icu.rs
@@ -1,7 +1,7 @@
 #[cfg(windows)]
 pub fn init() {
     use std::env;
-    let icudtl = include_bytes!(concat!(env!("OUT_DIR"), "/skia/icudtl.dat"));
+    static icudtl: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/skia/icudtl.dat"));
 
     #[cfg(feature = "embed-icudtl")]
     {

--- a/skia-bindings/src/icu.rs
+++ b/skia-bindings/src/icu.rs
@@ -13,15 +13,15 @@ pub fn init() {
         use std::fs;
 
         let path = env::current_exe()
-            .expect("failed to resolve the current executable's path")
+            .expect("Failed to resolve the current executable's path")
             .parent()
-            .expect("current executable's path does not point to a directory")
+            .expect("Current executable's parent path does not point to a directory")
             .join("icudtl.dat");
         if path.exists() {
             return;
         };
-        fs::write(path, &icu_dtl[..])
-            .expect("failed to write icudtl.dat into the current executable's directory");
+        fs::write(path, &icudtl[..])
+            .expect("Failed to write icudtl.dat into the current executable's directory");
     }
 }
 

--- a/skia-bindings/src/icu.rs
+++ b/skia-bindings/src/icu.rs
@@ -5,7 +5,18 @@ pub fn init() {
 
     #[cfg(feature = "embed-icudtl")]
     {
+        use std::sync::Mutex;
+
+        lazy_static::lazy_static!(
+            static ref MUTEX : Mutex<()> = Mutex::new(());
+        );
+
+        // Using `Once` does not work for yet unknown reasons.
+        // https://github.com/rust-skia/rust-skia/issues/566
+
+        let lock = MUTEX.lock().unwrap();
         unsafe { crate::C_SetICU(&icudtl[0] as &'static u8 as *const u8 as _) };
+        drop(lock);
     }
 
     #[cfg(not(feature = "embed-icudtl"))]

--- a/skia-org/src/skparagraph_example.rs
+++ b/skia-org/src/skparagraph_example.rs
@@ -1,13 +1,12 @@
 use crate::DrawingDriver;
-use skia_safe::textlayout::{FontCollection, ParagraphBuilder, ParagraphStyle, TextStyle};
-use skia_safe::{icu, Canvas, FontMgr, Paint, Point};
+use skia_safe::{
+    textlayout::{FontCollection, ParagraphBuilder, ParagraphStyle, TextStyle},
+    Canvas, FontMgr, Paint, Point,
+};
 use std::path;
 
 pub fn draw(driver: &mut impl DrawingDriver, path: &path::Path) {
     let path = path.join("SkParagraph-Example");
-
-    icu::init();
-
     driver.draw_image_256(&path, "lorem-ipsum", draw_lorem_ipsum);
 }
 

--- a/skia-org/src/skshaper_example.rs
+++ b/skia-org/src/skshaper_example.rs
@@ -1,11 +1,9 @@
 use crate::DrawingDriver;
-use skia_safe::{icu, Canvas, Font, Paint, Point, Shaper, Typeface};
+use skia_safe::{Canvas, Font, Paint, Point, Shaper, Typeface};
 use std::path;
 
 pub fn draw(driver: &mut impl DrawingDriver, path: &path::Path) {
     let path = path.join("SkShaper-Example");
-
-    icu::init();
 
     driver.draw_image_256(&path, "rtl-shaped", draw_rtl_shaped);
     driver.draw_image_256(&path, "rtl-unshaped", draw_rtl_unshaped);


### PR DESCRIPTION
The new embed-icudtl `icu::init()` function had several problems which are addressed in this PR:

Closes #565 
Closes #566 

And also fixes a compilation error when then feature `embed-icudtl` was missing.