### PR TITLE
Experiment: Remove clang-sys dependency

### DIFF
--- a/.github/workflows/supplemental-builds.yaml
+++ b/.github/workflows/supplemental-builds.yaml
@@ -83,7 +83,7 @@ jobs:
   #       cargo build -vv --features "gl"
 
   windows-link-dead-code:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v2
@@ -116,7 +116,7 @@ jobs:
         RUSTFLAGS: '-Clink-dead-code'
 
   windows-x86:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v2

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -74,11 +74,6 @@ ureq = { version = "2.0.1", optional = true }
 flate2 = { version = "1.0.7", optional = true }
 tar = { version = "0.4.26", optional = true }
 
-# On the CI we don't specify the libclang location explicitly and PATH contains
-# multiple of them. clang-sys version 1.0.2 changed the resolvement order.
-# https://github.com/KyleMayes/clang-sys/pull/118
-clang-sys = "=1.0.1"
-
 # For reading .cargo.vcs_info.json to get the repository sha1 that is used to download
 # the matching prebuilt binaries.
 serde_json = "1.0.39"


### PR DESCRIPTION
We should be able to build with clang-sys the newest version. If problems appear on the CI because of multiple conflicting libclang installations, we have to resolve that by patching the PATH variable.

Closes #627 