### PR TITLE
Publish wasm32-unknown-emscripten prebuilt binaries

### DIFF
--- a/.github/workflows/linux-qa.yaml
+++ b/.github/workflows/linux-qa.yaml
@@ -55,7 +55,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "egl,gl,textlayout,vulkan,wayland,webp,x11" --target x86_64-unknown-linux-gnu
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -129,7 +131,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout,vulkan,webp" --target aarch64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -203,7 +207,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout,vulkan,webp" --target x86_64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -277,7 +283,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout,vulkan,webp" --target i686-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -351,7 +359,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=wasm32-unknown-emscripten26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "true" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout,vulkan,webp" --target wasm32-unknown-emscripten
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -447,7 +457,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "egl,gl,textlayout,vulkan,wayland,webp,x11" --target x86_64-unknown-linux-gnu
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -521,7 +533,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout,vulkan,webp" --target aarch64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -595,7 +609,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout,vulkan,webp" --target x86_64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -669,7 +685,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout,vulkan,webp" --target i686-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -743,7 +761,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=wasm32-unknown-emscripten26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "true" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout,vulkan,webp" --target wasm32-unknown-emscripten
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}

--- a/.github/workflows/linux-qa.yaml
+++ b/.github/workflows/linux-qa.yaml
@@ -55,6 +55,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "egl,gl,textlayout,vulkan,wayland,webp,x11" --target x86_64-unknown-linux-gnu
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -62,6 +63,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -127,6 +129,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout,vulkan,webp" --target aarch64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -134,6 +137,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -199,6 +203,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout,vulkan,webp" --target x86_64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -206,6 +211,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -271,6 +277,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout,vulkan,webp" --target i686-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -278,6 +285,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -302,6 +310,80 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: skia-org-images-i686-linux-android
+        path: ${{ env.SKIA_STAGING_PATH }}/skia-org
+    
+    - name: 'Compress binaries'
+      if: false
+      uses: master-atul/tar-action@v1.0.2
+      with:
+        command: c
+        cwd: '${{ env.SKIA_STAGING_PATH }}'
+        files: 'skia-binaries'
+        outPath: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+    
+    - name: 'Release binaries'
+      if: false
+      uses: pragmatrix/release-action@exp
+      with:
+        owner: rust-skia
+        repo: skia-binaries
+        allowUpdates: true
+        replacesArtifacts: true
+        tag: '${{ env.SKIA_BINARIES_TAG }}'
+        artifacts: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+        artifactErrorsFailBuild: true
+        token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
+        prerelease: true
+    - name: 'Install Rust target wasm32-unknown-emscripten'
+      shell: bash
+      run: |
+        rustup target add wasm32-unknown-emscripten
+    
+    - name: 'Build all targets in skia-safe for wasm32-unknown-emscripten with features gl,textlayout,vulkan,webp'
+      shell: bash
+      run: |
+        if [ "false" == "true" ]; then
+          TARGET=wasm32-unknown-emscripten
+          TARGET=${TARGET//-/_}
+          export CC_${TARGET}=wasm32-unknown-emscripten26-clang
+          export CXX_${TARGET}=wasm32-unknown-emscripten26-clang++
+          TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
+          export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=wasm32-unknown-emscripten26-clang
+          echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
+        fi
+        source /emsdk/emsdk_env.sh
+        cargo clean
+        cargo build -p skia-safe --all-targets --release --features "gl,textlayout,vulkan,webp" --target wasm32-unknown-emscripten
+        echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_BINARIES_KEY=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/key.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
+      env:
+        BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
+    
+    - name: 'Run Clippy'
+      shell: bash
+      if: false
+      run: |
+        cargo clippy --release --features "gl,textlayout,vulkan,webp" --all-targets --target wasm32-unknown-emscripten -- -D warnings
+    
+    - name: 'Test all workspace projects'
+      shell: bash
+      if: false
+      run: |
+        cargo test --all --release --features "gl,textlayout,vulkan,webp" --all-targets --target wasm32-unknown-emscripten -- --nocapture
+      
+    - name: 'Generate skia-org example images'
+      shell: bash
+      if: false
+      run: |
+        cargo run --release --features "gl,textlayout,vulkan,webp" --target wasm32-unknown-emscripten "${{ env.SKIA_STAGING_PATH }}/skia-org" 
+    
+    - name: 'Upload skia-org example images'
+      if: false
+      uses: actions/upload-artifact@v2
+      with:
+        name: skia-org-images-wasm32-unknown-emscripten
         path: ${{ env.SKIA_STAGING_PATH }}/skia-org
     
     - name: 'Compress binaries'
@@ -365,6 +447,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "egl,gl,textlayout,vulkan,wayland,webp,x11" --target x86_64-unknown-linux-gnu
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -372,6 +455,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -437,6 +521,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout,vulkan,webp" --target aarch64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -444,6 +529,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -509,6 +595,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout,vulkan,webp" --target x86_64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -516,6 +603,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -581,6 +669,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout,vulkan,webp" --target i686-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -588,6 +677,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -612,6 +702,80 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: skia-org-images-i686-linux-android
+        path: ${{ env.SKIA_STAGING_PATH }}/skia-org
+    
+    - name: 'Compress binaries'
+      if: false
+      uses: master-atul/tar-action@v1.0.2
+      with:
+        command: c
+        cwd: '${{ env.SKIA_STAGING_PATH }}'
+        files: 'skia-binaries'
+        outPath: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+    
+    - name: 'Release binaries'
+      if: false
+      uses: pragmatrix/release-action@exp
+      with:
+        owner: rust-skia
+        repo: skia-binaries
+        allowUpdates: true
+        replacesArtifacts: true
+        tag: '${{ env.SKIA_BINARIES_TAG }}'
+        artifacts: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+        artifactErrorsFailBuild: true
+        token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
+        prerelease: true
+    - name: 'Install Rust target wasm32-unknown-emscripten'
+      shell: bash
+      run: |
+        rustup target add wasm32-unknown-emscripten
+    
+    - name: 'Build all targets in skia-safe for wasm32-unknown-emscripten with features gl,textlayout,vulkan,webp'
+      shell: bash
+      run: |
+        if [ "false" == "true" ]; then
+          TARGET=wasm32-unknown-emscripten
+          TARGET=${TARGET//-/_}
+          export CC_${TARGET}=wasm32-unknown-emscripten26-clang
+          export CXX_${TARGET}=wasm32-unknown-emscripten26-clang++
+          TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
+          export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=wasm32-unknown-emscripten26-clang
+          echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
+        fi
+        source /emsdk/emsdk_env.sh
+        cargo clean
+        cargo build -p skia-safe --all-targets --release --features "gl,textlayout,vulkan,webp" --target wasm32-unknown-emscripten
+        echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_BINARIES_KEY=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/key.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
+      env:
+        BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
+    
+    - name: 'Run Clippy'
+      shell: bash
+      if: false
+      run: |
+        cargo clippy --release --features "gl,textlayout,vulkan,webp" --all-targets --target wasm32-unknown-emscripten -- -D warnings
+    
+    - name: 'Test all workspace projects'
+      shell: bash
+      if: false
+      run: |
+        cargo test --all --release --features "gl,textlayout,vulkan,webp" --all-targets --target wasm32-unknown-emscripten -- --nocapture
+      
+    - name: 'Generate skia-org example images'
+      shell: bash
+      if: false
+      run: |
+        cargo run --release --features "gl,textlayout,vulkan,webp" --target wasm32-unknown-emscripten "${{ env.SKIA_STAGING_PATH }}/skia-org" 
+    
+    - name: 'Upload skia-org example images'
+      if: false
+      uses: actions/upload-artifact@v2
+      with:
+        name: skia-org-images-wasm32-unknown-emscripten
         path: ${{ env.SKIA_STAGING_PATH }}/skia-org
     
     - name: 'Compress binaries'

--- a/.github/workflows/linux-release.yaml
+++ b/.github/workflows/linux-release.yaml
@@ -50,7 +50,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "" --target x86_64-unknown-linux-gnu
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -124,7 +126,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "" --target aarch64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -198,7 +202,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "" --target x86_64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -272,7 +278,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "" --target i686-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -346,7 +354,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=wasm32-unknown-emscripten26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "true" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "" --target wasm32-unknown-emscripten
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -442,7 +452,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl" --target x86_64-unknown-linux-gnu
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -516,7 +528,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl" --target aarch64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -590,7 +604,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl" --target x86_64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -664,7 +680,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl" --target i686-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -738,7 +756,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=wasm32-unknown-emscripten26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "true" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl" --target wasm32-unknown-emscripten
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -834,7 +854,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan" --target x86_64-unknown-linux-gnu
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -908,7 +930,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan" --target aarch64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -982,7 +1006,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan" --target x86_64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1056,7 +1082,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan" --target i686-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1130,7 +1158,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=wasm32-unknown-emscripten26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "true" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan" --target wasm32-unknown-emscripten
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1226,7 +1256,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "textlayout" --target x86_64-unknown-linux-gnu
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1300,7 +1332,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "textlayout" --target aarch64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1374,7 +1408,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "textlayout" --target x86_64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1448,7 +1484,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "textlayout" --target i686-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1522,7 +1560,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=wasm32-unknown-emscripten26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "true" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "textlayout" --target wasm32-unknown-emscripten
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1618,7 +1658,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout" --target x86_64-unknown-linux-gnu
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1692,7 +1734,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout" --target aarch64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1766,7 +1810,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout" --target x86_64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1840,7 +1886,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout" --target i686-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1914,7 +1962,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=wasm32-unknown-emscripten26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "true" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout" --target wasm32-unknown-emscripten
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2010,7 +2060,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan,textlayout" --target x86_64-unknown-linux-gnu
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2084,7 +2136,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan,textlayout" --target aarch64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2158,7 +2212,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan,textlayout" --target x86_64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2232,7 +2288,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan,textlayout" --target i686-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2306,7 +2364,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=wasm32-unknown-emscripten26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "true" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan,textlayout" --target wasm32-unknown-emscripten
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2402,7 +2462,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,vulkan,textlayout" --target x86_64-unknown-linux-gnu
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2476,7 +2538,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,vulkan,textlayout" --target aarch64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2550,7 +2614,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,vulkan,textlayout" --target x86_64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2624,7 +2690,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,vulkan,textlayout" --target i686-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2698,7 +2766,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=wasm32-unknown-emscripten26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "true" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,vulkan,textlayout" --target wasm32-unknown-emscripten
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2794,7 +2864,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,x11" --target x86_64-unknown-linux-gnu
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2868,7 +2940,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,x11" --target aarch64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2942,7 +3016,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,x11" --target x86_64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -3016,7 +3092,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,x11" --target i686-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -3090,7 +3168,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=wasm32-unknown-emscripten26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "true" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,x11" --target wasm32-unknown-emscripten
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -3186,7 +3266,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout,x11" --target x86_64-unknown-linux-gnu
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -3260,7 +3342,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout,x11" --target aarch64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -3334,7 +3418,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout,x11" --target x86_64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -3408,7 +3494,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout,x11" --target i686-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -3482,7 +3570,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=wasm32-unknown-emscripten26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "true" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout,x11" --target wasm32-unknown-emscripten
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}

--- a/.github/workflows/linux-release.yaml
+++ b/.github/workflows/linux-release.yaml
@@ -50,6 +50,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "" --target x86_64-unknown-linux-gnu
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -57,6 +58,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -122,6 +124,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "" --target aarch64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -129,6 +132,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -194,6 +198,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "" --target x86_64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -201,6 +206,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -266,6 +272,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "" --target i686-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -273,6 +280,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -297,6 +305,80 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: skia-org-images-i686-linux-android
+        path: ${{ env.SKIA_STAGING_PATH }}/skia-org
+    
+    - name: 'Compress binaries'
+      if: true
+      uses: master-atul/tar-action@v1.0.2
+      with:
+        command: c
+        cwd: '${{ env.SKIA_STAGING_PATH }}'
+        files: 'skia-binaries'
+        outPath: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+    
+    - name: 'Release binaries'
+      if: true
+      uses: pragmatrix/release-action@exp
+      with:
+        owner: rust-skia
+        repo: skia-binaries
+        allowUpdates: true
+        replacesArtifacts: true
+        tag: '${{ env.SKIA_BINARIES_TAG }}'
+        artifacts: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+        artifactErrorsFailBuild: true
+        token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
+        prerelease: true
+    - name: 'Install Rust target wasm32-unknown-emscripten'
+      shell: bash
+      run: |
+        rustup target add wasm32-unknown-emscripten
+    
+    - name: 'Build all targets in skia-safe for wasm32-unknown-emscripten with features '
+      shell: bash
+      run: |
+        if [ "false" == "true" ]; then
+          TARGET=wasm32-unknown-emscripten
+          TARGET=${TARGET//-/_}
+          export CC_${TARGET}=wasm32-unknown-emscripten26-clang
+          export CXX_${TARGET}=wasm32-unknown-emscripten26-clang++
+          TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
+          export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=wasm32-unknown-emscripten26-clang
+          echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
+        fi
+        source /emsdk/emsdk_env.sh
+        cargo clean
+        cargo build -p skia-safe --all-targets --release --features "" --target wasm32-unknown-emscripten
+        echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_BINARIES_KEY=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/key.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
+      env:
+        BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
+    
+    - name: 'Run Clippy'
+      shell: bash
+      if: false
+      run: |
+        cargo clippy --release --features "" --all-targets --target wasm32-unknown-emscripten -- -D warnings
+    
+    - name: 'Test all workspace projects'
+      shell: bash
+      if: false
+      run: |
+        cargo test --all --release --features "" --all-targets --target wasm32-unknown-emscripten -- --nocapture
+      
+    - name: 'Generate skia-org example images'
+      shell: bash
+      if: false
+      run: |
+        cargo run --release --features "" --target wasm32-unknown-emscripten "${{ env.SKIA_STAGING_PATH }}/skia-org" 
+    
+    - name: 'Upload skia-org example images'
+      if: false
+      uses: actions/upload-artifact@v2
+      with:
+        name: skia-org-images-wasm32-unknown-emscripten
         path: ${{ env.SKIA_STAGING_PATH }}/skia-org
     
     - name: 'Compress binaries'
@@ -360,6 +442,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl" --target x86_64-unknown-linux-gnu
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -367,6 +450,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -432,6 +516,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl" --target aarch64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -439,6 +524,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -504,6 +590,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl" --target x86_64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -511,6 +598,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -576,6 +664,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl" --target i686-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -583,6 +672,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -607,6 +697,80 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: skia-org-images-i686-linux-android
+        path: ${{ env.SKIA_STAGING_PATH }}/skia-org
+    
+    - name: 'Compress binaries'
+      if: true
+      uses: master-atul/tar-action@v1.0.2
+      with:
+        command: c
+        cwd: '${{ env.SKIA_STAGING_PATH }}'
+        files: 'skia-binaries'
+        outPath: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+    
+    - name: 'Release binaries'
+      if: true
+      uses: pragmatrix/release-action@exp
+      with:
+        owner: rust-skia
+        repo: skia-binaries
+        allowUpdates: true
+        replacesArtifacts: true
+        tag: '${{ env.SKIA_BINARIES_TAG }}'
+        artifacts: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+        artifactErrorsFailBuild: true
+        token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
+        prerelease: true
+    - name: 'Install Rust target wasm32-unknown-emscripten'
+      shell: bash
+      run: |
+        rustup target add wasm32-unknown-emscripten
+    
+    - name: 'Build all targets in skia-safe for wasm32-unknown-emscripten with features gl'
+      shell: bash
+      run: |
+        if [ "false" == "true" ]; then
+          TARGET=wasm32-unknown-emscripten
+          TARGET=${TARGET//-/_}
+          export CC_${TARGET}=wasm32-unknown-emscripten26-clang
+          export CXX_${TARGET}=wasm32-unknown-emscripten26-clang++
+          TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
+          export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=wasm32-unknown-emscripten26-clang
+          echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
+        fi
+        source /emsdk/emsdk_env.sh
+        cargo clean
+        cargo build -p skia-safe --all-targets --release --features "gl" --target wasm32-unknown-emscripten
+        echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_BINARIES_KEY=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/key.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
+      env:
+        BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
+    
+    - name: 'Run Clippy'
+      shell: bash
+      if: false
+      run: |
+        cargo clippy --release --features "gl" --all-targets --target wasm32-unknown-emscripten -- -D warnings
+    
+    - name: 'Test all workspace projects'
+      shell: bash
+      if: false
+      run: |
+        cargo test --all --release --features "gl" --all-targets --target wasm32-unknown-emscripten -- --nocapture
+      
+    - name: 'Generate skia-org example images'
+      shell: bash
+      if: false
+      run: |
+        cargo run --release --features "gl" --target wasm32-unknown-emscripten "${{ env.SKIA_STAGING_PATH }}/skia-org" 
+    
+    - name: 'Upload skia-org example images'
+      if: false
+      uses: actions/upload-artifact@v2
+      with:
+        name: skia-org-images-wasm32-unknown-emscripten
         path: ${{ env.SKIA_STAGING_PATH }}/skia-org
     
     - name: 'Compress binaries'
@@ -670,6 +834,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan" --target x86_64-unknown-linux-gnu
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -677,6 +842,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -742,6 +908,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan" --target aarch64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -749,6 +916,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -814,6 +982,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan" --target x86_64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -821,6 +990,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -886,6 +1056,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan" --target i686-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -893,6 +1064,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -917,6 +1089,80 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: skia-org-images-i686-linux-android
+        path: ${{ env.SKIA_STAGING_PATH }}/skia-org
+    
+    - name: 'Compress binaries'
+      if: true
+      uses: master-atul/tar-action@v1.0.2
+      with:
+        command: c
+        cwd: '${{ env.SKIA_STAGING_PATH }}'
+        files: 'skia-binaries'
+        outPath: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+    
+    - name: 'Release binaries'
+      if: true
+      uses: pragmatrix/release-action@exp
+      with:
+        owner: rust-skia
+        repo: skia-binaries
+        allowUpdates: true
+        replacesArtifacts: true
+        tag: '${{ env.SKIA_BINARIES_TAG }}'
+        artifacts: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+        artifactErrorsFailBuild: true
+        token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
+        prerelease: true
+    - name: 'Install Rust target wasm32-unknown-emscripten'
+      shell: bash
+      run: |
+        rustup target add wasm32-unknown-emscripten
+    
+    - name: 'Build all targets in skia-safe for wasm32-unknown-emscripten with features vulkan'
+      shell: bash
+      run: |
+        if [ "false" == "true" ]; then
+          TARGET=wasm32-unknown-emscripten
+          TARGET=${TARGET//-/_}
+          export CC_${TARGET}=wasm32-unknown-emscripten26-clang
+          export CXX_${TARGET}=wasm32-unknown-emscripten26-clang++
+          TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
+          export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=wasm32-unknown-emscripten26-clang
+          echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
+        fi
+        source /emsdk/emsdk_env.sh
+        cargo clean
+        cargo build -p skia-safe --all-targets --release --features "vulkan" --target wasm32-unknown-emscripten
+        echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_BINARIES_KEY=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/key.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
+      env:
+        BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
+    
+    - name: 'Run Clippy'
+      shell: bash
+      if: false
+      run: |
+        cargo clippy --release --features "vulkan" --all-targets --target wasm32-unknown-emscripten -- -D warnings
+    
+    - name: 'Test all workspace projects'
+      shell: bash
+      if: false
+      run: |
+        cargo test --all --release --features "vulkan" --all-targets --target wasm32-unknown-emscripten -- --nocapture
+      
+    - name: 'Generate skia-org example images'
+      shell: bash
+      if: false
+      run: |
+        cargo run --release --features "vulkan" --target wasm32-unknown-emscripten "${{ env.SKIA_STAGING_PATH }}/skia-org" 
+    
+    - name: 'Upload skia-org example images'
+      if: false
+      uses: actions/upload-artifact@v2
+      with:
+        name: skia-org-images-wasm32-unknown-emscripten
         path: ${{ env.SKIA_STAGING_PATH }}/skia-org
     
     - name: 'Compress binaries'
@@ -980,6 +1226,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "textlayout" --target x86_64-unknown-linux-gnu
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -987,6 +1234,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1052,6 +1300,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "textlayout" --target aarch64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1059,6 +1308,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1124,6 +1374,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "textlayout" --target x86_64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1131,6 +1382,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1196,6 +1448,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "textlayout" --target i686-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1203,6 +1456,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1227,6 +1481,80 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: skia-org-images-i686-linux-android
+        path: ${{ env.SKIA_STAGING_PATH }}/skia-org
+    
+    - name: 'Compress binaries'
+      if: true
+      uses: master-atul/tar-action@v1.0.2
+      with:
+        command: c
+        cwd: '${{ env.SKIA_STAGING_PATH }}'
+        files: 'skia-binaries'
+        outPath: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+    
+    - name: 'Release binaries'
+      if: true
+      uses: pragmatrix/release-action@exp
+      with:
+        owner: rust-skia
+        repo: skia-binaries
+        allowUpdates: true
+        replacesArtifacts: true
+        tag: '${{ env.SKIA_BINARIES_TAG }}'
+        artifacts: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+        artifactErrorsFailBuild: true
+        token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
+        prerelease: true
+    - name: 'Install Rust target wasm32-unknown-emscripten'
+      shell: bash
+      run: |
+        rustup target add wasm32-unknown-emscripten
+    
+    - name: 'Build all targets in skia-safe for wasm32-unknown-emscripten with features textlayout'
+      shell: bash
+      run: |
+        if [ "false" == "true" ]; then
+          TARGET=wasm32-unknown-emscripten
+          TARGET=${TARGET//-/_}
+          export CC_${TARGET}=wasm32-unknown-emscripten26-clang
+          export CXX_${TARGET}=wasm32-unknown-emscripten26-clang++
+          TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
+          export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=wasm32-unknown-emscripten26-clang
+          echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
+        fi
+        source /emsdk/emsdk_env.sh
+        cargo clean
+        cargo build -p skia-safe --all-targets --release --features "textlayout" --target wasm32-unknown-emscripten
+        echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_BINARIES_KEY=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/key.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
+      env:
+        BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
+    
+    - name: 'Run Clippy'
+      shell: bash
+      if: false
+      run: |
+        cargo clippy --release --features "textlayout" --all-targets --target wasm32-unknown-emscripten -- -D warnings
+    
+    - name: 'Test all workspace projects'
+      shell: bash
+      if: false
+      run: |
+        cargo test --all --release --features "textlayout" --all-targets --target wasm32-unknown-emscripten -- --nocapture
+      
+    - name: 'Generate skia-org example images'
+      shell: bash
+      if: false
+      run: |
+        cargo run --release --features "textlayout" --target wasm32-unknown-emscripten "${{ env.SKIA_STAGING_PATH }}/skia-org" 
+    
+    - name: 'Upload skia-org example images'
+      if: false
+      uses: actions/upload-artifact@v2
+      with:
+        name: skia-org-images-wasm32-unknown-emscripten
         path: ${{ env.SKIA_STAGING_PATH }}/skia-org
     
     - name: 'Compress binaries'
@@ -1290,6 +1618,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout" --target x86_64-unknown-linux-gnu
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1297,6 +1626,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1362,6 +1692,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout" --target aarch64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1369,6 +1700,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1434,6 +1766,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout" --target x86_64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1441,6 +1774,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1506,6 +1840,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout" --target i686-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1513,6 +1848,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1537,6 +1873,80 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: skia-org-images-i686-linux-android
+        path: ${{ env.SKIA_STAGING_PATH }}/skia-org
+    
+    - name: 'Compress binaries'
+      if: true
+      uses: master-atul/tar-action@v1.0.2
+      with:
+        command: c
+        cwd: '${{ env.SKIA_STAGING_PATH }}'
+        files: 'skia-binaries'
+        outPath: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+    
+    - name: 'Release binaries'
+      if: true
+      uses: pragmatrix/release-action@exp
+      with:
+        owner: rust-skia
+        repo: skia-binaries
+        allowUpdates: true
+        replacesArtifacts: true
+        tag: '${{ env.SKIA_BINARIES_TAG }}'
+        artifacts: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+        artifactErrorsFailBuild: true
+        token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
+        prerelease: true
+    - name: 'Install Rust target wasm32-unknown-emscripten'
+      shell: bash
+      run: |
+        rustup target add wasm32-unknown-emscripten
+    
+    - name: 'Build all targets in skia-safe for wasm32-unknown-emscripten with features gl,textlayout'
+      shell: bash
+      run: |
+        if [ "false" == "true" ]; then
+          TARGET=wasm32-unknown-emscripten
+          TARGET=${TARGET//-/_}
+          export CC_${TARGET}=wasm32-unknown-emscripten26-clang
+          export CXX_${TARGET}=wasm32-unknown-emscripten26-clang++
+          TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
+          export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=wasm32-unknown-emscripten26-clang
+          echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
+        fi
+        source /emsdk/emsdk_env.sh
+        cargo clean
+        cargo build -p skia-safe --all-targets --release --features "gl,textlayout" --target wasm32-unknown-emscripten
+        echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_BINARIES_KEY=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/key.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
+      env:
+        BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
+    
+    - name: 'Run Clippy'
+      shell: bash
+      if: false
+      run: |
+        cargo clippy --release --features "gl,textlayout" --all-targets --target wasm32-unknown-emscripten -- -D warnings
+    
+    - name: 'Test all workspace projects'
+      shell: bash
+      if: false
+      run: |
+        cargo test --all --release --features "gl,textlayout" --all-targets --target wasm32-unknown-emscripten -- --nocapture
+      
+    - name: 'Generate skia-org example images'
+      shell: bash
+      if: false
+      run: |
+        cargo run --release --features "gl,textlayout" --target wasm32-unknown-emscripten "${{ env.SKIA_STAGING_PATH }}/skia-org" 
+    
+    - name: 'Upload skia-org example images'
+      if: false
+      uses: actions/upload-artifact@v2
+      with:
+        name: skia-org-images-wasm32-unknown-emscripten
         path: ${{ env.SKIA_STAGING_PATH }}/skia-org
     
     - name: 'Compress binaries'
@@ -1600,6 +2010,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan,textlayout" --target x86_64-unknown-linux-gnu
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1607,6 +2018,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1672,6 +2084,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan,textlayout" --target aarch64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1679,6 +2092,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1744,6 +2158,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan,textlayout" --target x86_64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1751,6 +2166,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1816,6 +2232,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan,textlayout" --target i686-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1823,6 +2240,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1847,6 +2265,80 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: skia-org-images-i686-linux-android
+        path: ${{ env.SKIA_STAGING_PATH }}/skia-org
+    
+    - name: 'Compress binaries'
+      if: true
+      uses: master-atul/tar-action@v1.0.2
+      with:
+        command: c
+        cwd: '${{ env.SKIA_STAGING_PATH }}'
+        files: 'skia-binaries'
+        outPath: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+    
+    - name: 'Release binaries'
+      if: true
+      uses: pragmatrix/release-action@exp
+      with:
+        owner: rust-skia
+        repo: skia-binaries
+        allowUpdates: true
+        replacesArtifacts: true
+        tag: '${{ env.SKIA_BINARIES_TAG }}'
+        artifacts: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+        artifactErrorsFailBuild: true
+        token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
+        prerelease: true
+    - name: 'Install Rust target wasm32-unknown-emscripten'
+      shell: bash
+      run: |
+        rustup target add wasm32-unknown-emscripten
+    
+    - name: 'Build all targets in skia-safe for wasm32-unknown-emscripten with features vulkan,textlayout'
+      shell: bash
+      run: |
+        if [ "false" == "true" ]; then
+          TARGET=wasm32-unknown-emscripten
+          TARGET=${TARGET//-/_}
+          export CC_${TARGET}=wasm32-unknown-emscripten26-clang
+          export CXX_${TARGET}=wasm32-unknown-emscripten26-clang++
+          TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
+          export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=wasm32-unknown-emscripten26-clang
+          echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
+        fi
+        source /emsdk/emsdk_env.sh
+        cargo clean
+        cargo build -p skia-safe --all-targets --release --features "vulkan,textlayout" --target wasm32-unknown-emscripten
+        echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_BINARIES_KEY=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/key.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
+      env:
+        BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
+    
+    - name: 'Run Clippy'
+      shell: bash
+      if: false
+      run: |
+        cargo clippy --release --features "vulkan,textlayout" --all-targets --target wasm32-unknown-emscripten -- -D warnings
+    
+    - name: 'Test all workspace projects'
+      shell: bash
+      if: false
+      run: |
+        cargo test --all --release --features "vulkan,textlayout" --all-targets --target wasm32-unknown-emscripten -- --nocapture
+      
+    - name: 'Generate skia-org example images'
+      shell: bash
+      if: false
+      run: |
+        cargo run --release --features "vulkan,textlayout" --target wasm32-unknown-emscripten "${{ env.SKIA_STAGING_PATH }}/skia-org" 
+    
+    - name: 'Upload skia-org example images'
+      if: false
+      uses: actions/upload-artifact@v2
+      with:
+        name: skia-org-images-wasm32-unknown-emscripten
         path: ${{ env.SKIA_STAGING_PATH }}/skia-org
     
     - name: 'Compress binaries'
@@ -1910,6 +2402,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,vulkan,textlayout" --target x86_64-unknown-linux-gnu
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1917,6 +2410,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1982,6 +2476,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,vulkan,textlayout" --target aarch64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1989,6 +2484,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -2054,6 +2550,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,vulkan,textlayout" --target x86_64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2061,6 +2558,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -2126,6 +2624,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,vulkan,textlayout" --target i686-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2133,6 +2632,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -2157,6 +2657,80 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: skia-org-images-i686-linux-android
+        path: ${{ env.SKIA_STAGING_PATH }}/skia-org
+    
+    - name: 'Compress binaries'
+      if: true
+      uses: master-atul/tar-action@v1.0.2
+      with:
+        command: c
+        cwd: '${{ env.SKIA_STAGING_PATH }}'
+        files: 'skia-binaries'
+        outPath: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+    
+    - name: 'Release binaries'
+      if: true
+      uses: pragmatrix/release-action@exp
+      with:
+        owner: rust-skia
+        repo: skia-binaries
+        allowUpdates: true
+        replacesArtifacts: true
+        tag: '${{ env.SKIA_BINARIES_TAG }}'
+        artifacts: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+        artifactErrorsFailBuild: true
+        token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
+        prerelease: true
+    - name: 'Install Rust target wasm32-unknown-emscripten'
+      shell: bash
+      run: |
+        rustup target add wasm32-unknown-emscripten
+    
+    - name: 'Build all targets in skia-safe for wasm32-unknown-emscripten with features gl,vulkan,textlayout'
+      shell: bash
+      run: |
+        if [ "false" == "true" ]; then
+          TARGET=wasm32-unknown-emscripten
+          TARGET=${TARGET//-/_}
+          export CC_${TARGET}=wasm32-unknown-emscripten26-clang
+          export CXX_${TARGET}=wasm32-unknown-emscripten26-clang++
+          TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
+          export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=wasm32-unknown-emscripten26-clang
+          echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
+        fi
+        source /emsdk/emsdk_env.sh
+        cargo clean
+        cargo build -p skia-safe --all-targets --release --features "gl,vulkan,textlayout" --target wasm32-unknown-emscripten
+        echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_BINARIES_KEY=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/key.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
+      env:
+        BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
+    
+    - name: 'Run Clippy'
+      shell: bash
+      if: false
+      run: |
+        cargo clippy --release --features "gl,vulkan,textlayout" --all-targets --target wasm32-unknown-emscripten -- -D warnings
+    
+    - name: 'Test all workspace projects'
+      shell: bash
+      if: false
+      run: |
+        cargo test --all --release --features "gl,vulkan,textlayout" --all-targets --target wasm32-unknown-emscripten -- --nocapture
+      
+    - name: 'Generate skia-org example images'
+      shell: bash
+      if: false
+      run: |
+        cargo run --release --features "gl,vulkan,textlayout" --target wasm32-unknown-emscripten "${{ env.SKIA_STAGING_PATH }}/skia-org" 
+    
+    - name: 'Upload skia-org example images'
+      if: false
+      uses: actions/upload-artifact@v2
+      with:
+        name: skia-org-images-wasm32-unknown-emscripten
         path: ${{ env.SKIA_STAGING_PATH }}/skia-org
     
     - name: 'Compress binaries'
@@ -2220,6 +2794,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,x11" --target x86_64-unknown-linux-gnu
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2227,6 +2802,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -2292,6 +2868,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,x11" --target aarch64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2299,6 +2876,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -2364,6 +2942,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,x11" --target x86_64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2371,6 +2950,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -2436,6 +3016,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,x11" --target i686-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2443,6 +3024,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -2467,6 +3049,80 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: skia-org-images-i686-linux-android
+        path: ${{ env.SKIA_STAGING_PATH }}/skia-org
+    
+    - name: 'Compress binaries'
+      if: true
+      uses: master-atul/tar-action@v1.0.2
+      with:
+        command: c
+        cwd: '${{ env.SKIA_STAGING_PATH }}'
+        files: 'skia-binaries'
+        outPath: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+    
+    - name: 'Release binaries'
+      if: true
+      uses: pragmatrix/release-action@exp
+      with:
+        owner: rust-skia
+        repo: skia-binaries
+        allowUpdates: true
+        replacesArtifacts: true
+        tag: '${{ env.SKIA_BINARIES_TAG }}'
+        artifacts: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+        artifactErrorsFailBuild: true
+        token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
+        prerelease: true
+    - name: 'Install Rust target wasm32-unknown-emscripten'
+      shell: bash
+      run: |
+        rustup target add wasm32-unknown-emscripten
+    
+    - name: 'Build all targets in skia-safe for wasm32-unknown-emscripten with features gl,x11'
+      shell: bash
+      run: |
+        if [ "false" == "true" ]; then
+          TARGET=wasm32-unknown-emscripten
+          TARGET=${TARGET//-/_}
+          export CC_${TARGET}=wasm32-unknown-emscripten26-clang
+          export CXX_${TARGET}=wasm32-unknown-emscripten26-clang++
+          TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
+          export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=wasm32-unknown-emscripten26-clang
+          echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
+        fi
+        source /emsdk/emsdk_env.sh
+        cargo clean
+        cargo build -p skia-safe --all-targets --release --features "gl,x11" --target wasm32-unknown-emscripten
+        echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_BINARIES_KEY=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/key.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
+      env:
+        BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
+    
+    - name: 'Run Clippy'
+      shell: bash
+      if: false
+      run: |
+        cargo clippy --release --features "gl,x11" --all-targets --target wasm32-unknown-emscripten -- -D warnings
+    
+    - name: 'Test all workspace projects'
+      shell: bash
+      if: false
+      run: |
+        cargo test --all --release --features "gl,x11" --all-targets --target wasm32-unknown-emscripten -- --nocapture
+      
+    - name: 'Generate skia-org example images'
+      shell: bash
+      if: false
+      run: |
+        cargo run --release --features "gl,x11" --target wasm32-unknown-emscripten "${{ env.SKIA_STAGING_PATH }}/skia-org" 
+    
+    - name: 'Upload skia-org example images'
+      if: false
+      uses: actions/upload-artifact@v2
+      with:
+        name: skia-org-images-wasm32-unknown-emscripten
         path: ${{ env.SKIA_STAGING_PATH }}/skia-org
     
     - name: 'Compress binaries'
@@ -2530,6 +3186,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-unknown-linux-gnu26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout,x11" --target x86_64-unknown-linux-gnu
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2537,6 +3194,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -2602,6 +3260,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout,x11" --target aarch64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2609,6 +3268,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -2674,6 +3334,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout,x11" --target x86_64-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2681,6 +3342,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -2746,6 +3408,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=i686-linux-android26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout,x11" --target i686-linux-android
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2753,6 +3416,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -2777,6 +3441,80 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: skia-org-images-i686-linux-android
+        path: ${{ env.SKIA_STAGING_PATH }}/skia-org
+    
+    - name: 'Compress binaries'
+      if: true
+      uses: master-atul/tar-action@v1.0.2
+      with:
+        command: c
+        cwd: '${{ env.SKIA_STAGING_PATH }}'
+        files: 'skia-binaries'
+        outPath: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+    
+    - name: 'Release binaries'
+      if: true
+      uses: pragmatrix/release-action@exp
+      with:
+        owner: rust-skia
+        repo: skia-binaries
+        allowUpdates: true
+        replacesArtifacts: true
+        tag: '${{ env.SKIA_BINARIES_TAG }}'
+        artifacts: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+        artifactErrorsFailBuild: true
+        token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
+        prerelease: true
+    - name: 'Install Rust target wasm32-unknown-emscripten'
+      shell: bash
+      run: |
+        rustup target add wasm32-unknown-emscripten
+    
+    - name: 'Build all targets in skia-safe for wasm32-unknown-emscripten with features gl,textlayout,x11'
+      shell: bash
+      run: |
+        if [ "false" == "true" ]; then
+          TARGET=wasm32-unknown-emscripten
+          TARGET=${TARGET//-/_}
+          export CC_${TARGET}=wasm32-unknown-emscripten26-clang
+          export CXX_${TARGET}=wasm32-unknown-emscripten26-clang++
+          TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
+          export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=wasm32-unknown-emscripten26-clang
+          echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
+        fi
+        source /emsdk/emsdk_env.sh
+        cargo clean
+        cargo build -p skia-safe --all-targets --release --features "gl,textlayout,x11" --target wasm32-unknown-emscripten
+        echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_BINARIES_KEY=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/key.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
+      env:
+        BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
+    
+    - name: 'Run Clippy'
+      shell: bash
+      if: false
+      run: |
+        cargo clippy --release --features "gl,textlayout,x11" --all-targets --target wasm32-unknown-emscripten -- -D warnings
+    
+    - name: 'Test all workspace projects'
+      shell: bash
+      if: false
+      run: |
+        cargo test --all --release --features "gl,textlayout,x11" --all-targets --target wasm32-unknown-emscripten -- --nocapture
+      
+    - name: 'Generate skia-org example images'
+      shell: bash
+      if: false
+      run: |
+        cargo run --release --features "gl,textlayout,x11" --target wasm32-unknown-emscripten "${{ env.SKIA_STAGING_PATH }}/skia-org" 
+    
+    - name: 'Upload skia-org example images'
+      if: false
+      uses: actions/upload-artifact@v2
+      with:
+        name: skia-org-images-wasm32-unknown-emscripten
         path: ${{ env.SKIA_STAGING_PATH }}/skia-org
     
     - name: 'Compress binaries'

--- a/.github/workflows/macos-qa.yaml
+++ b/.github/workflows/macos-qa.yaml
@@ -55,6 +55,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,metal,textlayout,vulkan,webp" --target x86_64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -62,6 +63,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -127,6 +129,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,metal,textlayout,vulkan,webp" --target aarch64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -134,6 +137,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -199,6 +203,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,metal,textlayout,vulkan,webp" --target aarch64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -206,6 +211,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -271,6 +277,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios-sim26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,metal,textlayout,vulkan,webp" --target aarch64-apple-ios-sim
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -278,6 +285,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -343,6 +351,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,metal,textlayout,vulkan,webp" --target x86_64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -350,6 +359,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -437,6 +447,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,metal,textlayout,vulkan,webp" --target x86_64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -444,6 +455,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -509,6 +521,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,metal,textlayout,vulkan,webp" --target aarch64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -516,6 +529,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -581,6 +595,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,metal,textlayout,vulkan,webp" --target aarch64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -588,6 +603,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -653,6 +669,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios-sim26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,metal,textlayout,vulkan,webp" --target aarch64-apple-ios-sim
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -660,6 +677,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -725,6 +743,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,metal,textlayout,vulkan,webp" --target x86_64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -732,6 +751,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash

--- a/.github/workflows/macos-qa.yaml
+++ b/.github/workflows/macos-qa.yaml
@@ -55,7 +55,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,metal,textlayout,vulkan,webp" --target x86_64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -129,7 +131,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,metal,textlayout,vulkan,webp" --target aarch64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -203,7 +207,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,metal,textlayout,vulkan,webp" --target aarch64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -277,7 +283,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios-sim26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,metal,textlayout,vulkan,webp" --target aarch64-apple-ios-sim
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -351,7 +359,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,metal,textlayout,vulkan,webp" --target x86_64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -447,7 +457,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,metal,textlayout,vulkan,webp" --target x86_64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -521,7 +533,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,metal,textlayout,vulkan,webp" --target aarch64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -595,7 +609,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,metal,textlayout,vulkan,webp" --target aarch64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -669,7 +685,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios-sim26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,metal,textlayout,vulkan,webp" --target aarch64-apple-ios-sim
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -743,7 +761,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,metal,textlayout,vulkan,webp" --target x86_64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}

--- a/.github/workflows/macos-release.yaml
+++ b/.github/workflows/macos-release.yaml
@@ -50,6 +50,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "" --target x86_64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -57,6 +58,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -122,6 +124,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "" --target aarch64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -129,6 +132,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -194,6 +198,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "" --target aarch64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -201,6 +206,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -266,6 +272,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios-sim26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "" --target aarch64-apple-ios-sim
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -273,6 +280,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -338,6 +346,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "" --target x86_64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -345,6 +354,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -432,6 +442,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl" --target x86_64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -439,6 +450,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -504,6 +516,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl" --target aarch64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -511,6 +524,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -576,6 +590,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl" --target aarch64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -583,6 +598,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -648,6 +664,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios-sim26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl" --target aarch64-apple-ios-sim
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -655,6 +672,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -720,6 +738,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl" --target x86_64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -727,6 +746,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -814,6 +834,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan" --target x86_64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -821,6 +842,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -886,6 +908,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan" --target aarch64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -893,6 +916,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -958,6 +982,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan" --target aarch64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -965,6 +990,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1030,6 +1056,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios-sim26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan" --target aarch64-apple-ios-sim
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1037,6 +1064,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1102,6 +1130,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan" --target x86_64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1109,6 +1138,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1196,6 +1226,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "textlayout" --target x86_64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1203,6 +1234,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1268,6 +1300,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "textlayout" --target aarch64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1275,6 +1308,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1340,6 +1374,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "textlayout" --target aarch64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1347,6 +1382,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1412,6 +1448,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios-sim26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "textlayout" --target aarch64-apple-ios-sim
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1419,6 +1456,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1484,6 +1522,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "textlayout" --target x86_64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1491,6 +1530,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1578,6 +1618,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout" --target x86_64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1585,6 +1626,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1650,6 +1692,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout" --target aarch64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1657,6 +1700,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1722,6 +1766,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout" --target aarch64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1729,6 +1774,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1794,6 +1840,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios-sim26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout" --target aarch64-apple-ios-sim
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1801,6 +1848,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1866,6 +1914,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout" --target x86_64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1873,6 +1922,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -1960,6 +2010,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan,textlayout" --target x86_64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1967,6 +2018,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -2032,6 +2084,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan,textlayout" --target aarch64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2039,6 +2092,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -2104,6 +2158,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan,textlayout" --target aarch64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2111,6 +2166,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -2176,6 +2232,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios-sim26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan,textlayout" --target aarch64-apple-ios-sim
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2183,6 +2240,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -2248,6 +2306,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan,textlayout" --target x86_64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2255,6 +2314,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -2342,6 +2402,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,vulkan,textlayout" --target x86_64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2349,6 +2410,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -2414,6 +2476,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,vulkan,textlayout" --target aarch64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2421,6 +2484,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -2486,6 +2550,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,vulkan,textlayout" --target aarch64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2493,6 +2558,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -2558,6 +2624,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios-sim26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,vulkan,textlayout" --target aarch64-apple-ios-sim
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2565,6 +2632,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -2630,6 +2698,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,vulkan,textlayout" --target x86_64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2637,6 +2706,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -2724,6 +2794,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "metal" --target x86_64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2731,6 +2802,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -2796,6 +2868,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "metal" --target aarch64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2803,6 +2876,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -2868,6 +2942,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "metal" --target aarch64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2875,6 +2950,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -2940,6 +3016,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios-sim26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "metal" --target aarch64-apple-ios-sim
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2947,6 +3024,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -3012,6 +3090,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "metal" --target x86_64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -3019,6 +3098,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -3106,6 +3186,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "metal,textlayout" --target x86_64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -3113,6 +3194,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -3178,6 +3260,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "metal,textlayout" --target aarch64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -3185,6 +3268,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -3250,6 +3334,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "metal,textlayout" --target aarch64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -3257,6 +3342,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -3322,6 +3408,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios-sim26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "metal,textlayout" --target aarch64-apple-ios-sim
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -3329,6 +3416,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -3394,6 +3482,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "metal,textlayout" --target x86_64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -3401,6 +3490,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash

--- a/.github/workflows/macos-release.yaml
+++ b/.github/workflows/macos-release.yaml
@@ -50,7 +50,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "" --target x86_64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -124,7 +126,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "" --target aarch64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -198,7 +202,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "" --target aarch64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -272,7 +278,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios-sim26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "" --target aarch64-apple-ios-sim
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -346,7 +354,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "" --target x86_64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -442,7 +452,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl" --target x86_64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -516,7 +528,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl" --target aarch64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -590,7 +604,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl" --target aarch64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -664,7 +680,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios-sim26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl" --target aarch64-apple-ios-sim
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -738,7 +756,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl" --target x86_64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -834,7 +854,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan" --target x86_64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -908,7 +930,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan" --target aarch64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -982,7 +1006,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan" --target aarch64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1056,7 +1082,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios-sim26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan" --target aarch64-apple-ios-sim
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1130,7 +1158,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan" --target x86_64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1226,7 +1256,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "textlayout" --target x86_64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1300,7 +1332,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "textlayout" --target aarch64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1374,7 +1408,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "textlayout" --target aarch64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1448,7 +1484,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios-sim26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "textlayout" --target aarch64-apple-ios-sim
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1522,7 +1560,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "textlayout" --target x86_64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1618,7 +1658,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout" --target x86_64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1692,7 +1734,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout" --target aarch64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1766,7 +1810,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout" --target aarch64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1840,7 +1886,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios-sim26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout" --target aarch64-apple-ios-sim
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -1914,7 +1962,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout" --target x86_64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2010,7 +2060,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan,textlayout" --target x86_64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2084,7 +2136,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan,textlayout" --target aarch64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2158,7 +2212,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan,textlayout" --target aarch64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2232,7 +2288,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios-sim26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan,textlayout" --target aarch64-apple-ios-sim
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2306,7 +2364,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan,textlayout" --target x86_64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2402,7 +2462,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,vulkan,textlayout" --target x86_64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2476,7 +2538,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,vulkan,textlayout" --target aarch64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2550,7 +2614,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,vulkan,textlayout" --target aarch64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2624,7 +2690,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios-sim26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,vulkan,textlayout" --target aarch64-apple-ios-sim
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2698,7 +2766,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,vulkan,textlayout" --target x86_64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2794,7 +2864,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "metal" --target x86_64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2868,7 +2940,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "metal" --target aarch64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -2942,7 +3016,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "metal" --target aarch64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -3016,7 +3092,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios-sim26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "metal" --target aarch64-apple-ios-sim
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -3090,7 +3168,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "metal" --target x86_64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -3186,7 +3266,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "metal,textlayout" --target x86_64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -3260,7 +3342,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-darwin26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "metal,textlayout" --target aarch64-apple-darwin
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -3334,7 +3418,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "metal,textlayout" --target aarch64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -3408,7 +3494,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=aarch64-apple-ios-sim26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "metal,textlayout" --target aarch64-apple-ios-sim
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -3482,7 +3570,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-apple-ios26-clang
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "metal,textlayout" --target x86_64-apple-ios
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}

--- a/.github/workflows/windows-qa.yaml
+++ b/.github/workflows/windows-qa.yaml
@@ -65,6 +65,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "d3d,gl,textlayout,vulkan,webp" --target x86_64-pc-windows-msvc
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -72,6 +73,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -169,6 +171,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "d3d,gl,textlayout,vulkan,webp" --target x86_64-pc-windows-msvc
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -176,6 +179,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash

--- a/.github/workflows/windows-qa.yaml
+++ b/.github/workflows/windows-qa.yaml
@@ -65,7 +65,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "d3d,gl,textlayout,vulkan,webp" --target x86_64-pc-windows-msvc
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -171,7 +173,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "d3d,gl,textlayout,vulkan,webp" --target x86_64-pc-windows-msvc
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}

--- a/.github/workflows/windows-release.yaml
+++ b/.github/workflows/windows-release.yaml
@@ -60,6 +60,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "" --target x86_64-pc-windows-msvc
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -67,6 +68,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -164,6 +166,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl" --target x86_64-pc-windows-msvc
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -171,6 +174,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -268,6 +272,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan" --target x86_64-pc-windows-msvc
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -275,6 +280,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -372,6 +378,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "textlayout" --target x86_64-pc-windows-msvc
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -379,6 +386,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -476,6 +484,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout" --target x86_64-pc-windows-msvc
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -483,6 +492,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -580,6 +590,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan,textlayout" --target x86_64-pc-windows-msvc
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -587,6 +598,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -684,6 +696,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,vulkan,textlayout" --target x86_64-pc-windows-msvc
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -691,6 +704,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -788,6 +802,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "d3d" --target x86_64-pc-windows-msvc
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -795,6 +810,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash
@@ -892,6 +908,7 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
+        source /emsdk/emsdk_env.sh
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "d3d,textlayout" --target x86_64-pc-windows-msvc
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -899,6 +916,7 @@ jobs:
         echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
       env:
         BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
     
     - name: 'Run Clippy'
       shell: bash

--- a/.github/workflows/windows-release.yaml
+++ b/.github/workflows/windows-release.yaml
@@ -60,7 +60,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "" --target x86_64-pc-windows-msvc
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -166,7 +168,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl" --target x86_64-pc-windows-msvc
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -272,7 +276,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan" --target x86_64-pc-windows-msvc
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -378,7 +384,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "textlayout" --target x86_64-pc-windows-msvc
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -484,7 +492,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,textlayout" --target x86_64-pc-windows-msvc
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -590,7 +600,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "vulkan,textlayout" --target x86_64-pc-windows-msvc
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -696,7 +708,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "gl,vulkan,textlayout" --target x86_64-pc-windows-msvc
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -802,7 +816,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "d3d" --target x86_64-pc-windows-msvc
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -908,7 +924,9 @@ jobs:
           export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
           echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
         fi
-        source /emsdk/emsdk_env.sh
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
         cargo clean
         cargo build -p skia-safe --all-targets --release --features "d3d,textlayout" --target x86_64-pc-windows-msvc
         echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Because building Skia takes a lot of time and needs tools that may be missing, t
 | macOS                             | `x86_64-apple-darwin`                              |
 | Android                           | `aarch64-linux-android`<br/>`x86_64-linux-android` |
 | iOS                               | `aarch64-apple-ios`<br/>`x86_64-apple-ios`         |
+| WebAssembly                       | `wasm32-unknown-emscripten`                        |
 
 ### Wrappers & Codecs & Supported Features
 

--- a/mk-workflows/src/config.rs
+++ b/mk-workflows/src/config.rs
@@ -127,6 +127,7 @@ fn linux_targets() -> Vec<Target> {
         ..Default::default()
     }];
     targets.extend(android_targets());
+    targets.extend(wasm_targets());
     targets
 }
 
@@ -178,5 +179,13 @@ fn android_targets() -> Vec<Target> {
             ..Default::default()
         },
     ]
+    .into()
+}
+
+fn wasm_targets() -> Vec<Target> {
+    [Target {
+        target: "wasm32-unknown-emscripten",
+        ..Default::default()
+    }]
     .into()
 }

--- a/mk-workflows/src/config.rs
+++ b/mk-workflows/src/config.rs
@@ -185,6 +185,7 @@ fn android_targets() -> Vec<Target> {
 fn wasm_targets() -> Vec<Target> {
     [Target {
         target: "wasm32-unknown-emscripten",
+        emscripten_env: true,
         ..Default::default()
     }]
     .into()

--- a/mk-workflows/src/main.rs
+++ b/mk-workflows/src/main.rs
@@ -185,6 +185,7 @@ fn build_target(workflow: &Workflow, job: &Job, target: &Target) -> String {
     let template_arguments: &[(&'static str, &dyn fmt::Display)] = &[
         ("target", &target.target),
         ("androidEnv", &target.android_env),
+        ("emscriptenEnv", &target.emscripten_env),
         ("androidAPILevel", &config::DEFAULT_ANDROID_API_LEVEL),
         ("features", &features),
         ("runTests", &native_target),
@@ -232,6 +233,7 @@ fn render_template(template: &str, replacements: &[(String, String)]) -> String 
 struct Target {
     target: &'static str,
     android_env: bool,
+    emscripten_env: bool,
     platform_features: Features,
 }
 

--- a/mk-workflows/src/templates/target.yaml
+++ b/mk-workflows/src/templates/target.yaml
@@ -15,7 +15,9 @@
       export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=$[[target]]$[[androidAPILevel]]-clang$[[hostBinExt]]
       echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
     fi
-    source /emsdk/emsdk_env.sh
+    if [ "$[[emscriptenEnv]]" == "true" ]; then
+      source /emsdk/emsdk_env.sh
+    fi
     cargo clean
     cargo build -p skia-safe --all-targets --release --features "$[[features]]" --target $[[target]]
     echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}

--- a/mk-workflows/src/templates/target.yaml
+++ b/mk-workflows/src/templates/target.yaml
@@ -15,6 +15,7 @@
       export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=$[[target]]$[[androidAPILevel]]-clang$[[hostBinExt]]
       echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
     fi
+    source /emsdk/emsdk_env.sh
     cargo clean
     cargo build -p skia-safe --all-targets --release --features "$[[features]]" --target $[[target]]
     echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
@@ -22,6 +23,7 @@
     echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
   env:
     BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+    EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
 
 - name: 'Run Clippy'
   shell: bash

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -57,7 +57,7 @@ serial_test = "0.6"
 static_assertions = "1.1"
 
 # gl-window
-[target.'cfg(not(target_os = "android"))'.dev-dependencies]
+[target.'cfg(all(not(target_os = "android"), not(target_os = "emscripten")))'.dev-dependencies]
 glutin = "0.28"
 gl-rs = { package = "gl", version = "0.14.0" }
 

--- a/skia-safe/examples/gl-window/main.rs
+++ b/skia-safe/examples/gl-window/main.rs
@@ -9,12 +9,17 @@ fn main() {
     println!("This example is not supported on Android (https://github.com/rust-windowing/winit/issues/948).")
 }
 
-#[cfg(all(not(target_os = "android"), not(feature = "gl")))]
+#[cfg(target_os = "emscripten")]
+fn main() {
+    println!("This example is not supported on Emscripten (https://github.com/rust-windowing/glutin/issues/1349)")
+}
+
+#[cfg(all(not(target_os = "android"), not(target_os = "emscripten"), not(feature = "gl")))]
 fn main() {
     println!("To run this example, invoke cargo with --features \"gl\".")
 }
 
-#[cfg(all(not(target_os = "android"), feature = "gl"))]
+#[cfg(all(not(target_os = "android"), not(target_os = "emscripten"), feature = "gl"))]
 fn main() {
     use gl::types::*;
     use gl_rs as gl;

--- a/skia-safe/examples/gl-window/main.rs
+++ b/skia-safe/examples/gl-window/main.rs
@@ -14,12 +14,20 @@ fn main() {
     println!("This example is not supported on Emscripten (https://github.com/rust-windowing/glutin/issues/1349)")
 }
 
-#[cfg(all(not(target_os = "android"), not(target_os = "emscripten"), not(feature = "gl")))]
+#[cfg(all(
+    not(target_os = "android"),
+    not(target_os = "emscripten"),
+    not(feature = "gl")
+))]
 fn main() {
     println!("To run this example, invoke cargo with --features \"gl\".")
 }
 
-#[cfg(all(not(target_os = "android"), not(target_os = "emscripten"), feature = "gl"))]
+#[cfg(all(
+    not(target_os = "android"),
+    not(target_os = "emscripten"),
+    feature = "gl"
+))]
 fn main() {
     use gl::types::*;
     use gl_rs as gl;


### PR DESCRIPTION
Building on #611 which adds WebAssembly build support, this PR adds support for publishing `wasm32-unknown-emscripten` builds alongside the other supported builds.

## Why?

To speed up our builds now that we're using this in our web app :)

## Notes

The `gl-window` example currently doesn't build under `wasm32-unknown-emscripten`. There's an issue about it here: https://github.com/rust-windowing/glutin/issues/1349.

