### PR TITLE
Milestone 102

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![Windows QA](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml) [![Linux QA](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml) [![macOS QA](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml)
 
-Skia Submodule Status: chrome/m101 ([upstream changes][skia-upstream], [our changes][skia-ours]).
+Skia Submodule Status: chrome/m102 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m101-0.50.0...google:chrome/m101
-[skia-ours]: https://github.com/google/skia/compare/chrome/m101...rust-skia:m101-0.50.0
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m102-0.50.1...google:chrome/m102
+[skia-ours]: https://github.com/google/skia/compare/chrome/m102...rust-skia:m102-0.50.1
 
 ## Goals
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m101-0.50.0"
+skia = "m102-0.50.1"
 depot_tools = "fade894"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.50.0"
+version = "0.51.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2018"
 build = "build.rs"

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -758,8 +758,17 @@ extern "C" bool C_SkColorInfo_Equals(const SkColorInfo* lhs, const SkColorInfo* 
     return *lhs == *rhs;
 }
 
-extern "C" bool C_SkColorInfo_gammaCloseToSRGB(const SkColorInfo* self) {
-    return self->gammaCloseToSRGB();
+
+extern "C" void C_SkColorInfo_makeAlphaType(const SkColorInfo* self, SkAlphaType newAlphaType, SkColorInfo* uninitialized) {
+    new (uninitialized) SkColorInfo(self->makeAlphaType(newAlphaType));
+}
+
+extern "C" void C_SkColorInfo_makeColorType(const SkColorInfo* self, SkColorType newColorType, SkColorInfo* uninitialized) {
+    new (uninitialized) SkColorInfo(self->makeColorType(newColorType));
+}
+
+extern "C" void C_SkColorInfo_makeColorSpace(const SkColorInfo* self, SkColorSpace* newColorSpace, SkColorInfo* uninitialized) {
+    new (uninitialized) SkColorInfo(self->makeColorSpace(sp(newColorSpace)));
 }
 
 extern "C" void C_SkImageInfo_Construct(SkImageInfo* uninitialized) {
@@ -778,12 +787,32 @@ extern "C" bool C_SkImageInfo_Equals(const SkImageInfo* lhs, const SkImageInfo* 
     return *lhs == *rhs;
 }
 
-extern "C" void C_SkImageInfo_Make(SkImageInfo* self, int width, int height, SkColorType ct, SkAlphaType at, SkColorSpace* cs) {
-    *self = SkImageInfo::Make(width, height, ct, at, sp(cs));
+extern "C" void C_SkImageInfo_Make(int width, int height, SkColorType ct, SkAlphaType at, SkColorSpace* cs, SkImageInfo* uninitialized) {
+    new (uninitialized) SkImageInfo(SkImageInfo::Make(width, height, ct, at, sp(cs)));
 }
 
-extern "C" void C_SkImageInfo_MakeS32(SkImageInfo* self, int width, int height, SkAlphaType at) {
-    *self = SkImageInfo::MakeS32(width, height, at);
+extern "C" void C_SkImageInfo_MakeN32(int width, int height, SkAlphaType at, SkColorSpace* cs, SkImageInfo* uninitialized) {
+    new (uninitialized) SkImageInfo(SkImageInfo::MakeN32(width, height, at, sp(cs)));
+}
+
+extern "C" void C_SkImageInfo_MakeS32(int width, int height, SkAlphaType at, SkImageInfo* uninitialized) {
+    new (uninitialized) SkImageInfo(SkImageInfo::MakeS32(width, height, at));
+}
+
+extern "C" void C_SkImageInfo_MakeN32Premul(int width, int height, SkColorSpace* cs, SkImageInfo* uninitialized) {
+    new (uninitialized) SkImageInfo(SkImageInfo::MakeN32Premul(width, height, sp(cs)));
+}
+
+extern "C" void C_SkImageInfo_MakeA8(int width, int height, SkImageInfo* uninitialized) {
+    new (uninitialized) SkImageInfo(SkImageInfo::MakeA8(width, height));
+}
+
+extern "C" void C_SkImageInfo_MakeUnknown(int width, int height, SkImageInfo* uninitialized) {
+    new (uninitialized) SkImageInfo(SkImageInfo::MakeUnknown(width, height));
+}
+
+extern "C" void C_SkImageInfo_makeColorSpace(const SkImageInfo* self, SkColorSpace* cs, SkImageInfo* uninitialized) {
+    new (uninitialized) SkImageInfo(self->makeColorSpace(sp(cs)));
 }
 
 extern "C" void C_SkImageInfo_reset(SkImageInfo* self) {
@@ -1820,10 +1849,6 @@ extern "C" void C_SkPixmap_destruct(SkPixmap* self) {
 
 extern "C" void C_SkPixmap_setColorSpace(SkPixmap* self, SkColorSpace* colorSpace) {
     self->setColorSpace(sp(colorSpace));
-}
-
-extern "C" SkISize C_SkPixmap_dimensions(const SkPixmap *self) {
-    return self->dimensions();
 }
 
 //

--- a/skia-bindings/src/paragraph.cpp
+++ b/skia-bindings/src/paragraph.cpp
@@ -305,6 +305,11 @@ extern "C" {
         new(uninitialized) TextStyle(*other);
     }
 
+    void C_TextStyle_cloneForPlaceholder(const TextStyle* self, TextStyle* uninitialized) {
+        // m102: We assume that they just forgot to mark `TextStyle::cloneForPlaceholder` as const.
+        new (uninitialized) TextStyle(const_cast<TextStyle*>(self)->cloneForPlaceholder());
+    }
+
     void C_TextStyle_destruct(TextStyle* self) {
         self->~TextStyle();
     }

--- a/skia-bindings/src/paragraph.cpp
+++ b/skia-bindings/src/paragraph.cpp
@@ -16,7 +16,39 @@
 // m84: needs definition of SkFontData
 #include "src/core/SkFontDescriptor.h"
 
+#include <optional>
+
 using namespace skia::textlayout;
+
+//
+// FontArguments.h
+//
+
+extern "C" {
+    void C_FontArguments_Construct(const SkFontArguments* fontArguments, FontArguments* uninitialized) {
+        new (uninitialized) FontArguments(*fontArguments);
+    }
+
+    void C_FontArguments_CopyConstruct(FontArguments* uninitialized, const FontArguments* self) {
+        new (uninitialized) FontArguments(*self);
+    }
+
+    void C_FontArguments_destruct(FontArguments* self) {
+        self->~FontArguments();
+    }
+
+    bool C_FontArguments_Equals(const FontArguments* lhs, const FontArguments* rhs) {
+        return *lhs == *rhs;
+    }
+
+    size_t C_FontArguments_hash(const FontArguments* self) {
+        return std::hash<FontArguments>{}(*self);
+    }
+
+    SkTypeface* C_FontArguments_cloneTypeface(const FontArguments* self, SkTypeface* tf) {
+        return self->CloneTypeface(sp(tf)).release();
+    }
+}
 
 //
 // FontCollection.h
@@ -55,8 +87,15 @@ extern "C" {
         return self->getFallbackManager().release();
     }
 
-    void C_FontCollection_findTypefaces(FontCollection* self, const SkStrings* familyNames, SkFontStyle fontStyle, VecSink<sk_sp<SkTypeface>>* typefaces) {
-        auto tfs = self->findTypefaces(familyNames->strings, fontStyle);
+    void C_FontCollection_findTypefaces(
+        FontCollection* self, 
+        const SkStrings* familyNames, 
+        SkFontStyle fontStyle,
+        const FontArguments* fontArguments,
+        VecSink<sk_sp<SkTypeface>>* typefaces) {
+        // TODO: Don't create a copy of `fontArguments`.
+        auto fa = fontArguments ? std::optional(*fontArguments) : std::nullopt;
+        auto tfs = self->findTypefaces(familyNames->strings, fontStyle, fa);
         typefaces->set(tfs);
     }
 
@@ -341,7 +380,16 @@ extern "C" {
     void C_TextStyle_resetFontFeatures(TextStyle* self) {
         self->resetFontFeatures();
     }
-    
+
+    const FontArguments* C_TextStyle_getFontArguments(const TextStyle* self) {
+        auto& fontArguments = self->getFontArguments();
+        return fontArguments ? &*fontArguments : nullptr;
+    }
+
+    void C_TextStyle_setFontArguments(TextStyle* self, const SkFontArguments* arguments) {
+        self->setFontArguments(arguments ? std::optional(*arguments) : std::nullopt);
+    }
+
     const SkString* C_TextStyle_getFontFamilies(const TextStyle* self, size_t* count) {
         auto& v = self->getFontFamilies();
         *count = v.size();

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.50.0"
+version = "0.51.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2018"
 
@@ -46,7 +46,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 [dependencies]
 bitflags = "1.2"
 lazy_static = "1.4"
-skia-bindings = { version = "=0.50.0", path = "../skia-bindings", default-features = false }
+skia-bindings = { version = "=0.51.0", path = "../skia-bindings", default-features = false }
 # for d3d types
 winapi = { version = "0.3.9", features = ["d3d12", "dxgi"], optional = true }
 # for ComPtr

--- a/skia-safe/src/core/bitmap.rs
+++ b/skia-safe/src/core/bitmap.rs
@@ -110,7 +110,7 @@ impl Bitmap {
     /// Returns [ColorSpace], the range of colors, associated with [ImageInfo]. The returned
     /// [ColorSpace] is immutable.
     pub fn color_space(&self) -> Option<ColorSpace> {
-        self.pixmap().color_space()
+        ColorSpace::from_unshared_ptr(unsafe { self.native().colorSpace() })
     }
 
     /// Returns number of bytes per pixel required by [ColorType].

--- a/skia-safe/src/core/color_type.rs
+++ b/skia-safe/src/core/color_type.rs
@@ -33,16 +33,16 @@ pub enum ColorType {
 native_transmutable!(SkColorType, ColorType, color_type_layout);
 
 impl ColorType {
-    // error[E0658]: dereferencing raw pointers in constants is unstable (see issue #51911)
-    /*
-    pub const N32 : Self = unsafe {
-        *((&SkColorType::kN32_SkColorType) as *const _ as *const _)
-    };
-    */
-
-    pub fn n32() -> Self {
-        Self::from_native_c(SkColorType::kN32_SkColorType)
+    #[deprecated(note = "Use ColorType::N32 ")]
+    pub const fn n32() -> Self {
+        Self::N32
     }
+
+    pub const N32: Self = unsafe { *((&SkColorType::kN32_SkColorType) as *const _ as *const _) };
+
+    pub const COUNT: usize =
+        unsafe { *((&SkColorType::kLastEnum_SkColorType) as *const _ as *const _) } as usize
+            + 1usize;
 
     pub fn bytes_per_pixel(self) -> usize {
         unsafe {
@@ -62,5 +62,18 @@ impl ColorType {
             sb::SkColorTypeValidateAlphaType(self.into_native(), alpha_type, &mut alpha_type_r)
         }
         .if_true_some(alpha_type_r)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn n32_matches() {
+        assert_eq!(
+            ColorType::from_native_c(skia_bindings::SkColorType::kN32_SkColorType),
+            ColorType::N32
+        );
     }
 }

--- a/skia-safe/src/core/color_type.rs
+++ b/skia-safe/src/core/color_type.rs
@@ -33,7 +33,7 @@ pub enum ColorType {
 native_transmutable!(SkColorType, ColorType, color_type_layout);
 
 impl ColorType {
-    #[deprecated(note = "Use ColorType::N32 ")]
+    #[deprecated(since = "0.51.0", note = "Use ColorType::N32 ")]
     pub const fn n32() -> Self {
         Self::N32
     }

--- a/skia-safe/src/core/image.rs
+++ b/skia-safe/src/core/image.rs
@@ -230,7 +230,7 @@ impl Image {
         backend_texture: &gpu::BackendTexture,
         texture_origin: gpu::SurfaceOrigin,
         color_type: ColorType,
-        alpha_type: AlphaType,
+        alpha_type: impl Into<Option<AlphaType>>,
         color_space: impl Into<Option<ColorSpace>>,
     ) -> Option<Image> {
         Image::from_ptr(unsafe {
@@ -239,7 +239,7 @@ impl Image {
                 backend_texture.native(),
                 texture_origin,
                 color_type.into_native(),
-                alpha_type,
+                alpha_type.into().unwrap_or(AlphaType::Premul),
                 color_space.into().into_ptr_or_null(),
             )
         })

--- a/skia-safe/src/core/milestone.rs
+++ b/skia-safe/src/core/milestone.rs
@@ -1,1 +1,1 @@
-pub const MILESTONE: usize = 101;
+pub const MILESTONE: usize = 102;

--- a/skia-safe/src/core/pixmap.rs
+++ b/skia-safe/src/core/pixmap.rs
@@ -110,7 +110,7 @@ impl Pixmap {
     }
 
     pub fn color_space(&self) -> Option<ColorSpace> {
-        self.info().color_space()
+        ColorSpace::from_unshared_ptr(unsafe { self.native().colorSpace() })
     }
 
     pub fn is_opaque(&self) -> bool {
@@ -345,13 +345,13 @@ unsafe impl Pixel for (f32, f32, f32, f32) {
 
 unsafe impl Pixel for u32 {
     fn matches_color_type(ct: ColorType) -> bool {
-        ct == ColorType::n32()
+        ct == ColorType::N32
     }
 }
 
 unsafe impl Pixel for Color {
     fn matches_color_type(ct: ColorType) -> bool {
-        ct == ColorType::n32()
+        ct == ColorType::N32
     }
 }
 

--- a/skia-safe/src/gpu/context_options.rs
+++ b/skia-safe/src/gpu/context_options.rs
@@ -28,7 +28,6 @@ pub struct ContextOptions {
     pub glyphs_as_paths_font_size: f32,
     pub allow_multiple_glyph_cache_textures: Enable,
     pub avoid_stencil_buffers: bool,
-    pub sharpen_mipmapped_textures: bool,
     pub use_draw_instead_of_clear: Enable,
     pub reduce_ops_task_splitting: Enable,
     pub prefer_external_images_over_es3: bool,

--- a/skia-safe/src/modules/paragraph.rs
+++ b/skia-safe/src/modules/paragraph.rs
@@ -2,34 +2,28 @@ use crate::interop::AsStr;
 use std::ops::Index;
 
 mod dart_types;
-pub use dart_types::*;
-
+mod font_arguments;
 mod font_collection;
-pub use font_collection::*;
-
 mod metrics;
-pub use metrics::*;
-
 #[allow(clippy::module_inception)]
 mod paragraph;
-pub use paragraph::*;
-
 mod paragraph_builder;
-pub use paragraph_builder::*;
-
 mod paragraph_cache;
-pub use paragraph_cache::*;
-
 mod paragraph_style;
-pub use paragraph_style::*;
-
 mod text_shadow;
-pub use text_shadow::*;
-
 mod text_style;
-pub use text_style::*;
-
 mod typeface_font_provider;
+
+pub use dart_types::*;
+pub use font_arguments::*;
+pub use font_collection::*;
+pub use metrics::*;
+pub use paragraph::*;
+pub use paragraph_builder::*;
+pub use paragraph_cache::*;
+pub use paragraph_style::*;
+pub use text_shadow::*;
+pub use text_style::*;
 pub use typeface_font_provider::*;
 
 /// Efficient reference type to a C++ vector of font family SkStrings.

--- a/skia-safe/src/modules/paragraph/dart_types.rs
+++ b/skia-safe/src/modules/paragraph/dart_types.rs
@@ -88,6 +88,3 @@ variant_name!(
 );
 
 // m84: LineMetricStyle is declared but not used in the public API yet.
-
-pub use sb::skia_textlayout_DrawOptions as DrawOptions;
-variant_name!(DrawOptions::Replay, draw_options_naming);

--- a/skia-safe/src/modules/paragraph/font_arguments.rs
+++ b/skia-safe/src/modules/paragraph/font_arguments.rs
@@ -1,6 +1,6 @@
 use crate::{prelude::*, Typeface};
 use skia_bindings::{self as sb, skia_textlayout_FontArguments};
-use std::fmt;
+use std::{fmt, hash};
 
 pub type FontArguments = Handle<skia_textlayout_FontArguments>;
 unsafe_send_sync!(FontArguments);
@@ -32,7 +32,7 @@ impl NativePartialEq for skia_textlayout_FontArguments {
 }
 
 impl NativeHash for skia_textlayout_FontArguments {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
         state.write_usize(unsafe { sb::C_FontArguments_hash(self) })
     }
 }

--- a/skia-safe/src/modules/paragraph/font_arguments.rs
+++ b/skia-safe/src/modules/paragraph/font_arguments.rs
@@ -1,0 +1,52 @@
+use crate::{prelude::*, Typeface};
+use skia_bindings::{self as sb, skia_textlayout_FontArguments};
+use std::fmt;
+
+pub type FontArguments = Handle<skia_textlayout_FontArguments>;
+unsafe_send_sync!(FontArguments);
+
+impl From<crate::FontArguments<'_, '_>> for FontArguments {
+    fn from(fa: crate::FontArguments<'_, '_>) -> Self {
+        FontArguments::construct(|uninitialized| unsafe {
+            sb::C_FontArguments_Construct(fa.native(), uninitialized)
+        })
+    }
+}
+
+impl NativeClone for skia_textlayout_FontArguments {
+    fn clone(&self) -> Self {
+        unsafe { construct(|fa| sb::C_FontArguments_CopyConstruct(fa, self)) }
+    }
+}
+
+impl NativeDrop for skia_textlayout_FontArguments {
+    fn drop(&mut self) {
+        unsafe { sb::C_FontArguments_destruct(self) }
+    }
+}
+
+impl NativePartialEq for skia_textlayout_FontArguments {
+    fn eq(&self, rhs: &Self) -> bool {
+        unsafe { sb::C_FontArguments_Equals(self, rhs) }
+    }
+}
+
+impl NativeHash for skia_textlayout_FontArguments {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        state.write_usize(unsafe { sb::C_FontArguments_hash(self) })
+    }
+}
+
+impl fmt::Debug for FontArguments {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FontArguments").finish()
+    }
+}
+
+impl FontArguments {
+    pub fn clone_typeface(&self, typeface: impl Into<Typeface>) -> Option<Typeface> {
+        Typeface::from_ptr(unsafe {
+            sb::C_FontArguments_cloneTypeface(self.native(), typeface.into().into_ptr())
+        })
+    }
+}

--- a/skia-safe/src/modules/paragraph/font_collection.rs
+++ b/skia-safe/src/modules/paragraph/font_collection.rs
@@ -7,6 +7,8 @@ use crate::{
 use skia_bindings::{self as sb, skia_textlayout_FontCollection};
 use std::{ffi, fmt, ptr};
 
+use super::FontArguments;
+
 pub type FontCollection = RCHandle<skia_textlayout_FontCollection>;
 
 impl NativeRefCountedBase for skia_textlayout_FontCollection {
@@ -109,6 +111,15 @@ impl FontCollection {
         family_names: &[impl AsRef<str>],
         font_style: FontStyle,
     ) -> Vec<Typeface> {
+        self.find_typefaces_with_font_arguments(family_names, font_style, None)
+    }
+
+    pub fn find_typefaces_with_font_arguments<'fa>(
+        &mut self,
+        family_names: &[impl AsRef<str>],
+        font_style: FontStyle,
+        font_args: impl Into<Option<&'fa FontArguments>>,
+    ) -> Vec<Typeface> {
         let family_names = interop::Strings::from_strs(family_names);
 
         let mut typefaces: Vec<Typeface> = Vec::new();
@@ -128,6 +139,7 @@ impl FontCollection {
                 self.native_mut(),
                 family_names.native(),
                 font_style.into_native(),
+                font_args.into().native_ptr_or_null(),
                 VecSink::new_mut(&mut set_typefaces).native_mut(),
             )
         };

--- a/skia-safe/src/modules/paragraph/paragraph_cache.rs
+++ b/skia-safe/src/modules/paragraph/paragraph_cache.rs
@@ -1,7 +1,6 @@
-use std::fmt;
-
 use crate::prelude::*;
 use skia_bindings::{self as sb, skia_textlayout_ParagraphCache};
+use std::fmt;
 
 pub type ParagraphCache = Handle<skia_textlayout_ParagraphCache>;
 

--- a/skia-safe/src/modules/paragraph/paragraph_style.rs
+++ b/skia-safe/src/modules/paragraph/paragraph_style.rs
@@ -1,6 +1,4 @@
-use std::fmt;
-
-use super::{DrawOptions, FontFamilies, TextAlign, TextDirection, TextStyle};
+use super::{FontFamilies, TextAlign, TextDirection, TextStyle};
 use crate::{
     interop::{self, AsStr, FromStrs, SetStr},
     modules::paragraph::TextHeightBehavior,
@@ -8,6 +6,7 @@ use crate::{
     scalar, FontStyle,
 };
 use skia_bindings as sb;
+use std::fmt;
 
 pub type StrutStyle = Handle<sb::skia_textlayout_StrutStyle>;
 unsafe_send_sync!(StrutStyle);
@@ -190,7 +189,6 @@ impl fmt::Debug for ParagraphStyle {
             .field("ellipsized", &self.ellipsized())
             .field("effective_align", &self.effective_align())
             .field("hinting_is_on", &self.hinting_is_on())
-            .field("draw_options", &self.draw_options())
             .finish()
     }
 }
@@ -298,15 +296,6 @@ impl ParagraphStyle {
 
     pub fn turn_hinting_off(&mut self) -> &mut Self {
         self.native_mut().fHintingIsOn = false;
-        self
-    }
-
-    pub fn draw_options(&self) -> DrawOptions {
-        self.native().fDrawingOptions
-    }
-
-    pub fn set_draw_options(&mut self, value: DrawOptions) -> &mut Self {
-        self.native_mut().fDrawingOptions = value;
         self
     }
 }

--- a/skia-safe/src/modules/paragraph/text_style.rs
+++ b/skia-safe/src/modules/paragraph/text_style.rs
@@ -1,4 +1,4 @@
-use super::{FontFamilies, TextBaseline, TextShadow};
+use super::{FontArguments, FontFamilies, TextBaseline, TextShadow};
 use crate::{
     interop::{self, AsStr, FromStrs, SetStr},
     prelude::*,
@@ -214,7 +214,7 @@ impl TextStyle {
 
     #[must_use]
     pub fn clone_for_placeholder(&self) -> Self {
-        TextStyle::construct(|ts| unsafe { sb::C_TextStyle_cloneForPlaceholder(self.native(), ts) })
+        Self::construct(|ts| unsafe { sb::C_TextStyle_cloneForPlaceholder(self.native(), ts) })
     }
 
     pub fn equals(&self, other: &TextStyle) -> bool {
@@ -318,6 +318,24 @@ impl TextStyle {
 
     pub fn reset_font_features(&mut self) {
         unsafe { sb::C_TextStyle_resetFontFeatures(self.native_mut()) }
+    }
+
+    pub fn font_arguments(&self) -> Option<&FontArguments> {
+        unsafe { sb::C_TextStyle_getFontArguments(self.native()) }
+            .into_option()
+            .map(|ptr| FontArguments::from_native_ref(unsafe { &*ptr }))
+    }
+
+    pub fn set_font_arguments<'fa>(
+        &mut self,
+        arguments: impl Into<Option<&'fa crate::FontArguments<'fa, 'fa>>>,
+    ) {
+        unsafe {
+            sb::C_TextStyle_setFontArguments(
+                self.native_mut(),
+                arguments.into().native_ptr_or_null(),
+            )
+        }
     }
 
     pub fn font_size(&self) -> scalar {
@@ -535,5 +553,23 @@ impl Placeholder {
             blocks_before,
             text_before,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn getting_setting_comparing_font_arguments() {
+        let mut ts = TextStyle::new();
+        let mut fa = crate::FontArguments::default();
+        fa.set_collection_index(100);
+        ts.set_font_arguments(&fa);
+        let tl_fa: FontArguments = fa.into();
+        let fa = ts.font_arguments().unwrap();
+        assert_eq!(tl_fa, *fa);
+        let default_fa: FontArguments = crate::FontArguments::default().into();
+        assert_ne!(default_fa, *fa);
     }
 }

--- a/skia-safe/src/modules/paragraph/text_style.rs
+++ b/skia-safe/src/modules/paragraph/text_style.rs
@@ -206,9 +206,15 @@ impl TextStyle {
         TextStyle::construct(|ts| unsafe { sb::C_TextStyle_Construct(ts) })
     }
 
+    #[deprecated(note = "Use clone_for_placeholder", since = "0.0.0")]
     #[must_use]
     pub fn to_placeholder(&self) -> Self {
-        TextStyle::from_native_c(unsafe { sb::skia_textlayout_TextStyle::new(self.native(), true) })
+        self.clone_for_placeholder()
+    }
+
+    #[must_use]
+    pub fn clone_for_placeholder(&self) -> Self {
+        TextStyle::construct(|ts| unsafe { sb::C_TextStyle_cloneForPlaceholder(self.native(), ts) })
     }
 
     pub fn equals(&self, other: &TextStyle) -> bool {

--- a/skia-safe/src/modules/paragraph/text_style.rs
+++ b/skia-safe/src/modules/paragraph/text_style.rs
@@ -206,7 +206,7 @@ impl TextStyle {
         TextStyle::construct(|ts| unsafe { sb::C_TextStyle_Construct(ts) })
     }
 
-    #[deprecated(note = "Use clone_for_placeholder", since = "0.51.0")]
+    #[deprecated(since = "0.51.0", note = "Use clone_for_placeholder")]
     #[must_use]
     pub fn to_placeholder(&self) -> Self {
         self.clone_for_placeholder()

--- a/skia-safe/src/modules/paragraph/text_style.rs
+++ b/skia-safe/src/modules/paragraph/text_style.rs
@@ -206,7 +206,7 @@ impl TextStyle {
         TextStyle::construct(|ts| unsafe { sb::C_TextStyle_Construct(ts) })
     }
 
-    #[deprecated(note = "Use clone_for_placeholder", since = "0.0.0")]
+    #[deprecated(note = "Use clone_for_placeholder", since = "0.51.0")]
     #[must_use]
     pub fn to_placeholder(&self) -> Self {
         self.clone_for_placeholder()

--- a/skia-safe/src/prelude.rs
+++ b/skia-safe/src/prelude.rs
@@ -227,9 +227,9 @@ pub trait NativeHash {
     fn hash<H: Hasher>(&self, state: &mut H);
 }
 
-/// Wraps a native type that can be represented and used in Rust memory.
+/// Wraps a native type that can be represented in Rust memory.
 ///
-/// This type requires the trait `NativeDrop` to be implemented.
+/// This type requires an implementation of the `NativeDrop` trait.
 #[repr(transparent)]
 pub struct Handle<N: NativeDrop>(
     N,

--- a/skia-safe/src/prelude.rs
+++ b/skia-safe/src/prelude.rs
@@ -246,27 +246,32 @@ impl<N: NativeDrop> AsRef<Handle<N>> for Handle<N> {
 
 impl<N: NativeDrop> Handle<N> {
     /// Wrap a native instance into a handle.
+    #[must_use]
     pub(crate) fn from_native_c(n: N) -> Self {
         Handle(n, PhantomData)
     }
 
     /// Create a reference to the Rust wrapper from a reference to the native type.
+    #[must_use]
     pub(crate) fn from_native_ref(n: &N) -> &Self {
         unsafe { transmute_ref(n) }
     }
 
     /// Create a mutable reference to the Rust wrapper from a reference to the native type.
+    #[must_use]
     pub(crate) fn from_native_ref_mut(n: &mut N) -> &mut Self {
         unsafe { transmute_ref_mut(n) }
     }
 
     /// Converts a pointer to a native value into a pointer to the Rust value.
+    #[must_use]
     pub(crate) fn from_native_ptr(np: *const N) -> *const Self {
         np as _
     }
 
     /// Converts a pointer to a mutable native value into a pointer to the mutable Rust value.
     #[allow(unused)]
+    #[must_use]
     pub(crate) fn from_native_ptr_mut(np: *mut N) -> *mut Self {
         np as _
     }
@@ -274,6 +279,7 @@ impl<N: NativeDrop> Handle<N> {
     /// Constructs a C++ object in place by calling a
     /// function that expects a pointer that points to
     /// uninitialized memory of the native type.
+    #[must_use]
     pub(crate) fn construct(construct: impl FnOnce(*mut N)) -> Self {
         Self::try_construct(|i| {
             construct(i);
@@ -282,18 +288,21 @@ impl<N: NativeDrop> Handle<N> {
         .unwrap()
     }
 
+    #[must_use]
     pub(crate) fn try_construct(construct: impl FnOnce(*mut N) -> bool) -> Option<Self> {
         self::try_construct(construct).map(Self::from_native_c)
     }
 
     /// Replaces the native instance with the one from this Handle, and returns the replaced one
     /// wrapped in a Rust Handle without dropping either one.
+    #[must_use]
     pub(crate) fn replace_native(mut self, native: &mut N) -> Self {
         mem::swap(&mut self.0, native);
         self
     }
 
     /// Consumes the wrapper and returns the native type.
+    #[must_use]
     pub(crate) fn into_native(mut self) -> N {
         let r = mem::replace(&mut self.0, unsafe { mem::zeroed() });
         mem::forget(self);
@@ -313,6 +322,7 @@ impl<N: NativeDrop> ReplaceWith<Handle<N>> for N {
 
 /// Constructs a C++ object in place by calling a lambda that is meant to initialize
 /// the pointer to the Rust memory provided as a pointer.
+#[must_use]
 pub(crate) fn construct<N>(construct: impl FnOnce(*mut N)) -> N {
     try_construct(|i| {
         construct(i);
@@ -321,6 +331,7 @@ pub(crate) fn construct<N>(construct: impl FnOnce(*mut N)) -> N {
     .unwrap()
 }
 
+#[must_use]
 pub(crate) fn try_construct<N>(construct: impl FnOnce(*mut N) -> bool) -> Option<N> {
     let mut instance = MaybeUninit::uninit();
     construct(instance.as_mut_ptr()).if_true_then_some(|| unsafe { instance.assume_init() })

--- a/skia-safe/tests/send_sync.rs
+++ b/skia-safe/tests/send_sync.rs
@@ -246,6 +246,7 @@ mod textlayout {
     assert_impl_all!(TextStyle: Send, Sync);
     assert_impl_all!(Block: Send, Sync);
     assert_impl_all!(Placeholder: Send, Sync);
+    assert_impl_all!(FontArguments: Send, Sync);
     assert_not_impl_any!(TypefaceFontStyleSet: Send, Sync);
     assert_not_impl_any!(TypefaceFontProvider: Send, Sync);
     assert_not_impl_any!(FontFamilies: Send, Sync);


### PR DESCRIPTION
This PR updates rust-skia to support Skia's `chrome/m102` branch.

- [x] Update `README.md` ([rendered](https://github.com/pragmatrix/rust-skia/blob/m102/README.md))  
  > Most important here is to change the Skia branch name and the current Skia submodule tag at the top of the `README.md` file.
- [x] Diff the the following files to see if the build organization has changed significantly:
  - [x] `/BUILD.gn`
  - [x] `/modules/skshaper/BUILD.gn`
  - [x] `/modules/paragraph/BUILD.gn`
- [x] Skia builds ([release notes](https://github.com/google/skia/blob/chrome/m102/RELEASE_NOTES.txt)).
- [x] `/skia-bindings` builds.
- [x] `/skia-safe`: Update & add new wrappers by diffing include files.  
  > Add TODOs for everything that can not be updated right now, and attempt to stay compatible with previous versions of skia-safe without trying too hard before version 1.0. Use `deprecated` attributes if needed.
  - [x] `codec/`
  - [x] `core/`
  - [x] `docs/`
  - [x] `effects/`
  - [x] `gpu/`
    - [x] `d3d/`
    - [x] `gl/`
    - [x] `mtl/`
    - [x] `vk/`
  - [x] `modules/`
    - [x] `paragraph/`
    - [x] `shaper/`
  - [x] `pathops/`
  - [x] `svg/`
  - [x] `utils/`
- [x] Review `Send` & `Sync` implementations for new wrappers.
- [x] Review `Debug` implementation for new wrapper types and functions.
- [x] Any pending changes in the Skia `chrome/m102` branch that aren't synchronized yet?
- [x] Rebase on or merge with master.
- [x] Do the `rust-skia:` commits in the `skia-bindings/skia` subdirectory match with `master`.
- [x] Update versions of `skia-bindings/Cargo.toml` and `skia-safe/Cargo.toml` and also add the version to the new `deprecated` attributes.
- [x] Do the tags/hashes in `skia-bindings/Cargo.toml` under `[package.metadata]` match the submodules `depot_tools` and `skia`?
- [ ] Test builds we don't do on the CI:
  - [ ] Compiles to Catalyst targets on macOS (#548).
    ```zsh
    make macos-qa
    ```
  > Needs python3 support #595 
- [x] Do one final review of all the changes.
- [x] Run `cargo doc` with all features and fix all warnings.

