### PR TITLE
Update NDK to r23b

### DIFF
--- a/.github/workflows/linux-qa.yaml
+++ b/.github/workflows/linux-qa.yaml
@@ -51,6 +51,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-unknown-linux-gnu26-clang
           export CXX_${TARGET}=x86_64-unknown-linux-gnu26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -123,6 +124,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-linux-android26-clang
           export CXX_${TARGET}=aarch64-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -195,6 +197,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-linux-android26-clang
           export CXX_${TARGET}=x86_64-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -267,6 +270,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=i686-linux-android26-clang
           export CXX_${TARGET}=i686-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -361,6 +365,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-unknown-linux-gnu26-clang
           export CXX_${TARGET}=x86_64-unknown-linux-gnu26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -433,6 +438,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-linux-android26-clang
           export CXX_${TARGET}=aarch64-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -505,6 +511,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-linux-android26-clang
           export CXX_${TARGET}=x86_64-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -577,6 +584,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=i686-linux-android26-clang
           export CXX_${TARGET}=i686-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -671,6 +679,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-unknown-linux-gnu26-clang
           export CXX_${TARGET}=x86_64-unknown-linux-gnu26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -743,6 +752,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-linux-android26-clang
           export CXX_${TARGET}=aarch64-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -815,6 +825,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-linux-android26-clang
           export CXX_${TARGET}=x86_64-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -887,6 +898,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=i686-linux-android26-clang
           export CXX_${TARGET}=i686-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"

--- a/.github/workflows/linux-release.yaml
+++ b/.github/workflows/linux-release.yaml
@@ -46,6 +46,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-unknown-linux-gnu26-clang
           export CXX_${TARGET}=x86_64-unknown-linux-gnu26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -118,6 +119,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-linux-android26-clang
           export CXX_${TARGET}=aarch64-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -190,6 +192,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-linux-android26-clang
           export CXX_${TARGET}=x86_64-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -262,6 +265,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=i686-linux-android26-clang
           export CXX_${TARGET}=i686-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -356,6 +360,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-unknown-linux-gnu26-clang
           export CXX_${TARGET}=x86_64-unknown-linux-gnu26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -428,6 +433,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-linux-android26-clang
           export CXX_${TARGET}=aarch64-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -500,6 +506,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-linux-android26-clang
           export CXX_${TARGET}=x86_64-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -572,6 +579,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=i686-linux-android26-clang
           export CXX_${TARGET}=i686-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -666,6 +674,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-unknown-linux-gnu26-clang
           export CXX_${TARGET}=x86_64-unknown-linux-gnu26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -738,6 +747,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-linux-android26-clang
           export CXX_${TARGET}=aarch64-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -810,6 +820,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-linux-android26-clang
           export CXX_${TARGET}=x86_64-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -882,6 +893,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=i686-linux-android26-clang
           export CXX_${TARGET}=i686-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -976,6 +988,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-unknown-linux-gnu26-clang
           export CXX_${TARGET}=x86_64-unknown-linux-gnu26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1048,6 +1061,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-linux-android26-clang
           export CXX_${TARGET}=aarch64-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1120,6 +1134,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-linux-android26-clang
           export CXX_${TARGET}=x86_64-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1192,6 +1207,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=i686-linux-android26-clang
           export CXX_${TARGET}=i686-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1286,6 +1302,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-unknown-linux-gnu26-clang
           export CXX_${TARGET}=x86_64-unknown-linux-gnu26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1358,6 +1375,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-linux-android26-clang
           export CXX_${TARGET}=aarch64-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1430,6 +1448,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-linux-android26-clang
           export CXX_${TARGET}=x86_64-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1502,6 +1521,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=i686-linux-android26-clang
           export CXX_${TARGET}=i686-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1596,6 +1616,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-unknown-linux-gnu26-clang
           export CXX_${TARGET}=x86_64-unknown-linux-gnu26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1668,6 +1689,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-linux-android26-clang
           export CXX_${TARGET}=aarch64-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1740,6 +1762,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-linux-android26-clang
           export CXX_${TARGET}=x86_64-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1812,6 +1835,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=i686-linux-android26-clang
           export CXX_${TARGET}=i686-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1906,6 +1930,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-unknown-linux-gnu26-clang
           export CXX_${TARGET}=x86_64-unknown-linux-gnu26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1978,6 +2003,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-linux-android26-clang
           export CXX_${TARGET}=aarch64-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -2050,6 +2076,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-linux-android26-clang
           export CXX_${TARGET}=x86_64-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -2122,6 +2149,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=i686-linux-android26-clang
           export CXX_${TARGET}=i686-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -2216,6 +2244,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-unknown-linux-gnu26-clang
           export CXX_${TARGET}=x86_64-unknown-linux-gnu26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -2288,6 +2317,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-linux-android26-clang
           export CXX_${TARGET}=aarch64-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -2360,6 +2390,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-linux-android26-clang
           export CXX_${TARGET}=x86_64-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -2432,6 +2463,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=i686-linux-android26-clang
           export CXX_${TARGET}=i686-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -2526,6 +2558,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-unknown-linux-gnu26-clang
           export CXX_${TARGET}=x86_64-unknown-linux-gnu26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -2598,6 +2631,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-linux-android26-clang
           export CXX_${TARGET}=aarch64-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -2670,6 +2704,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-linux-android26-clang
           export CXX_${TARGET}=x86_64-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -2742,6 +2777,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=i686-linux-android26-clang
           export CXX_${TARGET}=i686-linux-android26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"

--- a/.github/workflows/macos-qa.yaml
+++ b/.github/workflows/macos-qa.yaml
@@ -51,6 +51,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-apple-darwin26-clang
           export CXX_${TARGET}=x86_64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -123,6 +124,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-apple-darwin26-clang
           export CXX_${TARGET}=aarch64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -195,6 +197,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-apple-ios26-clang
           export CXX_${TARGET}=aarch64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -267,6 +270,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-apple-ios26-clang
           export CXX_${TARGET}=x86_64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -361,6 +365,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-apple-darwin26-clang
           export CXX_${TARGET}=x86_64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -433,6 +438,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-apple-darwin26-clang
           export CXX_${TARGET}=aarch64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -505,6 +511,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-apple-ios26-clang
           export CXX_${TARGET}=aarch64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -577,6 +584,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-apple-ios26-clang
           export CXX_${TARGET}=x86_64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -671,6 +679,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-apple-darwin26-clang
           export CXX_${TARGET}=x86_64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -743,6 +752,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-apple-darwin26-clang
           export CXX_${TARGET}=aarch64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -815,6 +825,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-apple-ios26-clang
           export CXX_${TARGET}=aarch64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -887,6 +898,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-apple-ios26-clang
           export CXX_${TARGET}=x86_64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"

--- a/.github/workflows/macos-release.yaml
+++ b/.github/workflows/macos-release.yaml
@@ -46,6 +46,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-apple-darwin26-clang
           export CXX_${TARGET}=x86_64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -118,6 +119,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-apple-darwin26-clang
           export CXX_${TARGET}=aarch64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -190,6 +192,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-apple-ios26-clang
           export CXX_${TARGET}=aarch64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -262,6 +265,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-apple-ios26-clang
           export CXX_${TARGET}=x86_64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -356,6 +360,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-apple-darwin26-clang
           export CXX_${TARGET}=x86_64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -428,6 +433,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-apple-darwin26-clang
           export CXX_${TARGET}=aarch64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -500,6 +506,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-apple-ios26-clang
           export CXX_${TARGET}=aarch64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -572,6 +579,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-apple-ios26-clang
           export CXX_${TARGET}=x86_64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -666,6 +674,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-apple-darwin26-clang
           export CXX_${TARGET}=x86_64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -738,6 +747,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-apple-darwin26-clang
           export CXX_${TARGET}=aarch64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -810,6 +820,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-apple-ios26-clang
           export CXX_${TARGET}=aarch64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -882,6 +893,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-apple-ios26-clang
           export CXX_${TARGET}=x86_64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -976,6 +988,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-apple-darwin26-clang
           export CXX_${TARGET}=x86_64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1048,6 +1061,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-apple-darwin26-clang
           export CXX_${TARGET}=aarch64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1120,6 +1134,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-apple-ios26-clang
           export CXX_${TARGET}=aarch64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1192,6 +1207,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-apple-ios26-clang
           export CXX_${TARGET}=x86_64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1286,6 +1302,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-apple-darwin26-clang
           export CXX_${TARGET}=x86_64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1358,6 +1375,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-apple-darwin26-clang
           export CXX_${TARGET}=aarch64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1430,6 +1448,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-apple-ios26-clang
           export CXX_${TARGET}=aarch64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1502,6 +1521,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-apple-ios26-clang
           export CXX_${TARGET}=x86_64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1596,6 +1616,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-apple-darwin26-clang
           export CXX_${TARGET}=x86_64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1668,6 +1689,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-apple-darwin26-clang
           export CXX_${TARGET}=aarch64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1740,6 +1762,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-apple-ios26-clang
           export CXX_${TARGET}=aarch64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1812,6 +1835,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-apple-ios26-clang
           export CXX_${TARGET}=x86_64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1906,6 +1930,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-apple-darwin26-clang
           export CXX_${TARGET}=x86_64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -1978,6 +2003,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-apple-darwin26-clang
           export CXX_${TARGET}=aarch64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -2050,6 +2076,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-apple-ios26-clang
           export CXX_${TARGET}=aarch64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -2122,6 +2149,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-apple-ios26-clang
           export CXX_${TARGET}=x86_64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -2216,6 +2244,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-apple-darwin26-clang
           export CXX_${TARGET}=x86_64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -2288,6 +2317,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-apple-darwin26-clang
           export CXX_${TARGET}=aarch64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -2360,6 +2390,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-apple-ios26-clang
           export CXX_${TARGET}=aarch64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -2432,6 +2463,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-apple-ios26-clang
           export CXX_${TARGET}=x86_64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -2526,6 +2558,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-apple-darwin26-clang
           export CXX_${TARGET}=x86_64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -2598,6 +2631,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-apple-darwin26-clang
           export CXX_${TARGET}=aarch64-apple-darwin26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -2670,6 +2704,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=aarch64-apple-ios26-clang
           export CXX_${TARGET}=aarch64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -2742,6 +2777,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-apple-ios26-clang
           export CXX_${TARGET}=x86_64-apple-ios26-clang++
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"

--- a/.github/workflows/windows-qa.yaml
+++ b/.github/workflows/windows-qa.yaml
@@ -61,6 +61,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-pc-windows-msvc26-clang.exe
           export CXX_${TARGET}=x86_64-pc-windows-msvc26-clang++.exe
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -165,6 +166,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-pc-windows-msvc26-clang.exe
           export CXX_${TARGET}=x86_64-pc-windows-msvc26-clang++.exe
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -269,6 +271,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-pc-windows-msvc26-clang.exe
           export CXX_${TARGET}=x86_64-pc-windows-msvc26-clang++.exe
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"

--- a/.github/workflows/windows-release.yaml
+++ b/.github/workflows/windows-release.yaml
@@ -56,6 +56,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-pc-windows-msvc26-clang.exe
           export CXX_${TARGET}=x86_64-pc-windows-msvc26-clang++.exe
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -160,6 +161,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-pc-windows-msvc26-clang.exe
           export CXX_${TARGET}=x86_64-pc-windows-msvc26-clang++.exe
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -264,6 +266,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-pc-windows-msvc26-clang.exe
           export CXX_${TARGET}=x86_64-pc-windows-msvc26-clang++.exe
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -368,6 +371,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-pc-windows-msvc26-clang.exe
           export CXX_${TARGET}=x86_64-pc-windows-msvc26-clang++.exe
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -472,6 +476,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-pc-windows-msvc26-clang.exe
           export CXX_${TARGET}=x86_64-pc-windows-msvc26-clang++.exe
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -576,6 +581,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-pc-windows-msvc26-clang.exe
           export CXX_${TARGET}=x86_64-pc-windows-msvc26-clang++.exe
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -680,6 +686,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-pc-windows-msvc26-clang.exe
           export CXX_${TARGET}=x86_64-pc-windows-msvc26-clang++.exe
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -784,6 +791,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-pc-windows-msvc26-clang.exe
           export CXX_${TARGET}=x86_64-pc-windows-msvc26-clang++.exe
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
@@ -888,6 +896,7 @@ jobs:
           TARGET=${TARGET//-/_}
           export CC_${TARGET}=x86_64-pc-windows-msvc26-clang.exe
           export CXX_${TARGET}=x86_64-pc-windows-msvc26-clang++.exe
+          export AR_${TARGET}=llvm-ar
           TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"

--- a/README.md
+++ b/README.md
@@ -161,13 +161,13 @@ For example, to compile for `aarch64`:
    ```bash
    rustup target install aarch64-linux-android
    ```
-2. Download the [r21e NDK](https://developer.android.com/ndk/downloads) for your host architecture and unzip it.
+2. Download the [r23b NDK](https://developer.android.com/ndk/downloads) for your host architecture and unzip it.
 3. Compile your package for the `aarch64-linux-android` target:
 
 On **macOS**:
 
 ```bash
-export ANDROID_NDK=:path-to-android-ndk-r21e
+export ANDROID_NDK=:path-to-android-ndk-r23b
 export PATH=$PATH:$ANDROID_NDK/toolchains/llvm/prebuilt/darwin-x86_64/bin
 export CC_aarch64_linux_android=aarch64-linux-android26-clang
 export CXX_aarch64_linux_android=aarch64-linux-android26-clang++
@@ -181,7 +181,7 @@ Note: we don't support Apple's Clang 11 to build for Android on macOS, so you ne
 On **Linux**:
 
 ```bash
-export ANDROID_NDK=:path-to-android-ndk-r21e
+export ANDROID_NDK=:path-to-android-ndk-r23b
 export PATH=$PATH:$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin
 export CC_aarch64_linux_android=aarch64-linux-android26-clang
 export CXX_aarch64_linux_android=aarch64-linux-android26-clang++
@@ -193,7 +193,7 @@ cargo build -vv --target aarch64-linux-android
 On **Windows** the Android NDK clang executable must be invoked through `.cmd` scripts:
 
 ```bash
-export ANDROID_NDK=:path-to-android-ndk-r21e
+export ANDROID_NDK=:path-to-android-ndk-r23b
 export PATH=$PATH:$ANDROID_NDK/toolchains/llvm/prebuilt/windows-x86_64/bin
 export CC_aarch64_linux_android=aarch64-linux-android26-clang.cmd
 export CXX_aarch64_linux_android=aarch64-linux-android26-clang++.cmd

--- a/mk-workflows/src/templates/target.yaml
+++ b/mk-workflows/src/templates/target.yaml
@@ -11,6 +11,7 @@
       TARGET=${TARGET//-/_}
       export CC_${TARGET}=$[[target]]$[[androidAPILevel]]-clang$[[hostBinExt]]
       export CXX_${TARGET}=$[[target]]$[[androidAPILevel]]-clang++$[[hostBinExt]]
+      export AR_${TARGET}=llvm-ar
       TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
       export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=$[[target]]$[[androidAPILevel]]-clang$[[hostBinExt]]
       echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"


### PR DESCRIPTION
Once the containers are updated, we can try to build rust-skia with the latest Android NDK r23b.

**Update:** Reverted the containers. This is not as easy as expected, the Android NDK has changed significantly:

- [ ] Use llvm-ar instead of gnu utils ar.
- [ ] features.h not found (wrong -sysroot?)
- [ ] `-lgcc` (`libgcc.a`) not found (who refers to it?, suspicion is the `cc` crate).