### PR TITLE
Milestone 99

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
+        "antialiasing",
         "EMCC",
         "emscripten"
     ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "cSpell.words": [
         "antialiasing",
         "EMCC",
-        "emscripten"
+        "emscripten",
+        "RGBX"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m99 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m99-0.47.0...google:chrome/m99
-[skia-ours]: https://github.com/google/skia/compare/chrome/m99...rust-skia:m99-0.47.0
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m99-0.47.1...google:chrome/m99
+[skia-ours]: https://github.com/google/skia/compare/chrome/m99...rust-skia:m99-0.47.1
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![Windows QA](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml) [![Linux QA](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml) [![macOS QA](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml)
 
-Skia Submodule Status: chrome/m98 ([upstream changes][skia-upstream], [our changes][skia-ours]).
+Skia Submodule Status: chrome/m99 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m98-0.46.3...google:chrome/m98
-[skia-ours]: https://github.com/google/skia/compare/chrome/m98...rust-skia:m98-0.46.3
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m99-0.47.0...google:chrome/m99
+[skia-ours]: https://github.com/google/skia/compare/chrome/m99...rust-skia:m99-0.47.0
 
 ## Goals
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.47.0"
+version = "0.48.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m98-0.46.3"
+skia = "m99-0.47.0"
 depot_tools = "fade894"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m99-0.47.0"
+skia = "m99-0.47.1"
 depot_tools = "fade894"
 
 [features]

--- a/skia-bindings/src/gl.cpp
+++ b/skia-bindings/src/gl.cpp
@@ -63,6 +63,7 @@ extern "C" GrGLFormat C_GrGLFormatFromGLEnum(GrGLenum glFormat) {
         case GR_GL_LUMINANCE16F:         return GrGLFormat::kLUMINANCE16F;
         case GR_GL_R16F:                 return GrGLFormat::kR16F;
         case GR_GL_RGB8:                 return GrGLFormat::kRGB8;
+        case GR_GL_RGBX8:                return GrGLFormat::kRGBX8;
         case GR_GL_RG8:                  return GrGLFormat::kRG8;
         case GR_GL_RGB10_A2:             return GrGLFormat::kRGB10_A2;
         case GR_GL_RGBA4:                return GrGLFormat::kRGBA4;
@@ -96,6 +97,7 @@ extern "C" GrGLenum C_GrGLFormatToEnum(GrGLFormat format) {
         case GrGLFormat::kLUMINANCE16F:         return GR_GL_LUMINANCE16F;
         case GrGLFormat::kR16F:                 return GR_GL_R16F;
         case GrGLFormat::kRGB8:                 return GR_GL_RGB8;
+        case GrGLFormat::kRGBX8:                return GR_GL_RGBX8;
         case GrGLFormat::kRG8:                  return GR_GL_RG8;
         case GrGLFormat::kRGB10_A2:             return GR_GL_RGB10_A2;
         case GrGLFormat::kRGBA4:                return GR_GL_RGBA4;

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.47.0"
+version = "0.48.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -46,7 +46,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 [dependencies]
 bitflags = "1.2"
 lazy_static = "1.4"
-skia-bindings = { version = "=0.47.0", path = "../skia-bindings", default-features = false }
+skia-bindings = { version = "=0.48.0", path = "../skia-bindings", default-features = false }
 # for d3d types
 winapi = { version = "0.3.9", features = ["d3d12", "dxgi"], optional = true }
 # for ComPtr

--- a/skia-safe/src/core/milestone.rs
+++ b/skia-safe/src/core/milestone.rs
@@ -1,1 +1,1 @@
-pub const MILESTONE: usize = 98;
+pub const MILESTONE: usize = 99;

--- a/skia-safe/src/gpu/context_options.rs
+++ b/skia-safe/src/gpu/context_options.rs
@@ -42,6 +42,7 @@ pub struct ContextOptions {
     pub suppress_mipmap_support: bool,
     pub enable_experimental_hardware_tessellation: bool,
     pub reduced_shader_variations: bool,
+    pub allow_msaa_on_new_intel: bool,
     pub driver_bug_workarounds: DriverBugWorkarounds,
 }
 unsafe_send_sync!(ContextOptions);
@@ -59,3 +60,5 @@ impl ContextOptions {
 }
 
 native_transmutable!(GrContextOptions, ContextOptions, context_options_layout);
+
+// TODO: PersistentCache, ShaderErrorHandler

--- a/skia-safe/src/gpu/gl/types.rs
+++ b/skia-safe/src/gpu/gl/types.rs
@@ -110,38 +110,40 @@ mod tests {
 
     #[test]
     fn test_all_formats_exhaustive() {
-        let x = Format::ALPHA8;
+        use Format::*;
+        let x = ALPHA8;
         // !!!!!
         // IF this match is not exhaustive anymore, the implementations of the format conversions
         // need to be updated in `skia-bindings/src/gl.cpp`, too.
         match x {
-            Format::Unknown => {}
-            Format::RGBA8 => {}
-            Format::R8 => {}
-            Format::ALPHA8 => {}
-            Format::LUMINANCE8 => {}
-            Format::LUMINANCE8_ALPHA8 => {}
-            Format::BGRA8 => {}
-            Format::RGB565 => {}
-            Format::RGBA16F => {}
-            Format::R16F => {}
-            Format::RGB8 => {}
-            Format::RG8 => {}
-            Format::RGB10_A2 => {}
-            Format::RGBA4 => {}
-            Format::SRGB8_ALPHA8 => {}
-            Format::COMPRESSED_ETC1_RGB8 => {}
-            Format::COMPRESSED_RGB8_ETC2 => {}
-            Format::COMPRESSED_RGB8_BC1 => {}
-            Format::COMPRESSED_RGBA8_BC1 => {}
-            Format::R16 => {}
-            Format::RG16 => {}
-            Format::RGBA16 => {}
-            Format::RG16F => {}
-            Format::LUMINANCE16F => {}
-            Format::STENCIL_INDEX8 => {}
-            Format::STENCIL_INDEX16 => {}
-            Format::DEPTH24_STENCIL8 => {}
+            Unknown => {}
+            RGBA8 => {}
+            R8 => {}
+            ALPHA8 => {}
+            LUMINANCE8 => {}
+            LUMINANCE8_ALPHA8 => {}
+            BGRA8 => {}
+            RGB565 => {}
+            RGBA16F => {}
+            R16F => {}
+            RGB8 => {}
+            RGBX8 => {}
+            RG8 => {}
+            RGB10_A2 => {}
+            RGBA4 => {}
+            SRGB8_ALPHA8 => {}
+            COMPRESSED_ETC1_RGB8 => {}
+            COMPRESSED_RGB8_ETC2 => {}
+            COMPRESSED_RGB8_BC1 => {}
+            COMPRESSED_RGBA8_BC1 => {}
+            R16 => {}
+            RG16 => {}
+            RGBA16 => {}
+            RG16F => {}
+            LUMINANCE16F => {}
+            STENCIL_INDEX8 => {}
+            STENCIL_INDEX16 => {}
+            DEPTH24_STENCIL8 => {}
         }
     }
 


### PR DESCRIPTION
This PR updates rust-skia to support Skia's `chrome/m99` branch.

- [x] Update `README.md` ([rendered](https://github.com/pragmatrix/rust-skia/blob/m99/README.md))  
  > Most important here is to change the Skia branch name and the current Skia submodule tag at the top of the `README.md` file.
- [x] Diff the the following files to see if the build organization has changed significantly:
  - [x] `/BUILD.gn`
  - [x] `/modules/skshaper/BUILD.gn`
  - [x] `/modules/paragraph/BUILD.gn`
- [x] Skia builds ([release notes](https://github.com/google/skia/blob/chrome/m99/RELEASE_NOTES.txt)).
- [x] `/skia-bindings` builds.
- [x] `/skia-safe`: Update & add new wrappers by diffing include files.  
  > Add TODOs for everything that can not be updated right now, and attempt to stay compatible with previous versions of skia-safe without trying too hard before version 1.0. Use `deprecated` attributes if needed.
  - [x] `codec/`
  - [x] `core/`
  - [x] `docs/`
  - [x] `effects/`
  - [x] `gpu/`
    - [x] `d3d/`
    - [x] `gl/`
    - [x] `mtl/`
    - [x] `vk/`
  - [x] `modules/`
    - [x] `paragraph/`
    - [x] `shaper/`
  - [x] `pathops/`
  - [x] `svg/`
  - [x] `utils/`
- [x] Review `Send` & `Sync` implementations for new wrappers.
- [x] Review `Debug` implementation for new wrapper types and functions.
- [x] Any pending changes in the Skia `chrome/m99` branch that aren't synchronized yet?
- [x] Rebase on or merge with master.
- [x] Do the `rust-skia:` commits in the `skia-bindings/skia` subdirectory match with `master`.
- [x] Update versions of `skia-bindings/Cargo.toml` and `skia-safe/Cargo.toml` and also add the version to the new `deprecated` attributes.
- [x] Do the tags/hashes in `skia-bindings/Cargo.toml` under `[package.metadata]` match the submodules `depot_tools` and `skia`?
- [x] Test builds we don't do on the CI:
  - [x] Compiles to Catalyst targets on macOS (#548).
    ```zsh
    make macos-qa
    ```
- [x] Do one final review of all the changes.
- [x] Run `cargo doc` with all features and fix all warnings.

