### PR TITLE
Fix a SIGSEGV when StyleMetrics were retrieved from LineMetrics

### DIFF
--- a/skia-bindings/src/paragraph.cpp
+++ b/skia-bindings/src/paragraph.cpp
@@ -163,7 +163,11 @@ extern "C" {
     void C_LineMetrics_destruct(LineMetrics* self) {
         self->~LineMetrics();
     }
-    
+
+    void C_LineMetrics_CopyConstruct(LineMetrics* uninitialized, const LineMetrics* from) {
+        new(uninitialized)LineMetrics(*from);
+    }
+
     size_t C_LineMetrics_fLineMetrics_count(const LineMetrics* self, size_t begin, size_t end) {
         auto lower = self->fLineMetrics.lower_bound(begin);
         auto upper = self->fLineMetrics.upper_bound(end);

--- a/skia-bindings/src/paragraph.cpp
+++ b/skia-bindings/src/paragraph.cpp
@@ -168,23 +168,21 @@ extern "C" {
         new(uninitialized)LineMetrics(*from);
     }
 
-    size_t C_LineMetrics_fLineMetrics_count(const LineMetrics* self, size_t begin, size_t end) {
-        auto lower = self->fLineMetrics.lower_bound(begin);
-        auto upper = self->fLineMetrics.upper_bound(end);
-        return std::distance(lower, upper);
+    size_t C_LineMetrics_styleMetricsCount(const LineMetrics* self) {
+        return self->fLineMetrics.size();
     }
-    
-    struct StyleMetricsRecord {
+
+    struct IndexedStyleMetrics {
         size_t index;
-        const StyleMetrics* metrics;
+        StyleMetrics metrics;
     };
-    
-    void C_LineMetrics_fLineMetrics_getRange(const LineMetrics* self, size_t begin, size_t end, StyleMetricsRecord* array) {
-        auto lower = self->fLineMetrics.lower_bound(begin);
-        auto upper = self->fLineMetrics.upper_bound(end);
-        for (auto it = lower; it != upper; it++)
-        {
-            *array++ = StyleMetricsRecord { it->first, &it->second };
+
+    void C_LineMetrics_getAllStyleMetrics(const LineMetrics* self, IndexedStyleMetrics* result) {
+        auto begin = self->fLineMetrics.begin();
+        auto end = self->fLineMetrics.end();
+
+        for (auto it = begin; it != end; ++it) {
+            *result++ = IndexedStyleMetrics { it->first, it->second };
         }
     }
 }

--- a/skia-bindings/src/paragraph.cpp
+++ b/skia-bindings/src/paragraph.cpp
@@ -160,14 +160,6 @@ extern "C" {
 //
 
 extern "C" {
-    void C_LineMetrics_destruct(LineMetrics* self) {
-        self->~LineMetrics();
-    }
-
-    void C_LineMetrics_CopyConstruct(LineMetrics* uninitialized, const LineMetrics* from) {
-        new(uninitialized)LineMetrics(*from);
-    }
-
     size_t C_LineMetrics_styleMetricsCount(const LineMetrics* self) {
         return self->fLineMetrics.size();
     }

--- a/skia-safe/src/modules/paragraph/metrics.rs
+++ b/skia-safe/src/modules/paragraph/metrics.rs
@@ -24,7 +24,7 @@ impl<'a> StyleMetrics<'a> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct LineMetrics<'a> {
     pub start_index: usize,
     pub end_index: usize,

--- a/skia-safe/src/modules/paragraph/metrics.rs
+++ b/skia-safe/src/modules/paragraph/metrics.rs
@@ -25,7 +25,7 @@ impl<'a> StyleMetrics<'a> {
 }
 
 #[repr(C)]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct LineMetrics<'a> {
     pub start_index: usize,
     pub end_index: usize,
@@ -50,6 +50,18 @@ native_transmutable!(
     LineMetrics<'_>,
     line_metrics_layout
 );
+
+impl<'a> Clone for LineMetrics<'a> {
+    fn clone(&self) -> Self {
+        Self::construct(|lm| unsafe { sb::C_LineMetrics_CopyConstruct(lm, self.native()) })
+    }
+}
+
+impl<'a> Drop for LineMetrics<'a> {
+    fn drop(&mut self) {
+        unsafe { sb::C_LineMetrics_destruct(self.native_mut()) }
+    }
+}
 
 // Internal Line Metrics mirror to compute what the map takes up space.
 // If the size of the structure does not match, the NativeTransmutable test above will fail.

--- a/skia-safe/src/modules/paragraph/paragraph.rs
+++ b/skia-safe/src/modules/paragraph/paragraph.rs
@@ -131,10 +131,7 @@ impl Paragraph {
     pub fn get_line_metrics(&self) -> Vec<LineMetrics> {
         let mut result: Vec<LineMetrics> = Vec::new();
         let mut set_lm = |lms: &[sb::skia_textlayout_LineMetrics]| {
-            result = lms
-                .iter()
-                .map(LineMetrics::from_native_ref)
-                .collect();
+            result = lms.iter().map(LineMetrics::from_native_ref).collect();
         };
 
         unsafe {

--- a/skia-safe/src/modules/paragraph/paragraph.rs
+++ b/skia-safe/src/modules/paragraph/paragraph.rs
@@ -128,13 +128,12 @@ impl Paragraph {
         range[0]..range[1]
     }
 
-    /// TODO: find a way to prevent the excessive cloning of LineMetrics.
     pub fn get_line_metrics(&self) -> Vec<LineMetrics> {
         let mut result: Vec<LineMetrics> = Vec::new();
         let mut set_lm = |lms: &[sb::skia_textlayout_LineMetrics]| {
             result = lms
                 .iter()
-                .map(|lm| LineMetrics::from_native_ref(lm).clone())
+                .map(|lm| LineMetrics::from_native_ref(lm))
                 .collect();
         };
 

--- a/skia-safe/src/modules/paragraph/paragraph.rs
+++ b/skia-safe/src/modules/paragraph/paragraph.rs
@@ -200,4 +200,24 @@ mod tests {
 
         static LOREM_IPSUM: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur at leo at nulla tincidunt placerat. Proin eget purus augue. Quisque et est ullamcorper, pellentesque felis nec, pulvinar massa. Aliquam imperdiet, nulla ut dictum euismod, purus dui pulvinar risus, eu suscipit elit neque ac est. Nullam eleifend justo quis placerat ultricies. Vestibulum ut elementum velit. Praesent et dolor sit amet purus bibendum mattis. Aliquam erat volutpat.";
     }
+
+    /// Regression test for <https://github.com/rust-skia/rust-skia/issues/585>
+    #[test]
+    #[serial_test::serial]
+    fn test_style_metrics() {
+        icu::init();
+
+        let mut style = ParagraphStyle::new();
+        let ts = TextStyle::new();
+        style.set_text_style(&ts);
+        let mut font_collection = FontCollection::new();
+        font_collection.set_default_font_manager(FontMgr::default(), None);
+        let mut paragraph_builder = ParagraphBuilder::new(&style, font_collection);
+        paragraph_builder.add_text("Lorem ipsum dolor sit amet\n");
+        let mut paragraph = paragraph_builder.build();
+        paragraph.layout(100.0);
+
+        let line_metrics = &paragraph.get_line_metrics()[0];
+        line_metrics.get_style_metrics(line_metrics.start_index..line_metrics.end_index);
+    }
 }

--- a/skia-safe/src/modules/paragraph/paragraph.rs
+++ b/skia-safe/src/modules/paragraph/paragraph.rs
@@ -128,6 +128,7 @@ impl Paragraph {
         range[0]..range[1]
     }
 
+    /// TODO: find a way to prevent the excessive cloning of LineMetrics.
     pub fn get_line_metrics(&self) -> Vec<LineMetrics> {
         let mut result: Vec<LineMetrics> = Vec::new();
         let mut set_lm = |lms: &[sb::skia_textlayout_LineMetrics]| {

--- a/skia-safe/src/modules/paragraph/paragraph.rs
+++ b/skia-safe/src/modules/paragraph/paragraph.rs
@@ -133,7 +133,7 @@ impl Paragraph {
         let mut set_lm = |lms: &[sb::skia_textlayout_LineMetrics]| {
             result = lms
                 .iter()
-                .map(|lm| LineMetrics::from_native_ref(lm))
+                .map(LineMetrics::from_native_ref)
                 .collect();
         };
 


### PR DESCRIPTION
@romanzes This PR needs some polishing but is functionally complete. It fixes the SIGSEGV reported by copying over StyleMetrics into a Rust Vec instead of cloning or moving the underlying C++ `std::map`. I kept the API surface the same, so that we can release an updated version 0.45.1.

Closes #585 