### PR TITLE
Add support for building against a Yocto SDK

### DIFF
--- a/skia-bindings/README.md
+++ b/skia-bindings/README.md
@@ -84,6 +84,6 @@ It's possible to cross compile Skia and the Rust bindings for different architec
 
  For linking your Rust application, you may also need to instruct cargo to use the correct linker and look for native library dependencies (such as Skia's FreeType dependency) in the sysroot. This can for be done via a `.cargo/config` file or via environment variables. For example if your Rust target platform is `aarch64-unknown-linux-gnu` and you're Yocto SDK's target is `aarch64-poky-linux`:
 
- * `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=$SDKTARGETSYSROOT/usr/bin/aarch64-poky-linux/aarch64-poky-linux-g++`
+ * `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-poky-linux-g++`
  * `RUSTFLAGS="-Clink-args=--sysroot=$SDKTARGETSYSROOT"`
 

--- a/skia-bindings/README.md
+++ b/skia-bindings/README.md
@@ -68,3 +68,22 @@ This struct represents the top level build configuration for `skia-bindings` and
 
 The `FinalBuildConfiguration` is created from the `BuildConfiguration` and contains name value pairs used by GN to parameterize the Skia build and preprocessor defines used to create the `src/bindings.rs` file and the `skia-bindings` library.
 
+## Cross Compiling for Linux
+
+It's possible to cross compile Skia and the Rust bindings for different architectures on Linux. Set the following environment variables and then invoke cargo with the desired [--target triple](https://doc.rust-lang.org/cargo/commands/cargo-build.html#compilation-options):
+
+ * `CLANGCC`: Command line to invoke clang to cross-compile C code for the desired target architecure. This command line may include a `--target=<triple>` option.
+ * `CLANGCXX`: Command line to invoke clang to cross-compile C++ code for the desired target architecure. This command line may include a `--target=<triple>` option.
+ * `SDKTARGETSYSROOT`: Path to the target sysroot.
+ * Either:
+   * `CC`/`CXX` providing command lines to cross-compile (clang is not required) and `HOST_CC` providing a command line for build for the host.
+   * `CC_<target>`/`CXX_<target>` providing command lines to cross-compile (clang is not required).
+
+ When using a Yocto SDK for cross-compiling, all of the above environment variables will be set when entering the Yocto SDK environment by sourcing the `environment-setup-*` script,
+ and `CC`/`CXX` are set to cross-compile. That means it is also necessary to set `HOST_CC`, which usually works when set to just `gcc`.
+
+ For linking your Rust application, you may also need to instruct cargo to use the correct linker and look for native library dependencies (such as Skia's FreeType dependency) in the sysroot. This can for be done via a `.cargo/config` file or via environment variables. For example if your Rust target platform is `aarch64-unknown-linux-gnu` and you're Yocto SDK's target is `aarch64-poky-linux`:
+
+ * `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=$SDKTARGETSYSROOT/usr/bin/aarch64-poky-linux/aarch64-poky-linux-g++`
+ * `RUSTFLAGS="-Clink-args=--sysroot=$SDKTARGETSYSROOT"`
+

--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -32,7 +32,7 @@ fn build_from_source(
     skia_source_dir: &std::path::Path,
     skia_debug: bool,
     offline: bool,
-) -> Option<Target> {
+) -> Target {
     let build_config = skia::BuildConfiguration::from_features(features, skia_debug);
     let final_configuration = skia::FinalBuildConfiguration::from_build_configuration(
         &build_config,
@@ -56,7 +56,7 @@ fn generate_bindings(
     definitions: Vec<skia_bindgen::Definition>,
     binaries_config: &binaries_config::BinariesConfiguration,
     skia_source_dir: &std::path::Path,
-    target: Option<Target>,
+    target: Target,
 ) {
     // Emit the ninja definitions, to help debug build consistency.
     skia_bindgen::definitions::save_definitions(&definitions, &binaries_config.output_directory)
@@ -95,7 +95,13 @@ fn main() {
             binaries_config.import(&search_path, false).unwrap();
 
             let definitions = skia_bindgen::definitions::from_env();
-            generate_bindings(&features, definitions, &binaries_config, &source_dir, None);
+            generate_bindings(
+                &features,
+                definitions,
+                &binaries_config,
+                &source_dir,
+                cargo::target(),
+            );
         } else {
             println!("STARTING OFFLINE BUILD");
 

--- a/skia-bindings/build_support/cargo.rs
+++ b/skia-bindings/build_support/cargo.rs
@@ -59,7 +59,7 @@ pub fn add_link_search(dir: impl AsRef<str>) {
     println!("cargo:rustc-link-search={}", dir.as_ref());
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Target {
     pub architecture: String,
     pub vendor: String,
@@ -125,7 +125,7 @@ pub fn host() -> Target {
     parse_target(host_str)
 }
 
-fn parse_target(target_str: impl AsRef<str>) -> Target {
+pub fn parse_target(target_str: impl AsRef<str>) -> Target {
     let target_str = target_str.as_ref();
     let target: Vec<String> = target_str.split('-').map(|s| s.into()).collect();
     assert!(target.len() >= 3, "Failed to parse TARGET {}", target_str);

--- a/skia-bindings/build_support/skia/config.rs
+++ b/skia-bindings/build_support/skia/config.rs
@@ -173,6 +173,8 @@ impl FinalBuildConfiguration {
             let mut cflags: Vec<String> = Vec::new();
             let mut asmflags: Vec<String> = Vec::new();
 
+            // SDKROOT is the environment variable used on macOS to specify the sysroot. SDKTARGETSYSROOT is the environment
+            // variable set in Yocto Linux SDKs when cross-compiling.
             if let Some(sysroot) =
                 cargo::env_var("SDKTARGETSYSROOT").or_else(|| cargo::env_var("SDKROOT"))
             {

--- a/skia-bindings/build_support/skia/config.rs
+++ b/skia-bindings/build_support/skia/config.rs
@@ -55,7 +55,7 @@ impl BuildConfiguration {
                 let target_str = target_tail
                     .split_once(' ')
                     .map_or(target_tail, |(target_str, ..)| target_str);
-                crate::build_support::cargo::parse_target(target_str)
+                cargo::parse_target(target_str)
             })
             .unwrap_or_else(cargo::target);
 

--- a/skia-bindings/build_support/skia/config.rs
+++ b/skia-bindings/build_support/skia/config.rs
@@ -36,6 +36,8 @@ pub struct BuildConfiguration {
 /// Builds a Skia configuration from a Features set.
 impl BuildConfiguration {
     pub fn from_features(features: features::Features, skia_debug: bool) -> Self {
+        // Yocto SDKs set CLANGCC/CLANGCXX, which is a better choice to determine clang,
+        // as CC/CXX are likely referring to gcc.
         let cc = cargo::env_var("CLANGCC")
             .or_else(|| cargo::env_var("CC"))
             .unwrap_or_else(|| "clang".to_string());

--- a/skia-bindings/build_support/skia/config.rs
+++ b/skia-bindings/build_support/skia/config.rs
@@ -39,6 +39,10 @@ impl BuildConfiguration {
         let cc = cargo::env_var("CLANGCC")
             .or_else(|| cargo::env_var("CC"))
             .unwrap_or_else(|| "clang".to_string());
+        let cxx = cargo::env_var("CLANGCXX")
+            .or_else(|| cargo::env_var("CXX"))
+            .unwrap_or_else(|| "clang++".to_string());
+
         let target = cc.find("--target=").and_then(|target_option_offset| {
             cc[(target_option_offset + "--target=".len())..]
                 .split_once(' ')
@@ -52,9 +56,7 @@ impl BuildConfiguration {
             features,
             skia_debug,
             cc,
-            cxx: cargo::env_var("CLANGCXX")
-                .or_else(|| cargo::env_var("CXX"))
-                .unwrap_or_else(|| "clang++".to_string()),
+            cxx,
             target,
         }
     }

--- a/skia-bindings/build_support/skia_bindgen.rs
+++ b/skia-bindings/build_support/skia_bindgen.rs
@@ -63,7 +63,12 @@ impl FinalBuildConfiguration {
     }
 }
 
-pub fn generate_bindings(build: &FinalBuildConfiguration, output_directory: &Path, target: Target) {
+pub fn generate_bindings(
+    build: &FinalBuildConfiguration,
+    output_directory: &Path,
+    target: Target,
+    sysroot: Option<&str>,
+) {
     let mut builder = bindgen::Builder::default()
         .generate_comments(false)
         .layout_tests(true)
@@ -206,10 +211,7 @@ pub fn generate_bindings(build: &FinalBuildConfiguration, output_directory: &Pat
     builder = builder.clang_arg(format!("--target={}", target_str));
 
     let sdk;
-    // SDKROOT is the environment variable used on macOS to specify the sysroot. SDKTARGETSYSROOT is the environment
-    // variable set in Yocto Linux SDKs when cross-compiling.
-    let sysroot = cargo::env_var("SDKTARGETSYSROOT").or_else(|| cargo::env_var("SDKROOT"));
-    let mut sysroot: Option<&str> = sysroot.as_ref().map(AsRef::as_ref);
+    let mut sysroot = sysroot;
     let mut sysroot_flag = "--sysroot=";
 
     match target.as_strs() {

--- a/skia-bindings/build_support/skia_bindgen.rs
+++ b/skia-bindings/build_support/skia_bindgen.rs
@@ -1,6 +1,6 @@
 //! Full build support for the SkiaBindings library, and bindings.rs file.
 
-use crate::build_support::{android, binaries_config, cargo, features, ios, xcode};
+use crate::build_support::{android, binaries_config, cargo, cargo::Target, features, ios, xcode};
 use bindgen::{CodegenConfig, EnumVariation, RustTarget};
 use cc::Build;
 use std::path::{Path, PathBuf};
@@ -63,11 +63,7 @@ impl FinalBuildConfiguration {
     }
 }
 
-pub fn generate_bindings(
-    build: &FinalBuildConfiguration,
-    output_directory: &Path,
-    target: Option<Target>,
-) {
+pub fn generate_bindings(build: &FinalBuildConfiguration, output_directory: &Path, target: Target) {
     let mut builder = bindgen::Builder::default()
         .generate_comments(false)
         .layout_tests(true)
@@ -130,8 +126,6 @@ pub fn generate_bindings(
         .clang_arg("-std=c++17")
         .clang_args(&["-x", "c++"])
         .clang_arg("-v");
-
-    let target = target.unwrap_or_else(cargo::target);
 
     // Don't generate destructors for Windows targets: https://github.com/rust-skia/rust-skia/issues/318
     if target.is_windows() {
@@ -717,8 +711,6 @@ pub(crate) mod rewrite {
 }
 
 pub use definitions::{Definition, Definitions};
-
-use super::cargo::Target;
 
 pub(crate) mod definitions {
     use super::env;

--- a/skia-bindings/build_support/skia_bindgen.rs
+++ b/skia-bindings/build_support/skia_bindgen.rs
@@ -206,6 +206,8 @@ pub fn generate_bindings(build: &FinalBuildConfiguration, output_directory: &Pat
     builder = builder.clang_arg(format!("--target={}", target_str));
 
     let sdk;
+    // SDKROOT is the environment variable used on macOS to specify the sysroot. SDKTARGETSYSROOT is the environment
+    // variable set in Yocto Linux SDKs when cross-compiling.
     let sysroot = cargo::env_var("SDKTARGETSYSROOT").or_else(|| cargo::env_var("SDKROOT"));
     let mut sysroot: Option<&str> = sysroot.as_ref().map(AsRef::as_ref);
     let mut sysroot_flag = "--sysroot=";


### PR DESCRIPTION
In a Yocto SDK environment the following relevant environment variables
are set:

 - SDKTARGETSYSROOT: points to the target sysroot.
 - CLANGCC/CLANGCXX: the command line to use for cross-compiling with
   clang to the target.
 - CC/CXX: the gcc command line for cross-compiling.

This patch introduces a dependency to these two variables, as preferred
sysroot and clang choices after the macOS specific SDKROOT and CC/CXX.

Another aspect to the Yocto build is that the target name diverges from
cargo.  For example what's aarch64-unknown-linux-gnu with cargo might be
aarch64-poky-linux (vendor set, no abi specified).

On a clang level this is dealt with by CLANGCC/CLANGCXX including
--target=aarch64-poky-linux for example.

Unfortunately the Skia build also adds --target to the command line,
based on Cargo's target. In the final command line when compiling Skia,
compiling bindings.cpp or generating the bindings, clang's attempt at
locating the correct gcc installation for libstdc++ headers fails,
because --target=aarch64-unknown-linux-gnu does not match the
compiled-in paths that clang would look for if the target was
aarch64-poky-linux (as per original command line).

In order to fix that, this patch also extracts any existing
--target=$foo from the build configuration and uses it throughout in
favor of cargo::target() if provided.