### PR TITLE
Milestone 97

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![Windows QA](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml) [![Linux QA](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml) [![macOS QA](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml)
 
-Skia Submodule Status: chrome/m96 ([upstream changes][skia-upstream], [our changes][skia-ours]).
+Skia Submodule Status: chrome/m97 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m96-0.44.3...google:chrome/m96
-[skia-ours]: https://github.com/google/skia/compare/chrome/m96...rust-skia:m96-0.44.3
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m97-0.45.2...google:chrome/m97
+[skia-ours]: https://github.com/google/skia/compare/chrome/m97...rust-skia:m97-0.45.2
 
 ## Goals
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.45.1"
+version = "0.46.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m96-0.44.3"
+skia = "m97-0.45.2"
 depot_tools = "fade894"
 
 [features]

--- a/skia-bindings/src/vulkan.cpp
+++ b/skia-bindings/src/vulkan.cpp
@@ -13,12 +13,12 @@
 // Additional types not yet referenced.
 extern "C" void C_GrVkTypes(GrVkSurfaceInfo *) {};
 
-extern "C" void C_GrBackendFormat_ConstructVk(GrBackendFormat* uninitialized, VkFormat format) {
-    new(uninitialized)GrBackendFormat(GrBackendFormat::MakeVk(format));
+extern "C" void C_GrBackendFormat_ConstructVk(GrBackendFormat* uninitialized, VkFormat format, bool willUseDRMFormatModifiers) {
+    new(uninitialized)GrBackendFormat(GrBackendFormat::MakeVk(format, willUseDRMFormatModifiers));
 }
 
-extern "C" void C_GrBackendFormat_ConstructVk2(GrBackendFormat* uninitialized, const GrVkYcbcrConversionInfo* ycbcrInfo) {
-    new(uninitialized)GrBackendFormat(GrBackendFormat::MakeVk(*ycbcrInfo));
+extern "C" void C_GrBackendFormat_ConstructVk2(GrBackendFormat* uninitialized, const GrVkYcbcrConversionInfo* ycbcrInfo,  bool willUseDRMFormatModifiers) {
+    new(uninitialized)GrBackendFormat(GrBackendFormat::MakeVk(*ycbcrInfo, willUseDRMFormatModifiers));
 }
 
 extern "C" void C_GrBackendTexture_ConstructVk(GrBackendTexture* uninitialized, int width, int height, const GrVkImageInfo* vkInfo) {

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.45.1"
+version = "0.46.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -46,7 +46,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 [dependencies]
 bitflags = "1.2"
 lazy_static = "1.4"
-skia-bindings = { version = "=0.45.1", path = "../skia-bindings", default-features = false }
+skia-bindings = { version = "=0.46.0", path = "../skia-bindings", default-features = false }
 # for d3d types
 winapi = { version = "0.3.9", features = ["d3d12", "dxgi"], optional = true }
 # for ComPtr

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -35,7 +35,7 @@ bitflags! {
 }
 
 /// [`SaveLayerRec`] contains the state used to create the layer.
-#[allow(dead_code)]
+#[repr(C)]
 pub struct SaveLayerRec<'a> {
     // We _must_ store _references_ to the native types here, because not all of them are native
     // transmutable, like ImageFilter or Image, which are represented as ref counted pointers and so
@@ -44,6 +44,7 @@ pub struct SaveLayerRec<'a> {
     paint: Option<&'a SkPaint>,
     backdrop: Option<&'a SkImageFilter>,
     flags: SaveLayerFlags,
+    experimental_backdrop_scale: scalar,
 }
 
 native_transmutable!(
@@ -62,6 +63,10 @@ impl fmt::Debug for SaveLayerRec<'_> {
                 &ImageFilter::from_unshared_ptr_ref(&(self.backdrop.as_ptr_or_null() as *mut _)),
             )
             .field("flags", &self.flags)
+            .field(
+                "experimental_backdrop_scale",
+                &self.experimental_backdrop_scale,
+            )
             .finish()
     }
 }
@@ -77,6 +82,7 @@ impl<'a> Default for SaveLayerRec<'a> {
             paint: None,
             backdrop: None,
             flags: SaveLayerFlags::empty(),
+            experimental_backdrop_scale: 1.0,
         }
     }
 }

--- a/skia-safe/src/core/image.rs
+++ b/skia-safe/src/core/image.rs
@@ -378,7 +378,7 @@ impl Image {
     }
 
     #[cfg(feature = "gpu")]
-    #[deprecated(since = "0.0.0", note = "use flush()")]
+    #[deprecated(since = "0.46.0", note = "use flush()")]
     pub fn flush_with_info(
         &self,
         context: &mut gpu::DirectContext,

--- a/skia-safe/src/core/milestone.rs
+++ b/skia-safe/src/core/milestone.rs
@@ -1,1 +1,1 @@
-pub const MILESTONE: usize = 96;
+pub const MILESTONE: usize = 97;

--- a/skia-safe/src/effects/color_matrix.rs
+++ b/skia-safe/src/effects/color_matrix.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::{prelude::*, YUVColorSpace};
 use skia_bindings::{self as sb, SkColorMatrix};
 use std::fmt;
 
@@ -63,6 +63,14 @@ impl ColorMatrix {
                 m31, m32, m33, m34,
             )
         })
+    }
+
+    pub fn rgb_to_yuv(rgb: YUVColorSpace) -> Self {
+        Self::from_native_c(unsafe { sb::SkColorMatrix_RGBtoYUV(rgb) })
+    }
+
+    pub fn yuv_to_rgb(yuv: YUVColorSpace) -> Self {
+        Self::from_native_c(unsafe { sb::SkColorMatrix_YUVtoRGB(yuv) })
     }
 
     pub fn set_identity(&mut self) {

--- a/skia-safe/src/gpu/backend_surface.rs
+++ b/skia-safe/src/gpu/backend_surface.rs
@@ -65,15 +65,29 @@ impl BackendFormat {
     }
 
     #[cfg(feature = "vulkan")]
-    pub fn new_vulkan(format: vk::Format) -> Self {
-        Self::construct(|bf| unsafe { sb::C_GrBackendFormat_ConstructVk(bf, format) })
-            .assert_valid()
+    pub fn new_vulkan(
+        format: vk::Format,
+        will_use_drm_format_modifiers: impl Into<Option<bool>>,
+    ) -> Self {
+        let will_use_drm_format_modifiers = will_use_drm_format_modifiers.into().unwrap_or(false);
+        Self::construct(|bf| unsafe {
+            sb::C_GrBackendFormat_ConstructVk(bf, format, will_use_drm_format_modifiers)
+        })
+        .assert_valid()
     }
 
     #[cfg(feature = "vulkan")]
-    pub fn new_vulkan_ycbcr(conversion_info: &vk::YcbcrConversionInfo) -> Self {
+    pub fn new_vulkan_ycbcr(
+        conversion_info: &vk::YcbcrConversionInfo,
+        will_use_drm_format_modifiers: impl Into<Option<bool>>,
+    ) -> Self {
+        let will_use_drm_format_modifiers = will_use_drm_format_modifiers.into().unwrap_or(false);
         Self::construct(|bf| unsafe {
-            sb::C_GrBackendFormat_ConstructVk2(bf, conversion_info.native())
+            sb::C_GrBackendFormat_ConstructVk2(
+                bf,
+                conversion_info.native(),
+                will_use_drm_format_modifiers,
+            )
         })
         .assert_valid()
     }

--- a/skia-safe/src/modules/paragraph/text_style.rs
+++ b/skia-safe/src/modules/paragraph/text_style.rs
@@ -187,6 +187,7 @@ impl fmt::Debug for TextStyle {
             .field("font_features", &self.font_features())
             .field("font_size", &self.font_size())
             .field("font_families", &self.font_families())
+            .field("baseline_shift", &self.baseline_shift())
             .field("height", &self.height())
             .field("height_override", &self.height_override())
             .field("half_leading", &self.half_leading())
@@ -335,6 +336,15 @@ impl TextStyle {
         unsafe {
             sb::C_TextStyle_setFontFamilies(self.native_mut(), families.as_ptr(), families.len())
         }
+        self
+    }
+
+    pub fn baseline_shift(&self) -> scalar {
+        self.native().fBaselineShift
+    }
+
+    pub fn set_baseline_shift(&mut self, baseline_shift: scalar) -> &mut Self {
+        self.native_mut().fBaselineShift = baseline_shift;
         self
     }
 


### PR DESCRIPTION
This PR updates rust-skia to support Skia's `chrome/m97` branch.

- [x] Update `README.md` ([rendered](https://github.com/pragmatrix/rust-skia/blob/m97/README.md))  
  > Most important here is to change the Skia branch name and the current Skia submodule tag at the top of the `README.md` file.
- [x] Diff the the following files to see if the build organization has changed significantly:
  - [x] `/BUILD.gn`
  - [x] `/modules/skshaper/BUILD.gn`
  - [x] `/modules/paragraph/BUILD.gn`
- [x] Skia builds ([release notes](https://github.com/google/skia/blob/chrome/m97/RELEASE_NOTES.txt)).
- [x] `/skia-bindings` builds.
- [x] `/skia-safe`: Update & add new wrappers by diffing include files.  
  > Add TODOs for everything that can not be updated right now, and attempt to stay compatible with previous versions of skia-safe without trying too hard before version 1.0. Use `deprecated` attributes if needed.
  - [x] `codec/`
  - [x] `core/`
  - [x] `docs/`
  - [x] `effects/`
  - [x] `gpu/`
    - [x] `d3d/`
    - [x] `gl/`
    - [x] `mtl/`
    - [x] `vk/`
  - [x] `modules/`
    - [x] `paragraph/`
    - [x] `shaper/`
  - [x] `pathops/`
  - [x] `svg/`
  - [x] `utils/`
- [x] Review `Send` & `Sync` implementations for new wrappers.
- [x] Review `Debug` implementation for new wrapper types and functions.
- [x] Any pending changes in the Skia `chrome/m97` branch that aren't synchronized yet?
- [x] Rebase on or merge with master.
- [x] Do the `rust-skia:` commits in the `skia-bindings/skia` subdirectory match with `master`.
- [x] Update versions of `skia-bindings/Cargo.toml` and `skia-safe/Cargo.toml` and also add the version to the new `deprecated` attributes.
- [x] Do the tags/hashes in `skia-bindings/Cargo.toml` under `[package.metadata]` match the submodules `depot_tools` and `skia`?
- [x] Test builds we don't do on the CI:
  - [x] Compiles to Catalyst targets on macOS (#548).
    ```zsh
    make macos-qa
    ```
- [x] Do one final review of all the changes.
- [x] Run `cargo doc` with all features and fix all warnings.

