### PR TITLE
Support Visual Studio 2022

### DIFF
--- a/.github/workflows/windows-qa.yaml
+++ b/.github/workflows/windows-qa.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   windows-qa-stable-all-features:
-    runs-on: windows-2019
+    runs-on: windows-2022
     # Containers are not supported on Windows.
     # container: ghcr.io/pragmatrix/rust-skia-windows:latest
     env: 
@@ -121,7 +121,7 @@ jobs:
         token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
         prerelease: true
   windows-qa-stable-all-features-debug:
-    runs-on: windows-2019
+    runs-on: windows-2022
     # Containers are not supported on Windows.
     # container: ghcr.io/pragmatrix/rust-skia-windows:latest
     env: 
@@ -225,7 +225,7 @@ jobs:
         token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
         prerelease: true
   windows-qa-beta-all-features:
-    runs-on: windows-2019
+    runs-on: windows-2022
     # Containers are not supported on Windows.
     # container: ghcr.io/pragmatrix/rust-skia-windows:latest
     env: 

--- a/.github/workflows/windows-release.yaml
+++ b/.github/workflows/windows-release.yaml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   windows-release-release:
-    runs-on: windows-2019
+    runs-on: windows-2022
     # Containers are not supported on Windows.
     # container: ghcr.io/pragmatrix/rust-skia-windows:latest
     env: 
@@ -116,7 +116,7 @@ jobs:
         token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
         prerelease: true
   windows-release-release-gl:
-    runs-on: windows-2019
+    runs-on: windows-2022
     # Containers are not supported on Windows.
     # container: ghcr.io/pragmatrix/rust-skia-windows:latest
     env: 
@@ -220,7 +220,7 @@ jobs:
         token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
         prerelease: true
   windows-release-release-vulkan:
-    runs-on: windows-2019
+    runs-on: windows-2022
     # Containers are not supported on Windows.
     # container: ghcr.io/pragmatrix/rust-skia-windows:latest
     env: 
@@ -324,7 +324,7 @@ jobs:
         token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
         prerelease: true
   windows-release-release-textlayout:
-    runs-on: windows-2019
+    runs-on: windows-2022
     # Containers are not supported on Windows.
     # container: ghcr.io/pragmatrix/rust-skia-windows:latest
     env: 
@@ -428,7 +428,7 @@ jobs:
         token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
         prerelease: true
   windows-release-release-gl-textlayout:
-    runs-on: windows-2019
+    runs-on: windows-2022
     # Containers are not supported on Windows.
     # container: ghcr.io/pragmatrix/rust-skia-windows:latest
     env: 
@@ -532,7 +532,7 @@ jobs:
         token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
         prerelease: true
   windows-release-release-vulkan-textlayout:
-    runs-on: windows-2019
+    runs-on: windows-2022
     # Containers are not supported on Windows.
     # container: ghcr.io/pragmatrix/rust-skia-windows:latest
     env: 
@@ -636,7 +636,7 @@ jobs:
         token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
         prerelease: true
   windows-release-release-gl-vulkan-textlayout:
-    runs-on: windows-2019
+    runs-on: windows-2022
     # Containers are not supported on Windows.
     # container: ghcr.io/pragmatrix/rust-skia-windows:latest
     env: 
@@ -740,7 +740,7 @@ jobs:
         token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
         prerelease: true
   windows-release-release-d3d:
-    runs-on: windows-2019
+    runs-on: windows-2022
     # Containers are not supported on Windows.
     # container: ghcr.io/pragmatrix/rust-skia-windows:latest
     env: 
@@ -844,7 +844,7 @@ jobs:
         token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
         prerelease: true
   windows-release-release-d3d-textlayout:
-    runs-on: windows-2019
+    runs-on: windows-2022
     # Containers are not supported on Windows.
     # container: ghcr.io/pragmatrix/rust-skia-windows:latest
     env: 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The build script probes for `python --version` and `python2 --version` and uses 
 
 - Have the latest versions of `git` and Rust ready.
 
-- [Install Visual Studio 2019 Build Tools](https://visualstudio.microsoft.com/downloads/) or one of the IDE releases. If you installed the IDE, make sure that the [Desktop Development with C++ workload](https://docs.microsoft.com/en-us/cpp/build/vscpp-step-0-installation?view=vs-2019) is installed.
+- [Install Visual Studio 2022 Build Tools](https://visualstudio.microsoft.com/downloads/) or one of the other IDE editions. If you installed the IDE, make sure that the [Desktop Development with C++ workload](https://docs.microsoft.com/en-us/cpp/build/vscpp-step-0-installation?view=msvc-170) is installed.
 
 - Install the [latest LLVM](http://releases.llvm.org/download.html) distribution.
 

--- a/mk-workflows/src/templates/windows-job.yaml
+++ b/mk-workflows/src/templates/windows-job.yaml
@@ -1,4 +1,4 @@
-runs-on: windows-2019
+runs-on: windows-2022
 # Containers are not supported on Windows.
 # container: ghcr.io/pragmatrix/rust-skia-windows:latest
 env: 

--- a/skia-bindings/build_support/skia/vs.rs
+++ b/skia-bindings/build_support/skia/vs.rs
@@ -9,13 +9,13 @@ pub fn resolve_win_vc() -> Option<PathBuf> {
         return Some(PathBuf::from(install_dir));
     }
 
-    [
-        "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\VC",
-        "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC",
-        "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Professional\\VC",
-        "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC",
-    ]
-    .iter()
-    .map(PathBuf::from)
-    .find(|pb| pb.exists())
+    let releases = [("Program Files", "2022"), ("Program Files (x86)", "2019")];
+    let editions = ["BuildTools", "Enterprise", "Professional", "Community"];
+
+    releases
+        .iter()
+        .flat_map(|r| editions.iter().map(move |e| (r, e)))
+        .map(|((rp, r), ed)| format!("C:\\{}\\Microsoft Visual Studio\\{}\\{}\\VC", rp, r, ed))
+        .map(PathBuf::from)
+        .find(|pb| pb.exists())
 }


### PR DESCRIPTION
This PR supports the detection of the Visual Studio 2022 compiler paths, falling back to Visual Studio 2019 if they are missing.