### PR TITLE
Comment converter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ members = [
     "skia-bindings",
     "skia-safe",
     "skia-org",
-    "mk-workflows"
+    "mk-workflows",
+    "comment-converter"
 ]
 
 [profile.release]

--- a/comment-converter/Cargo.toml
+++ b/comment-converter/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "comment-converter"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0.61"
+heck = "0.4.0"
+rstest = "0.15.0"
+

--- a/comment-converter/src/main.rs
+++ b/comment-converter/src/main.rs
@@ -131,9 +131,9 @@ fn process_tokens(tokens: &[Token]) -> String {
 fn consume_tokens(tokens: &[RefToken]) -> (usize, String) {
     use RefToken::*;
     match tokens {
-        [Word("@param"), Whitespace(" "), Word(name), ..] => {
+        [Word("@param"), Whitespace(" "), Word(name), Whitespace(_), ..] => {
             let param = name.to_snake_case();
-            (3, format!("- `{param}` "))
+            (4, format!("* `{param}` - "))
         }
         [Word("@note"), Whitespace(" "), ..] => (2, "Note: ".into()),
         [Word("@return"), Whitespace(_), Word(_), ..] => (2, "Returns: ".into()),

--- a/comment-converter/src/main.rs
+++ b/comment-converter/src/main.rs
@@ -365,7 +365,7 @@ fn tokenize(source: &str) -> Vec<Token> {
     let mut str = String::new();
     let mut r = Vec::new();
 
-    for (_, c) in source.chars().enumerate() {
+    for c in source.chars() {
         let token_class = TokenClass::classify(c);
         if current != Some(token_class) {
             if let Some(current) = current {

--- a/comment-converter/src/main.rs
+++ b/comment-converter/src/main.rs
@@ -132,7 +132,10 @@ fn process_tokens(tokens: &[Token]) -> String {
 fn consume_tokens(tokens: &[RefToken]) -> (usize, String) {
     use RefToken::*;
     match tokens {
-        [Word("@param"), Whitespace(" "), Word(name), ..] => (3, format!("- `{name}` ")),
+        [Word("@param"), Whitespace(" "), Word(name), ..] => {
+            let param = name.to_snake_case();
+            (3, format!("- `{param}` "))
+        }
         [Word("@return"), Whitespace(_), Word(_), ..] => (2, "Returns: ".into()),
         [Word(word), ..] => {
             if let Some(sk_ref) = sk_reference(word) {

--- a/comment-converter/src/main.rs
+++ b/comment-converter/src/main.rs
@@ -178,10 +178,12 @@ fn consume_until_ws(tokens: &[RefToken]) -> (usize, String) {
 }
 
 fn sk_reference(word: &str) -> Option<&str> {
-    if word == "Skia" {
-        return None;
+    if let Some(stripped) = word.strip_prefix("Sk") {
+        if stripped.to_upper_camel_case() == stripped {
+            return Some(stripped);
+        }
     }
-    word.strip_prefix("Sk")
+    None
 }
 
 fn k_case_ty(word: &str) -> Option<String> {

--- a/comment-converter/src/main.rs
+++ b/comment-converter/src/main.rs
@@ -136,7 +136,21 @@ fn consume_tokens(tokens: &[RefToken]) -> (usize, String) {
             let param = name.to_snake_case();
             (3, format!("- `{param}` "))
         }
+        [Word("@note"), Whitespace(" "), ..] => (2, "Note: ".into()),
         [Word("@return"), Whitespace(_), Word(_), ..] => (2, "Returns: ".into()),
+        [Word(word), Separator("()"), ..] => {
+            // Looks like a function reference.
+            if let Some(sk_ref) = sk_reference(word) {
+                let reference = convert_reference(sk_ref);
+                return (2, format!("[`{reference}()`]"));
+            }
+            if let Some(gr_ref) = gr_reference(word) {
+                let reference = convert_reference(gr_ref);
+                return (2, format!("[`{reference}()`]"));
+            }
+            let function_name = word.to_snake_case();
+            (2, format!("`{function_name}()`"))
+        }
         [Word(word), ..] => {
             if let Some(sk_ref) = sk_reference(word) {
                 let reference = convert_reference(sk_ref);

--- a/comment-converter/src/main.rs
+++ b/comment-converter/src/main.rs
@@ -138,19 +138,12 @@ fn consume_tokens(tokens: &[RefToken]) -> (usize, String) {
         }
         [Word("@note"), Whitespace(" "), ..] => (2, "Note: ".into()),
         [Word("@return"), Whitespace(_), Word(_), ..] => (2, "Returns: ".into()),
-        [Word(word), Separator("()"), ..] => {
-            // Looks like a function reference.
-            if let Some(sk_ref) = sk_reference(word) {
-                let reference = convert_reference(sk_ref);
-                return (2, format!("[`{reference}()`]"));
-            }
-            if let Some(gr_ref) = gr_reference(word) {
-                let reference = convert_reference(gr_ref);
-                return (2, format!("[`{reference}()`]"));
-            }
-            let function_name = word.to_snake_case();
-            (2, format!("`{function_name}()`"))
+
+        [Word(word_a), Separator("."), Word(word_b), Separator("()"), ..] => {
+            // Function reference with a dot.
+            process_function(4, &format!("{word_a}.{word_b}"))
         }
+        [Word(word), Separator("()"), ..] => process_function(2, word),
         [Word(word), ..] => {
             if let Some(sk_ref) = sk_reference(word) {
                 let reference = convert_reference(sk_ref);
@@ -183,6 +176,20 @@ fn consume_tokens(tokens: &[RefToken]) -> (usize, String) {
         [Separator(sep), ..] => (1, sep.to_string()),
         [] => panic!("Internal error"),
     }
+}
+
+fn process_function(consumed: usize, word: &str) -> (usize, String) {
+    // Looks like a function reference.
+    if let Some(sk_ref) = sk_reference(word) {
+        let reference = convert_reference(sk_ref);
+        return (consumed, format!("[`{reference}()`]"));
+    }
+    if let Some(gr_ref) = gr_reference(word) {
+        let reference = convert_reference(gr_ref);
+        return (consumed, format!("[`{reference}()`]"));
+    }
+    let function_name = word.to_snake_case();
+    (consumed, format!("`{function_name}()`"))
 }
 
 fn consume_until_ws(tokens: &[RefToken]) -> (usize, String) {

--- a/comment-converter/src/main.rs
+++ b/comment-converter/src/main.rs
@@ -140,8 +140,8 @@ fn consume_tokens(tokens: &[RefToken]) -> (usize, String) {
             if *word == "true" || *word == "false" {
                 return (1, format!("`{word}`"));
             }
-            if let Some(new_name) = is_c_function(word) {
-                return (1, format!("`{new_name}`"));
+            if let Some(new_function_name) = convert_c_function(word) {
+                return (1, format!("`{new_function_name}`"));
             }
             (1, word.to_string())
         }
@@ -151,7 +151,7 @@ fn consume_tokens(tokens: &[RefToken]) -> (usize, String) {
     }
 }
 
-fn is_c_function(word: &str) -> Option<String> {
+fn convert_c_function(word: &str) -> Option<String> {
     if let Some(fn_name) = word.strip_suffix("()") {
         if fn_name.to_lower_camel_case() == fn_name {
             return Some(fn_name.to_snake_case() + "()");

--- a/comment-converter/src/main.rs
+++ b/comment-converter/src/main.rs
@@ -232,11 +232,9 @@ fn is_multi_word_identifier(word: &str) -> bool {
     if !word.chars().next().unwrap().is_lowercase() {
         return false;
     }
-
     if !word.chars().skip(1).any(|c| c.is_uppercase()) {
         return false;
     }
-
     true
 }
 

--- a/comment-converter/src/main.rs
+++ b/comment-converter/src/main.rs
@@ -41,9 +41,13 @@ fn comment(str: &str) -> String {
         let is_last = i == lines.len() - 1;
 
         let line = &mut lines[i];
-        let convert = !((is_last && line.trim().is_empty()) || line.starts_with("/// "));
+        let convert = !((is_last && line.trim().is_empty()) || line.starts_with("///"));
         if convert {
-            *line = format!("/// {line}");
+            *line = if line.trim().is_empty() {
+                "///".into()
+            } else {
+                format!("/// {line}")
+            }
         }
     }
 

--- a/comment-converter/src/main.rs
+++ b/comment-converter/src/main.rs
@@ -136,7 +136,11 @@ fn consume_tokens(tokens: &[RefToken]) -> (usize, String) {
         [Word("@return"), Whitespace(_), Word(_), ..] => (2, "Returns: ".into()),
         [Word(word), ..] => {
             if let Some(sk_ref) = sk_reference(word) {
-                let reference = convert_sk_reference(sk_ref);
+                let reference = convert_reference(sk_ref);
+                return (1, format!("[`{reference}`]"));
+            }
+            if let Some(gr_ref) = gr_reference(word) {
+                let reference = convert_reference(gr_ref);
                 return (1, format!("[`{reference}`]"));
             }
             if let Some(k_case_ty) = k_case_ty(word) {
@@ -179,7 +183,16 @@ fn consume_until_ws(tokens: &[RefToken]) -> (usize, String) {
 
 fn sk_reference(word: &str) -> Option<&str> {
     if let Some(stripped) = word.strip_prefix("Sk") {
-        if stripped.to_upper_camel_case() == stripped {
+        if !stripped.is_empty() && stripped.chars().next().unwrap().is_uppercase() {
+            return Some(stripped);
+        }
+    }
+    None
+}
+
+fn gr_reference(word: &str) -> Option<&str> {
+    if let Some(stripped) = word.strip_prefix("Gr") {
+        if !stripped.is_empty() && stripped.chars().next().unwrap().is_uppercase() {
             return Some(stripped);
         }
     }
@@ -211,7 +224,7 @@ fn convert_c_function(word: &str) -> Option<String> {
 }
 
 /// Converts references like `Path::updateBoundsCache` or `Path::Verb`.
-fn convert_sk_reference(reference: &str) -> String {
+fn convert_reference(reference: &str) -> String {
     if let Some((type_name, sub_name)) = reference.split_once("::") {
         // Nested type: like Path::Verb -> path::Verb.
         if sub_name.to_upper_camel_case() == sub_name {

--- a/comment-converter/src/main.rs
+++ b/comment-converter/src/main.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use heck::{ToLowerCamelCase, ToSnakeCase, ToUpperCamelCase};
 use std::{
-    fmt,
     io::{self, Read, Write},
     str,
 };
@@ -239,15 +238,6 @@ fn k_case_ty(word: &str) -> Option<String> {
     None
 }
 
-// fn convert_c_function(word: &str) -> Option<String> {
-//     if let Some(fn_name) = word.strip_suffix("()") {
-//         if fn_name.to_lower_camel_case() == fn_name {
-//             return Some(fn_name.to_snake_case() + "()");
-//         }
-//     }
-//     None
-// }
-
 fn is_multi_word_identifier(word: &str) -> bool {
     assert!(!word.is_empty());
     if !word.chars().all(|c| c.is_alphanumeric()) {
@@ -307,18 +297,6 @@ enum RefToken<'a> {
     Word(&'a str),
     Whitespace(&'a str),
     Separator(&'a str),
-}
-
-impl fmt::Display for RefToken<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use RefToken::*;
-        let str = match self {
-            Word(w) => w,
-            Whitespace(ws) => ws,
-            Separator(sep) => sep,
-        };
-        f.write_str(str)
-    }
 }
 
 impl RefToken<'_> {

--- a/comment-converter/src/main.rs
+++ b/comment-converter/src/main.rs
@@ -1,0 +1,253 @@
+use anyhow::Result;
+use heck::{ToLowerCamelCase, ToSnakeCase};
+use std::{
+    io::{self, Read, Write},
+    str,
+};
+
+fn main() -> Result<()> {
+    let mut stdin = io::stdin();
+    let mut buf = String::new();
+    stdin.read_to_string(&mut buf)?;
+    let result = convert(&buf);
+    io::stdout().write_all(result.as_bytes())?;
+    Ok(())
+}
+
+fn convert(source: &str) -> String {
+    let line_trimmed = remove_lines(source, remove_line);
+    let line_trimmed = {
+        let mut lines: Vec<_> = lines(&line_trimmed)
+            .into_iter()
+            .map(|l| l.to_string())
+            .collect();
+        if !lines.is_empty() {
+            lines[0] = first_line_converter(lines[0].as_str());
+        }
+        lines.join("\n")
+    };
+    let trimmed = trim_common_indent(&line_trimmed, |b| b == b' ');
+    let trimmed = trim_common_indent(&trimmed, |b| b == b'*');
+    let trimmed = trim_common_indent(&trimmed, |b| b == b' ');
+    let tokens = tokenize(&trimmed);
+    let processed = process_tokens(&tokens);
+    comment(&processed)
+}
+
+fn comment(str: &str) -> String {
+    let mut lines: Vec<_> = lines(str).into_iter().map(|l| l.to_string()).collect();
+
+    for i in 0..lines.len() {
+        let is_last = i == lines.len() - 1;
+
+        let line = &mut lines[i];
+        let convert = !((is_last && line.trim().is_empty()) || line.starts_with("/// "));
+        if convert {
+            *line = format!("/// {line}");
+        }
+    }
+
+    lines.join("\n")
+}
+
+fn remove_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed == "/**" || trimmed == "*/" ||
+    // like `/** \class SkPath`
+    trimmed.starts_with("/** \\")
+}
+
+/// Trims the common indent of all lines.
+fn trim_common_indent(source: &str, is_indent: impl Fn(u8) -> bool) -> String {
+    let min_indent = source
+        .lines()
+        .filter_map(|line| indent_size(line, &is_indent))
+        .min()
+        .unwrap_or_default();
+
+    let lines: Vec<String> = lines(source)
+        .into_iter()
+        .map(|str| {
+            String::from_utf8(str.bytes().skip(min_indent).collect::<Vec<u8>>())
+                .expect("Internal Error, UTF8 conversion failed")
+        })
+        .collect();
+    lines.join("\n")
+}
+
+/// Symmetric line splitting.
+fn lines(all: &str) -> Vec<&str> {
+    let mut r: Vec<_> = all.lines().collect();
+    if all.ends_with('\n') {
+        r.push("");
+    }
+    r
+}
+
+/// This replaces a `/** ` by spaces when it appears in the first line after an optional indent.
+fn first_line_converter(first_line: &str) -> String {
+    let indent_size = indent_size(first_line, |b| b == b' ').unwrap_or_default();
+    if first_line[indent_size..].starts_with("/** ") {
+        let indent = &first_line[0..indent_size];
+        let rest = &first_line[indent_size + 4..];
+        return format!("{indent}    {rest}");
+    }
+
+    first_line.to_string()
+}
+
+fn remove_lines(source: &str, remove_if: impl Fn(&str) -> bool) -> String {
+    let lines: Vec<String> = lines(source)
+        .into_iter()
+        .filter_map(|line| {
+            if remove_if(line) {
+                None
+            } else {
+                Some(line.to_string())
+            }
+        })
+        .collect();
+    lines.join("\n")
+}
+
+fn process_tokens(tokens: &[Token]) -> String {
+    let mut r = String::new();
+    let mut current = 0;
+    let tokens: Vec<_> = tokens.iter().map(|t| t.as_ref()).collect();
+
+    while current != tokens.len() {
+        let (consumed, str) = consume_tokens(&tokens[current..]);
+        current += consumed;
+        assert!(current <= tokens.len());
+        r += &str;
+    }
+    r
+}
+
+fn consume_tokens(tokens: &[RefToken]) -> (usize, String) {
+    use RefToken::*;
+    match tokens {
+        [Word("@param"), Whitespace(" "), Word(name), ..] => (3, format!("- `{name}` ")),
+        [Word("@return"), Whitespace(_), Word(_), ..] => (2, "Returns: ".into()),
+        [Word(word), ..] => {
+            if let Some(reference) = word.strip_prefix("Sk") {
+                let reference = convert_reference(reference);
+                return (1, format!("[`{reference}`]"));
+            }
+            if word.starts_with("https://") {
+                return (1, format!("<{word}>"));
+            }
+            if *word == "true" || *word == "false" {
+                return (1, format!("`{word}`"));
+            }
+            if let Some(new_name) = is_c_function(word) {
+                return (1, format!("`{new_name}`"));
+            }
+            (1, word.to_string())
+        }
+        [Whitespace(ws), ..] => (1, ws.to_string()),
+        [] => panic!("Internal error"),
+    }
+}
+
+fn is_c_function(word: &str) -> Option<String> {
+    if let Some(fn_name) = word.strip_suffix("()") {
+        if fn_name.to_lower_camel_case() == fn_name {
+            return Some(fn_name.to_snake_case() + "()");
+        }
+    }
+    None
+}
+
+/// Converts references like `Path::updateBoundsCache` to snake case function names.
+fn convert_reference(reference: &str) -> String {
+    match reference.split_once("::") {
+        Some((type_name, fun_name)) => {
+            let fun_name = fun_name.to_snake_case();
+            format!("{type_name}::{fun_name}")
+        }
+        None => reference.into(),
+    }
+}
+
+fn indent_size(source: &str, is_indent: impl Fn(u8) -> bool) -> Option<usize> {
+    source.bytes().position(|b| !is_indent(b))
+}
+
+enum Token {
+    Word(String),
+    Whitespace(String),
+}
+
+impl Token {
+    pub fn as_ref(&self) -> RefToken {
+        match self {
+            Token::Word(w) => RefToken::Word(w),
+            Token::Whitespace(ws) => RefToken::Whitespace(ws),
+        }
+    }
+}
+
+enum RefToken<'a> {
+    Word(&'a str),
+    Whitespace(&'a str),
+}
+
+fn tokenize(source: &str) -> Vec<Token> {
+    use Token::*;
+    let mut current = None;
+    let mut r = Vec::new();
+
+    for c in source.chars() {
+        match current {
+            None => {
+                if c.is_whitespace() {
+                    current = Some(Whitespace(c.into()))
+                } else {
+                    current = Some(Word(c.into()))
+                }
+            }
+            Some(Word(ref mut str)) => {
+                if !c.is_whitespace() {
+                    str.push(c);
+                } else {
+                    r.push(current.take().unwrap());
+                    current = Some(Whitespace(c.into()))
+                }
+            }
+            Some(Whitespace(ref mut str)) => {
+                if c.is_whitespace() {
+                    str.push(c);
+                } else {
+                    r.push(current.take().unwrap());
+                    current = Some(Word(c.into()))
+                }
+            }
+        }
+    }
+
+    if let Some(last) = current.take() {
+        r.push(last);
+    }
+
+    r
+}
+
+#[cfg(test)]
+mod cfg {
+    use super::lines;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("")]
+    #[case("a")]
+    #[case("a\n")]
+    #[case("a\nb")]
+    #[case("a\nb\n\nc")]
+    #[case("a\nb\n\nc\n")]
+    #[case("a\nb\n\nc\n\n")]
+    pub fn lines_splitting_is_symmetric(#[case] v: &str) {
+        let r = lines(v).join("\n");
+        assert_eq!(v, r)
+    }
+}


### PR DESCRIPTION
This PR adds a executable project named `comment-converter` that helps converting Skia C++ comments to Rust comments. To convert selections directly in VSCode, the extension [FilterText](https://marketplace.visualstudio.com/items?itemName=yhirose.FilterText) can be used.

The comment-converter is not perfect, but does ~90% of the manual conversion that is needed.