### PR TITLE
update flake.nix to include darwin m1 support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1614392332,
-        "narHash": "sha256-K+2Ootl+JxjvuwK6jvwHqAtOWgEorOfjKcwNPQgIFQc=",
+        "lastModified": 1656359916,
+        "narHash": "sha256-kzS3TcC6tm4VqNnBmZttsKSZjBk30uUch9KJqq0QmdQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c796cc4eacedb91feec77e30a2ed79f64a23e08b",
+        "rev": "8c972668313c6e61a39671efbe48bce148918aa5",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1610051610,
-        "narHash": "sha256-U9rPz/usA1/Aohhk7Cmc2gBrEEKRzcW4nwPWMPwja4Y=",
+        "lastModified": 1656065134,
+        "narHash": "sha256-oc6E6ByIw3oJaIyc67maaFcnjYOz1mMcOtHxbEf9NwQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3982c9903e93927c2164caa727cd3f6a0e6d14cc",
+        "rev": "bee6a7250dd1b01844a2de7e02e4df7d8a0a206c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
     utils.lib.eachDefaultSystem (system:
       let pkgs = nixpkgs.legacyPackages."${system}";
       in {
-        devShell = pkgs.mkShell {
+        devShells.default = pkgs.mkShell {
           SKIA_NINJA_COMMAND = "${pkgs.ninja}/bin/ninja";
           SKIA_GN_COMMAND = "${pkgs.gn}/bin/gn";
           LIBCLANG_PATH = "${pkgs.llvmPackages.libclang}/lib/libclang.so";
@@ -19,10 +19,24 @@
           shellHook = ''
             export CC="${pkgs.clang}/bin/clang"
             export CXX="${pkgs.clang}/bin/clang++"
+            export LIBCLANG_PATH="${pkgs.libclang.lib}/lib"
             rustup override set stable
             '';
 
-          nativeBuildInputs = with pkgs; [ rustup python fontconfig clang ];
+          nativeBuildInputs = with pkgs; [ 
+            clang
+            fontconfig
+            libiconv
+            python
+            rustup
+          ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+            AppKit
+            ApplicationServices
+            CoreVideo
+            fixDarwinDylibNames
+            OpenGL
+            Security
+          ]);
         };
       });
 }


### PR DESCRIPTION
Allows for the project to be built on apple m1 machines using nixpkgs.  
Also bumps the versions in `flake.lock` and makes some minor changes to the names used in the flake since the naming conventions changed.

I have also taken the liberty of sorting the packages alphabetically as it makes it a little easier to find a specific package when the list gets too long.