### PR TITLE
Support cross-compilation for Windows arm64

### DIFF
--- a/skia-bindings/build_support/cargo.rs
+++ b/skia-bindings/build_support/cargo.rs
@@ -114,7 +114,9 @@ pub fn target() -> Target {
 }
 
 pub fn target_crt_static() -> bool {
-    cfg!(target_feature = "crt-static")
+    env::var("CARGO_CFG_TARGET_FEATURE")
+        .map(|features| features.contains("crt-static"))
+        .unwrap_or(false)
 }
 
 pub fn host() -> Target {

--- a/skia-bindings/build_support/skia/config.rs
+++ b/skia-bindings/build_support/skia/config.rs
@@ -202,7 +202,7 @@ impl FinalBuildConfiguration {
                             "Unable to locate LLVM installation. skia-bindings can not be built."
                         );
                     }
-					args.push(("target_cpu", quote(clang::target_arch(arch))));
+                    args.push(("target_cpu", quote(clang::target_arch(arch))));
                 }
                 (arch, "linux", "android", _) | (arch, "linux", "androideabi", _) => {
                     args.push(("ndk", quote(&android::ndk())));

--- a/skia-bindings/build_support/skia/config.rs
+++ b/skia-bindings/build_support/skia/config.rs
@@ -202,7 +202,13 @@ impl FinalBuildConfiguration {
                             "Unable to locate LLVM installation. skia-bindings can not be built."
                         );
                     }
-                    args.push(("target_cpu", quote(clang::target_arch(arch))));
+                    // Setting `target_cpu` to `i686` or `x86`, nightly builds would lead to
+                    // > 'C:/Program' is not recognized as an internal or external command
+                    // Without it, the executables pop out just fine. See the GH job
+                    // `supplemental-builds/windows-x86`.
+                    if arch != "i686" {
+                        args.push(("target_cpu", quote(clang::target_arch(arch))));
+                    }
                 }
                 (arch, "linux", "android", _) | (arch, "linux", "androideabi", _) => {
                     args.push(("ndk", quote(&android::ndk())));

--- a/skia-bindings/build_support/skia/config.rs
+++ b/skia-bindings/build_support/skia/config.rs
@@ -177,7 +177,7 @@ impl FinalBuildConfiguration {
             }
 
             match target.as_strs() {
-                (_, _, "windows", Some("msvc")) if build.on_windows => {
+                (arch, _, "windows", Some("msvc")) if build.on_windows => {
                     if let Some(win_vc) = vs::resolve_win_vc() {
                         args.push(("win_vc", quote(win_vc.to_str().unwrap())))
                     }
@@ -202,6 +202,7 @@ impl FinalBuildConfiguration {
                             "Unable to locate LLVM installation. skia-bindings can not be built."
                         );
                     }
+					args.push(("target_cpu", quote(clang::target_arch(arch))));
                 }
                 (arch, "linux", "android", _) | (arch, "linux", "androideabi", _) => {
                     args.push(("ndk", quote(&android::ndk())));


### PR DESCRIPTION
This pull request adds support for cross-compilation of `rust-skia` for `--target aarch64-pc-windows-msvc` with `crt-static`.

- When cross-compiling on Windows, `cfg!(target_feature = "crt-static")` always returns `false` even though `CARGO_CFG_TARGET_FEATURE` contains `crt-static` feature. 
- `target_cpu` should be specified similarly to linux and mac.