### PR TITLE
Milestone 98

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m98 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m98-0.46.1...google:chrome/m98
-[skia-ours]: https://github.com/google/skia/compare/chrome/m98...rust-skia:m98-0.46.1
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m98-0.46.2...google:chrome/m98
+[skia-ours]: https://github.com/google/skia/compare/chrome/m98...rust-skia:m98-0.46.2
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![Windows QA](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml) [![Linux QA](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml) [![macOS QA](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml)
 
-Skia Submodule Status: chrome/m97 ([upstream changes][skia-upstream], [our changes][skia-ours]).
+Skia Submodule Status: chrome/m98 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m97-0.45.4...google:chrome/m97
-[skia-ours]: https://github.com/google/skia/compare/chrome/m97...rust-skia:m97-0.45.4
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m98-0.46.1...google:chrome/m98
+[skia-ours]: https://github.com/google/skia/compare/chrome/m98...rust-skia:m98-0.46.1
 
 ## Goals
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m98-0.46.1"
+skia = "m98-0.46.2"
 depot_tools = "fade894"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m97-0.45.4"
+skia = "m98-0.46.1"
 depot_tools = "fade894"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.46.0"
+version = "0.47.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"

--- a/skia-bindings/build_support/android.rs
+++ b/skia-bindings/build_support/android.rs
@@ -8,6 +8,10 @@ pub fn ndk() -> String {
     cargo::env_var("ANDROID_NDK").expect("ANDROID_NDK variable not set")
 }
 
+pub fn extra_skia_cflags() -> Vec<String> {
+    vec![format!("-D__ANDROID_API__={}", API_LEVEL)]
+}
+
 pub fn additional_clang_args(target: &str, target_arch: &str) -> Vec<String> {
     let mut args: Vec<String> = Vec::new();
 
@@ -28,6 +32,7 @@ pub fn additional_clang_args(target: &str, target_arch: &str) -> Vec<String> {
         ndk
     ));
     args.push(format!("--target={}", target));
+    args.extend(extra_skia_cflags());
     args
 }
 

--- a/skia-bindings/build_support/ios.rs
+++ b/skia-bindings/build_support/ios.rs
@@ -55,8 +55,8 @@ impl Platform {
 }
 
 // TODO: add support for 32 bit devices and simulators.
-pub fn extra_skia_cflags(arch: &str, abi: Option<&str>, flags: &mut Vec<&str>) {
-    flags.push(Platform::new(arch, abi).flags());
+pub fn extra_skia_cflags(arch: &str, abi: Option<&str>) -> Vec<String> {
+    vec![Platform::new(arch, abi).flags().into()]
 }
 
 pub fn additional_clang_args(arch: &str, abi: Option<&str>) -> Vec<String> {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -2356,14 +2356,14 @@ const unsigned char* C_SkRuntimeEffect_source(const SkRuntimeEffect *self, size_
 
 const SkRuntimeEffect::Uniform* C_SkRuntimeEffect_uniforms(const SkRuntimeEffect* self, size_t* count) {
     auto uniforms = self->uniforms();
-    *count = uniforms.count();
-    return &*uniforms.begin();
+    *count = uniforms.size();
+    return uniforms.begin();
 }
 
 const SkRuntimeEffect::Child* C_SkRuntimeEffect_children(const SkRuntimeEffect* self, size_t* count) {
     auto children = self->children();
-    *count = children.count();
-    return &*children.begin();
+    *count = children.size();
+    return children.begin();
 }
 
 }

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -299,8 +299,8 @@ extern "C" SkImage* C_SkImage_MakeFromGenerator(SkImageGenerator* imageGenerator
     return SkImage::MakeFromGenerator(std::unique_ptr<SkImageGenerator>(imageGenerator)).release();
 }
 
-extern "C" SkImage* C_SkImage_MakeFromEncoded(SkData* encoded) {
-    return SkImage::MakeFromEncoded(sp(encoded)).release();
+extern "C" SkImage* C_SkImage_MakeFromEncoded(SkData* encoded, const SkAlphaType* alphaType) {
+    return SkImage::MakeFromEncoded(sp(encoded), opt(alphaType)).release();
 }
 
 extern "C" SkImage* C_SkImage_MakeFromPicture(
@@ -319,6 +319,13 @@ extern "C" SkShader* C_SkImage_makeShader(
     SkTileMode tileMode1, SkTileMode tileMode2, 
     const SkSamplingOptions* samplingOptions, const SkMatrix* localMatrix) {
     return self->makeShader(tileMode1, tileMode2, *samplingOptions, localMatrix).release();
+}
+
+extern "C" SkShader* C_SkImage_makeRawShader(
+    const SkImage* self, 
+    SkTileMode tileMode1, SkTileMode tileMode2, 
+    const SkSamplingOptions* samplingOptions, const SkMatrix* localMatrix) {
+    return self->makeRawShader(tileMode1, tileMode2, *samplingOptions, localMatrix).release();
 }
 
 extern "C" SkData* C_SkImage_encodeToData(const SkImage* self, SkEncodedImageFormat imageFormat, int quality) {
@@ -398,6 +405,10 @@ extern "C" SkData* C_SkData_MakeSubset(const SkData* src, size_t offset, size_t 
 
 extern "C" SkData* C_SkData_MakeUninitialized(size_t length) {
     return SkData:: MakeUninitialized(length).release();
+}
+
+extern "C" SkData* C_SkData_MakeZeroInitialized(size_t length) {
+    return SkData:: MakeZeroInitialized(length).release();
 }
 
 extern "C" SkData* C_SkData_MakeWithCString(const char* cstr) {
@@ -1716,8 +1727,8 @@ extern "C" SkData *C_SkImageGenerator_refEncodedData(SkImageGenerator *self) {
     return self->refEncodedData().release();
 }
 
-extern "C" SkImageGenerator *C_SkImageGenerator_MakeFromEncoded(SkData *data) {
-    return SkImageGenerator::MakeFromEncoded(sp(data)).release();
+extern "C" SkImageGenerator *C_SkImageGenerator_MakeFromEncoded(SkData *data, const SkAlphaType* alphaType) {
+    return SkImageGenerator::MakeFromEncoded(sp(data), opt(alphaType)).release();
 }
 
 extern "C" SkImageGenerator *C_SkImageGenerator_MakeFromPicture(

--- a/skia-bindings/src/bindings.h
+++ b/skia-bindings/src/bindings.h
@@ -1,9 +1,10 @@
 #ifndef SKIA_BINDINGS_BINDINGS_H
 #define SKIA_BINDINGS_BINDINGS_H
 
+#include <vector>
 #include "include/core/SkRefCnt.h"
 #include "include/core/SkString.h"
-#include <vector>
+#include "include/private/SkTOptional.h"
 
 template<typename T>
 inline sk_sp<T> spFromConst(const T* pt) {
@@ -13,6 +14,11 @@ inline sk_sp<T> spFromConst(const T* pt) {
 template<typename T>
 inline sk_sp<T> sp(T* pt) {
     return sk_sp<T>(pt);
+}
+
+template<typename T>
+inline skstd::optional<T> opt(const T* pt) {
+    return pt ? skstd::optional<T>(*pt) : skstd::nullopt;
 }
 
 extern "C" struct TraitObject {

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.46.0"
+version = "0.47.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -46,7 +46,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 [dependencies]
 bitflags = "1.2"
 lazy_static = "1.4"
-skia-bindings = { version = "=0.46.0", path = "../skia-bindings", default-features = false }
+skia-bindings = { version = "=0.47.0", path = "../skia-bindings", default-features = false }
 # for d3d types
 winapi = { version = "0.3.9", features = ["d3d12", "dxgi"], optional = true }
 # for ComPtr

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -1033,9 +1033,6 @@ impl Canvas {
         self
     }
 
-    // TODO: markCTM
-    // TODO: findMarkedCTM
-
     pub fn concat_44(&mut self, m: &M44) -> &mut Self {
         unsafe { self.native_mut().concat1(m.native()) }
         self
@@ -1962,37 +1959,35 @@ impl Canvas {
     /// If `paint` contains an [`Shader`] and vertices does not contain tex coords, the shader is
     /// mapped using the vertices' positions.
     ///
-    /// If vertices colors are defined in vertices, and [`Paint`] `paint` contains [`Shader`],
-    /// [`BlendMode`] mode combines vertices colors with [`Shader`].
+    /// [`BlendMode`] is ignored if [`Vertices`] does not have colors. Otherwise, it combines
+    ///   - the [`Shader`] if [`Paint`] contains [`Shader`
+    ///   - or the opaque [`Paint`] color if [`Paint`] does not contain [`Shader`]
+    /// as the src of the blend and the interpolated vertex colors as the dst.
     ///
+    /// [`MaskFilter`], [`PathEffect`], and antialiasing on [`Paint`] are ignored.
+    //
     /// - `vertices` triangle mesh to draw
-    /// - `mode` combines vertices colors with [`Shader`], if both are present
-    /// - `paint` specifies the [`Shader`], used as [`Vertices`] texture, may be `None`
+    /// - `mode` combines vertices' colors with [`Shader`] if present or [`Paint`] opaque color if
+    ///   not. Ignored if the vertices do not contain color.
+    /// - `paint` specifies the [`Shader`], used as [`Vertices`] texture, and [`ColorFilter`].
     ///
+    /// example: <https://fiddle.skia.org/c/@Canvas_drawVertices>
     /// example: <https://fiddle.skia.org/c/@Canvas_drawVertices_2>
     pub fn draw_vertices(
         &mut self,
         vertices: &Vertices,
-        mode: impl Into<Option<BlendMode>>,
-        paint: Option<&Paint>,
+        mode: BlendMode,
+        paint: &Paint,
     ) -> &mut Self {
         unsafe {
-            self.native_mut().drawVertices(
-                vertices.native(),
-                mode.into().unwrap_or(BlendMode::Modulate),
-                paint.native_ptr_or_null(),
-            )
+            self.native_mut()
+                .drawVertices(vertices.native(), mode, paint.native())
         }
         self
     }
 
     /// Draws a Coons patch: the interpolation of four cubics with shared corners,
     /// associating a color, and optionally a texture [`Point`], with each corner.
-    ///
-    /// Coons patch uses clip and [`Matrix`], `paint` [`Shader`], [`crate::ColorFilter`],
-    /// alpha, [`ImageFilter`], and [`BlendMode`]. If [`Shader`] is provided it is treated
-    /// as Coons patch texture; [`BlendMode`] mode combines color colors and [`Shader`] if
-    /// both are provided.
     ///
     /// [`Point`] array cubics specifies four [`Path`] cubic starting at the top-left corner,
     /// in clockwise order, sharing every fourth point. The last [`Path`] cubic ends at the
@@ -2005,28 +2000,40 @@ impl Canvas {
     /// corners in top-left, top-right, bottom-right, bottom-left order. If `tex_coords` is
     /// `None`, [`Shader`] is mapped using positions (derived from cubics).
     ///
+    /// [`BlendMode`] is ignored if colors is `None`. Otherwise, it combines
+    ///   - the [`Shader`] if [`Paint`] contains [`Shader`]
+    ///   - or the opaque [`Paint`] color if [`Paint`] does not contain [`Shader`]
+    /// as the src of the blend and the interpolated patch colors as the dst.
+    ///
+    /// [`MaskFilter`], [`SkPathEffect`], and antialiasing on [`Paint`] are ignored.
+    ///
     /// - `cubics` [`Path`] cubic array, sharing common points
     /// - `colors` color array, one for each corner
     /// - `tex_coords` [`Point`] array of texture coordinates, mapping [`Shader`] to corners;
     ///   may be `None`
-    /// - `mode` [`BlendMode`] for colors, and for [`Shader`] if `paint` has one
+    /// - `mode` combines patch's colors with [`Shader`] if present or [`Paint`] opaque color if
+    ///    not. Ignored if colors is `None`.
     /// - `paint` [`Shader`], [`crate::ColorFilter`], [`BlendMode`], used to draw
-    pub fn draw_patch(
+    pub fn draw_patch<'a>(
         &mut self,
         cubics: &[Point; 12],
-        colors: &[Color; 4],
+        colors: impl Into<Option<&'a [Color; 4]>>,
         tex_coords: Option<&[Point; 4]>,
-        mode: impl Into<Option<BlendMode>>,
+        mode: BlendMode,
         paint: &Paint,
     ) -> &mut Self {
+        let colors = colors
+            .into()
+            .map(|c| c.native().as_ptr())
+            .unwrap_or(ptr::null());
         unsafe {
             self.native_mut().drawPatch(
                 cubics.native().as_ptr(),
-                colors.native().as_ptr(),
+                colors,
                 tex_coords
                     .map(|tc| tc.native().as_ptr())
                     .unwrap_or(ptr::null()),
-                mode.into().unwrap_or(BlendMode::Modulate),
+                mode,
                 paint.native(),
             )
         }

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -1964,12 +1964,13 @@ impl Canvas {
     ///   - or the opaque [`Paint`] color if [`Paint`] does not contain [`Shader`]
     /// as the src of the blend and the interpolated vertex colors as the dst.
     ///
-    /// [`MaskFilter`], [`PathEffect`], and antialiasing on [`Paint`] are ignored.
+    /// [`crate::MaskFilter`], [`crate::PathEffect`], and antialiasing on [`Paint`] are ignored.
     //
     /// - `vertices` triangle mesh to draw
     /// - `mode` combines vertices' colors with [`Shader`] if present or [`Paint`] opaque color if
     ///   not. Ignored if the vertices do not contain color.
-    /// - `paint` specifies the [`Shader`], used as [`Vertices`] texture, and [`ColorFilter`].
+    /// - `paint` specifies the [`Shader`], used as [`Vertices`] texture, and
+    ///   [`crate::ColorFilter`].
     ///
     /// example: <https://fiddle.skia.org/c/@Canvas_drawVertices>
     /// example: <https://fiddle.skia.org/c/@Canvas_drawVertices_2>
@@ -2005,7 +2006,7 @@ impl Canvas {
     ///   - or the opaque [`Paint`] color if [`Paint`] does not contain [`Shader`]
     /// as the src of the blend and the interpolated patch colors as the dst.
     ///
-    /// [`MaskFilter`], [`SkPathEffect`], and antialiasing on [`Paint`] are ignored.
+    /// [`crate::MaskFilter`], [`crate::PathEffect`], and antialiasing on [`Paint`] are ignored.
     ///
     /// - `cubics` [`Path`] cubic array, sharing common points
     /// - `colors` color array, one for each corner

--- a/skia-safe/src/core/data.rs
+++ b/skia-safe/src/core/data.rs
@@ -84,6 +84,10 @@ impl Data {
         Data::from_ptr(sb::C_SkData_MakeUninitialized(length)).unwrap()
     }
 
+    pub fn new_zero_initialized(length: usize) -> Data {
+        Data::from_ptr(unsafe { sb::C_SkData_MakeZeroInitialized(length) }).unwrap()
+    }
+
     // TODO: use Range as stand in for offset / length?
     pub fn new_subset(data: &Data, offset: usize, length: usize) -> Data {
         Data::from_ptr(unsafe { sb::C_SkData_MakeSubset(data.native(), offset, length) }).unwrap()

--- a/skia-safe/src/core/milestone.rs
+++ b/skia-safe/src/core/milestone.rs
@@ -1,1 +1,1 @@
-pub const MILESTONE: usize = 97;
+pub const MILESTONE: usize = 98;

--- a/skia-safe/src/core/rect.rs
+++ b/skia-safe/src/core/rect.rs
@@ -74,48 +74,48 @@ impl IRect {
         }
     }
 
-    pub fn left(&self) -> i32 {
+    pub const fn left(&self) -> i32 {
         self.left
     }
 
-    pub fn top(&self) -> i32 {
+    pub const fn top(&self) -> i32 {
         self.top
     }
 
-    pub fn right(&self) -> i32 {
+    pub const fn right(&self) -> i32 {
         self.right
     }
 
-    pub fn bottom(&self) -> i32 {
+    pub const fn bottom(&self) -> i32 {
         self.bottom
     }
 
-    pub fn x(&self) -> i32 {
+    pub const fn x(&self) -> i32 {
         self.left
     }
 
-    pub fn y(&self) -> i32 {
+    pub const fn y(&self) -> i32 {
         self.top
     }
 
-    pub fn width(&self) -> i32 {
+    pub const fn width(&self) -> i32 {
         sk32::can_overflow_sub(self.right, self.left)
     }
 
-    pub fn height(&self) -> i32 {
+    pub const fn height(&self) -> i32 {
         sk32::can_overflow_sub(self.bottom, self.top)
     }
 
-    pub fn size(&self) -> ISize {
-        (self.width(), self.height()).into()
+    pub const fn size(&self) -> ISize {
+        ISize::new(self.width(), self.height())
     }
 
-    pub fn width_64(&self) -> i64 {
-        i64::from(self.right) - i64::from(self.left)
+    pub const fn width_64(&self) -> i64 {
+        self.right as i64 - self.left as i64
     }
 
-    pub fn height_64(&self) -> i64 {
-        i64::from(self.bottom) - i64::from(self.top)
+    pub const fn height_64(&self) -> i64 {
+        self.bottom as i64 - self.top as i64
     }
 
     pub fn is_empty_64(&self) -> bool {
@@ -416,27 +416,27 @@ impl Rect {
         !accum.is_nan()
     }
 
-    pub fn x(&self) -> scalar {
+    pub const fn x(&self) -> scalar {
         self.left
     }
 
-    pub fn y(&self) -> scalar {
+    pub const fn y(&self) -> scalar {
         self.top
     }
 
-    pub fn left(&self) -> scalar {
+    pub const fn left(&self) -> scalar {
         self.left
     }
 
-    pub fn top(&self) -> scalar {
+    pub const fn top(&self) -> scalar {
         self.top
     }
 
-    pub fn right(&self) -> scalar {
+    pub const fn right(&self) -> scalar {
         self.right
     }
 
-    pub fn bottom(&self) -> scalar {
+    pub const fn bottom(&self) -> scalar {
         self.bottom
     }
 

--- a/skia-safe/src/core/surface.rs
+++ b/skia-safe/src/core/surface.rs
@@ -10,7 +10,9 @@ use std::{fmt, ptr};
 pub use skia_bindings::SkSurface_ContentChangeMode as ContentChangeMode;
 variant_name!(ContentChangeMode::Retain, content_change_mode_naming);
 
+#[cfg(feature = "gpu")]
 pub use skia_bindings::SkSurface_BackendHandleAccess as BackendHandleAccess;
+#[cfg(feature = "gpu")]
 variant_name!(
     BackendHandleAccess::FlushWrite,
     backend_handle_access_naming

--- a/skia-safe/src/core/surface.rs
+++ b/skia-safe/src/core/surface.rs
@@ -136,6 +136,44 @@ impl Surface {
         })
     }
 
+    pub fn new_render_target(
+        context: &mut gpu::RecordingContext,
+        budgeted: crate::Budgeted,
+        image_info: &ImageInfo,
+        sample_count: impl Into<Option<usize>>,
+        surface_origin: impl Into<Option<gpu::SurfaceOrigin>>,
+        surface_props: Option<&SurfaceProps>,
+        should_create_with_mips: impl Into<Option<bool>>,
+    ) -> Option<Self> {
+        Self::from_ptr(unsafe {
+            sb::C_SkSurface_MakeRenderTarget(
+                context.native_mut(),
+                budgeted.into_native(),
+                image_info.native(),
+                sample_count.into().unwrap_or(0).try_into().unwrap(),
+                surface_origin
+                    .into()
+                    .unwrap_or(gpu::SurfaceOrigin::BottomLeft),
+                surface_props.native_ptr_or_null(),
+                should_create_with_mips.into().unwrap_or_default(),
+            )
+        })
+    }
+
+    pub fn new_render_target_with_characterization(
+        context: &mut gpu::RecordingContext,
+        characterization: &SurfaceCharacterization,
+        budgeted: crate::Budgeted,
+    ) -> Option<Self> {
+        Self::from_ptr(unsafe {
+            sb::C_SkSurface_MakeRenderTarget2(
+                context.native_mut(),
+                characterization.native(),
+                budgeted.into_native(),
+            )
+        })
+    }
+
     #[allow(clippy::missing_safety_doc)]
     #[allow(clippy::too_many_arguments)]
     #[cfg(feature = "metal")]
@@ -202,41 +240,6 @@ impl Surface {
                 color_type.into_native(),
                 color_space.into().into_ptr_or_null(),
                 surface_props.native_ptr_or_null(),
-            )
-        })
-    }
-    pub fn new_render_target(
-        context: &mut gpu::RecordingContext,
-        budgeted: crate::Budgeted,
-        image_info: &ImageInfo,
-        sample_count: impl Into<Option<usize>>,
-        surface_origin: gpu::SurfaceOrigin,
-        surface_props: Option<&SurfaceProps>,
-        should_create_with_mips: impl Into<Option<bool>>,
-    ) -> Option<Self> {
-        Self::from_ptr(unsafe {
-            sb::C_SkSurface_MakeRenderTarget(
-                context.native_mut(),
-                budgeted.into_native(),
-                image_info.native(),
-                sample_count.into().unwrap_or(0).try_into().unwrap(),
-                surface_origin,
-                surface_props.native_ptr_or_null(),
-                should_create_with_mips.into().unwrap_or_default(),
-            )
-        })
-    }
-
-    pub fn new_render_target_with_characterization(
-        context: &mut gpu::RecordingContext,
-        characterization: &SurfaceCharacterization,
-        budgeted: crate::Budgeted,
-    ) -> Option<Self> {
-        Self::from_ptr(unsafe {
-            sb::C_SkSurface_MakeRenderTarget2(
-                context.native_mut(),
-                characterization.native(),
-                budgeted.into_native(),
             )
         })
     }

--- a/skia-safe/src/docs/pdf_document.rs
+++ b/skia-safe/src/docs/pdf_document.rs
@@ -9,12 +9,6 @@ pub mod pdf {
     };
     use std::{ffi::CString, fmt, mem, ptr};
 
-    pub use sb::SkPDF_DocumentStructureType as DocumentStructureType;
-    #[test]
-    fn document_structure_type_naming() {
-        let _ = DocumentStructureType::BibEntry;
-    }
-
     pub type AttributeList = Handle<SkPDF_AttributeList>;
     unsafe_send_sync!(AttributeList);
 

--- a/skia-safe/src/effects/runtime_effect.rs
+++ b/skia-safe/src/effects/runtime_effect.rs
@@ -66,7 +66,7 @@ pub mod uniform {
     bitflags! {
         pub struct Flags : u32 {
             const ARRAY = sb::SkRuntimeEffect_Uniform_Flags_kArray_Flag as _;
-            const SRGB_UNPREMUL = sb::SkRuntimeEffect_Uniform_Flags_kSRGBUnpremul_Flag as _;
+            const COLOR = sb::SkRuntimeEffect_Uniform_Flags_kColor_Flag as _;
         }
     }
 }

--- a/skia-safe/src/effects/runtime_effect.rs
+++ b/skia-safe/src/effects/runtime_effect.rs
@@ -52,6 +52,10 @@ impl Uniform {
         self.flags().contains(uniform::Flags::ARRAY)
     }
 
+    pub fn is_color(&self) -> bool {
+        self.flags().contains(uniform::Flags::COLOR)
+    }
+
     pub fn size_in_bytes(&self) -> usize {
         unsafe { self.native().sizeInBytes() }
     }
@@ -295,6 +299,8 @@ impl RuntimeEffect {
             )
         })
     }
+
+    // TODO: wrap MakeTraced
 
     pub fn source(&self) -> &str {
         let mut len = 0;

--- a/skia-safe/src/gpu/vk/types.rs
+++ b/skia-safe/src/gpu/vk/types.rs
@@ -320,7 +320,6 @@ pub struct DrawableInfo {
     pub compatible_render_pass: vk::RenderPass,
     pub format: vk::Format,
     pub draw_bounds: *mut vk::Rect2D,
-    pub image: vk::Image,
 }
 
 native_transmutable!(GrVkDrawableInfo, DrawableInfo, drawable_info_layout);
@@ -334,7 +333,6 @@ impl Default for DrawableInfo {
             compatible_render_pass: vk::NULL_HANDLE.into(),
             format: vk::Format::UNDEFINED,
             draw_bounds: ptr::null_mut(),
-            image: vk::NULL_HANDLE.into(),
         }
     }
 }


### PR DESCRIPTION

This PR updates rust-skia to support Skia's `chrome/m98` branch.

- [x] Update `README.md` ([rendered](https://github.com/pragmatrix/rust-skia/blob/m98/README.md))  
  > Most important here is to change the Skia branch name and the current Skia submodule tag at the top of the `README.md` file.
- [x] Diff the the following files to see if the build organization has changed significantly:
  - [x] `/BUILD.gn`
  - [x] `/modules/skshaper/BUILD.gn`
  - [x] `/modules/paragraph/BUILD.gn`
- [x] Skia builds ([release notes](https://github.com/google/skia/blob/chrome/m98/RELEASE_NOTES.txt)).
- [x] `/skia-bindings` builds.
- [x] `/skia-safe`: Update & add new wrappers by diffing include files.  
  > Add TODOs for everything that can not be updated right now, and attempt to stay compatible with previous versions of skia-safe without trying too hard before version 1.0. Use `deprecated` attributes if needed.
  - [x] `codec/`
  - [x] `core/`
  - [x] `docs/`
  - [x] `effects/`
  - [x] `gpu/`
    - [x] `d3d/`
    - [x] `gl/`
    - [x] `mtl/`
    - [x] `vk/`
  - [x] `modules/`
    - [x] `paragraph/`
    - [x] `shaper/`
  - [x] `pathops/`
  - [x] `svg/`
  - [x] `utils/`
- [x] Review `Send` & `Sync` implementations for new wrappers.
- [x] Review `Debug` implementation for new wrapper types and functions.
- [x] Any pending changes in the Skia `chrome/m98` branch that aren't synchronized yet?
- [x] Rebase on or merge with master.
- [x] Do the `rust-skia:` commits in the `skia-bindings/skia` subdirectory match with `master`.
- [x] Update versions of `skia-bindings/Cargo.toml` and `skia-safe/Cargo.toml` and also add the version to the new `deprecated` attributes.
- [x] Do the tags/hashes in `skia-bindings/Cargo.toml` under `[package.metadata]` match the submodules `depot_tools` and `skia`?
- [x] Test builds we don't do on the CI:
  - [x] Compiles to Catalyst targets on macOS (#548).
    ```zsh
    make macos-qa
    ```
- [x] Do one final review of all the changes.
- [x] Run `cargo doc` with all features and fix all warnings.

