### PR TITLE
Fix 1.58-beta.1 clippy warnings

### DIFF
--- a/mk-workflows/src/main.rs
+++ b/mk-workflows/src/main.rs
@@ -79,7 +79,7 @@ fn build_workflow(workflow: &Workflow, jobs: &[Job]) {
     let job_template = workflow.job_template;
     let targets = &workflow.targets;
 
-    let workflow_name = format!("{}-{}", host_os.to_string(), workflow.kind.to_string());
+    let workflow_name = format!("{}-{}", host_os, workflow.kind);
     let output_filename = PathBuf::new()
         .join(".github")
         .join("workflows")

--- a/skia-bindings/build_support/binaries_config.rs
+++ b/skia-bindings/build_support/binaries_config.rs
@@ -202,7 +202,7 @@ impl BinariesConfiguration {
                     "COPY OPERATION FAILED: from '{}' to '{}': {}",
                     from_path.display(),
                     to_path.display(),
-                    e.to_string()
+                    e
                 );
                 e
             })

--- a/skia-bindings/build_support/skia/config.rs
+++ b/skia-bindings/build_support/skia/config.rs
@@ -139,7 +139,7 @@ impl FinalBuildConfiguration {
 
             // target specific gn args.
             let target = cargo::target();
-            let target_str: &str = &format!("--target={}", target.to_string());
+            let target_str: &str = &format!("--target={}", target);
             let mut set_target = true;
             let sysroot_arg;
             let opt_level_arg;

--- a/skia-safe/examples/icon/main.rs
+++ b/skia-safe/examples/icon/main.rs
@@ -29,7 +29,7 @@ fn main() {
             } else {
                 match args[1].parse::<i32>() {
                     Ok(integer) => (integer, true),
-                    Err(e) => panic!("Error: {}\nUsage: {}", e.to_string(), USAGE),
+                    Err(e) => panic!("Error: {}\nUsage: {}", e, USAGE),
                 }
             }
         }

--- a/skia-safe/src/lib.rs
+++ b/skia-safe/src/lib.rs
@@ -1,5 +1,6 @@
 #![macro_use]
 #![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::non_send_fields_in_send_ty)]
 
 mod macros;
 


### PR DESCRIPTION
I am bit a concerned about the unsound warnings, but haven't found any solution other than disabling them. 