### PR TITLE
Milestone 106

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,9 +15,11 @@
         "mios",
         "miphoneos",
         "RGBX",
+        "SDKTARGETSYSROOT",
         "skottie",
         "unoptimized",
         "webgl",
-        "wuffs"
+        "wuffs",
+        "Yocto"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m106 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m106-0.54.1...google:chrome/m106
-[skia-ours]: https://github.com/google/skia/compare/chrome/m106...rust-skia:m106-0.54.1
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m106-0.54.2...google:chrome/m106
+[skia-ours]: https://github.com/google/skia/compare/chrome/m106...rust-skia:m106-0.54.2
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![Windows QA](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml) [![Linux QA](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml) [![macOS QA](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml)
 
-Skia Submodule Status: chrome/m105 ([upstream changes][skia-upstream], [our changes][skia-ours]).
+Skia Submodule Status: chrome/m106 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m105-0.53.3...google:chrome/m105
-[skia-ours]: https://github.com/google/skia/compare/chrome/m105...rust-skia:m105-0.53.3
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m106-0.54.0...google:chrome/m106
+[skia-ours]: https://github.com/google/skia/compare/chrome/m106...rust-skia:m106-0.54.0
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m106 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m106-0.54.0...google:chrome/m106
-[skia-ours]: https://github.com/google/skia/compare/chrome/m106...rust-skia:m106-0.54.0
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m106-0.54.1...google:chrome/m106
+[skia-ours]: https://github.com/google/skia/compare/chrome/m106...rust-skia:m106-0.54.1
 
 ## Goals
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.54.0"
+version = "0.55.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2021"
 build = "build.rs"

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m106-0.54.1"
+skia = "m106-0.54.2"
 depot_tools = "fade894"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m105-0.53.3"
+skia = "m106-0.54.0"
 depot_tools = "fade894"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -32,7 +32,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m106-0.54.0"
+skia = "m106-0.54.1"
 depot_tools = "fade894"
 
 [features]

--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -54,6 +54,7 @@ fn build_from_source(
 fn generate_bindings(
     features: &features::Features,
     definitions: Vec<skia_bindgen::Definition>,
+    cflags: Vec<String>,
     binaries_config: &binaries_config::BinariesConfiguration,
     skia_source_dir: &std::path::Path,
     target: Target,
@@ -66,6 +67,7 @@ fn generate_bindings(
     let bindings_config = skia_bindgen::FinalBuildConfiguration::from_build_configuration(
         features,
         definitions,
+        cflags,
         skia_source_dir,
     );
     skia_bindgen::generate_bindings(
@@ -100,6 +102,7 @@ fn main() {
             generate_bindings(
                 &features,
                 definitions,
+                Vec::new(),
                 &binaries_config,
                 &source_dir,
                 cargo::target(),
@@ -122,6 +125,7 @@ fn main() {
             generate_bindings(
                 &features,
                 definitions,
+                final_build_configuration.flags,
                 &binaries_config,
                 &source_dir,
                 final_build_configuration.target,
@@ -164,6 +168,7 @@ fn main() {
             generate_bindings(
                 &features,
                 definitions,
+                final_build_configuration.flags,
                 &binaries_config,
                 &source_dir,
                 final_build_configuration.target,

--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -54,7 +54,6 @@ fn build_from_source(
 fn generate_bindings(
     features: &features::Features,
     definitions: Vec<skia_bindgen::Definition>,
-    cflags: Vec<String>,
     binaries_config: &binaries_config::BinariesConfiguration,
     skia_source_dir: &std::path::Path,
     target: Target,
@@ -67,7 +66,6 @@ fn generate_bindings(
     let bindings_config = skia_bindgen::FinalBuildConfiguration::from_build_configuration(
         features,
         definitions,
-        cflags,
         skia_source_dir,
     );
     skia_bindgen::generate_bindings(
@@ -102,7 +100,6 @@ fn main() {
             generate_bindings(
                 &features,
                 definitions,
-                Vec::new(),
                 &binaries_config,
                 &source_dir,
                 cargo::target(),
@@ -125,7 +122,6 @@ fn main() {
             generate_bindings(
                 &features,
                 definitions,
-                final_build_configuration.flags,
                 &binaries_config,
                 &source_dir,
                 final_build_configuration.target,
@@ -168,7 +164,6 @@ fn main() {
             generate_bindings(
                 &features,
                 definitions,
-                final_build_configuration.flags,
                 &binaries_config,
                 &source_dir,
                 final_build_configuration.target,

--- a/skia-bindings/build_support.rs
+++ b/skia-bindings/build_support.rs
@@ -8,6 +8,7 @@ pub mod cargo;
 pub mod clang;
 pub mod features;
 pub mod ios;
+pub mod macos;
 pub mod skia;
 pub mod skia_bindgen;
 pub mod xcode;

--- a/skia-bindings/build_support/macos.rs
+++ b/skia-bindings/build_support/macos.rs
@@ -1,0 +1,17 @@
+/// 6 digit deployment target.
+pub fn deployment_target_6(macosx_deployment_target: &str) -> String {
+    // use remove_matches as soon it's stable.
+    let split: Vec<_> = macosx_deployment_target.split('.').collect();
+    let joined = split.join("");
+    dbg!(format!("{:0<6}", joined))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::deployment_target_6;
+
+    #[test]
+    fn deployment_target_6_digit_conversion() {
+        assert!(deployment_target_6("10.16"), "101600")
+    }
+}

--- a/skia-bindings/build_support/macos.rs
+++ b/skia-bindings/build_support/macos.rs
@@ -1,5 +1,23 @@
+use super::cargo;
+
+pub fn extra_skia_cflags() -> Vec<String> {
+    let deployment_target = cargo::env_var("MACOSX_DEPLOYMENT_TARGET");
+
+    if let Some(deployment_target) = deployment_target {
+        let deployment_target = deployment_target_6(&deployment_target);
+        return vec![format!(
+            "-D__MAC_OS_X_VERSION_MAX_ALLOWED={deployment_target}"
+        )];
+    }
+    Vec::new()
+}
+
+pub fn additional_clang_args() -> Vec<String> {
+    extra_skia_cflags()
+}
+
 /// 6 digit deployment target.
-pub fn deployment_target_6(macosx_deployment_target: &str) -> String {
+fn deployment_target_6(macosx_deployment_target: &str) -> String {
     // use remove_matches as soon it's stable.
     let split: Vec<_> = macosx_deployment_target.split('.').collect();
     let joined = split.join("");

--- a/skia-bindings/build_support/skia_bindgen.rs
+++ b/skia-bindings/build_support/skia_bindgen.rs
@@ -23,12 +23,15 @@ pub struct FinalBuildConfiguration {
 
     /// Further definitions needed for build consistency.
     pub definitions: Definitions,
+
+    pub cflags: Vec<String>,
 }
 
 impl FinalBuildConfiguration {
     pub fn from_build_configuration(
         features: &features::Features,
         definitions: Definitions,
+        cflags: Vec<String>,
         skia_source_dir: &Path,
     ) -> FinalBuildConfiguration {
         let binding_sources = {
@@ -61,6 +64,7 @@ impl FinalBuildConfiguration {
             skia_source_dir: skia_source_dir.into(),
             binding_sources,
             definitions,
+            cflags,
         }
     }
 }
@@ -197,6 +201,11 @@ pub fn generate_bindings(
                 builder = builder.clang_arg(format!("-D{}", name));
             }
         }
+    }
+
+    for flag in &build.cflags {
+        cc_build.flag(flag);
+        builder = builder.clang_arg(flag)
     }
 
     cc_build.cpp(true).out_dir(output_directory);

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1596,6 +1596,10 @@ extern "C" SkColorFilter* C_SkColorFilters_Compose(SkColorFilter* outer, SkColor
     return SkColorFilters::Compose(sp(outer), sp(inner)).release();
 }
 
+extern "C" SkColorFilter* C_SkColorFilters_Blend2(const SkColor4f* c, SkColorSpace* colorSpace, SkBlendMode blendMode) {
+    return SkColorFilters::Blend(*c, sp(colorSpace), blendMode).release();
+}
+
 extern "C" SkColorFilter* C_SkColorFilters_Blend(const SkColor c, SkBlendMode blendMode) {
     return SkColorFilters::Blend(c, blendMode).release();
 }
@@ -2796,24 +2800,10 @@ extern "C" SkTypeface *C_SkCustomTypefaceBuilder_detach(SkCustomTypefaceBuilder 
     return self->detach().release();
 }
 
-/* Th following wrappers may be needed as soon the Skia implementation finds its way into an official release (m84).
 extern "C" void
-C_SkCustomTypefaceBuilder_setGlyph1(SkCustomTypefaceBuilder *self, SkGlyphID glyph, float advance, const SkPath *path,
-                                    const SkPaint *paint) {
-    self->setGlyph(glyph, advance, *path, *paint);
+C_SkCustomTypefaceBuilder_setGlyph(SkCustomTypefaceBuilder *self, SkGlyphID glyph, float advance, SkDrawable* drawable, const SkRect* bounds) {
+    self->setGlyph(glyph, advance, sp(drawable), *bounds);
 }
-
-extern "C" void
-C_SkCustomTypefaceBuilder_setGlyph2(SkCustomTypefaceBuilder *self, SkGlyphID glyph, float advance, SkImage *image,
-                                    float scale) {
-    self->setGlyph(glyph, advance, sp(image), scale);
-}
-
-extern "C" void
-C_SkCustomTypefaceBuilder_setGlyph3(SkCustomTypefaceBuilder *self, SkGlyphID glyph, float advance, SkPicture *picture) {
-    self->setGlyph(glyph, advance, sp(picture));
-}
-*/
 
 extern "C" SkCanvas* C_SkMakeNullCanvas() {
     return SkMakeNullCanvas().release();

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.54.0"
+version = "0.55.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2021"
 
@@ -45,7 +45,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 [dependencies]
 bitflags = "1.2"
 lazy_static = "1.4"
-skia-bindings = { version = "=0.54.0", path = "../skia-bindings", default-features = false }
+skia-bindings = { version = "=0.55.0", path = "../skia-bindings", default-features = false }
 
 # D3D types
 winapi = { version = "0.3.9", features = ["d3d12", "dxgi"], optional = true }

--- a/skia-safe/src/core/milestone.rs
+++ b/skia-safe/src/core/milestone.rs
@@ -1,1 +1,1 @@
-pub const MILESTONE: usize = 105;
+pub const MILESTONE: usize = 106;


### PR DESCRIPTION
This PR updates rust-skia to support Skia's `chrome/m106` branch.

- [x] Update `README.md` ([rendered](https://github.com/pragmatrix/rust-skia/blob/m106/README.md))  
  > Most important here is to change the Skia branch name and the current Skia submodule tag at the top of the `README.md` file.
- [x] Diff the the following files to see if the build organization has changed significantly:
  - [x] `/BUILD.gn`
  - [x] `/modules/skshaper/BUILD.gn`
  - [x] `/modules/paragraph/BUILD.gn`
- [x] Skia builds ([release notes](https://github.com/google/skia/blob/chrome/m106/RELEASE_NOTES.txt)).
- [x] `/skia-bindings` builds.
- [x] `/skia-safe`: Update & add new wrappers by diffing include files.  
  > Add TODOs for everything that can not be updated right now, and attempt to stay compatible with previous versions of skia-safe without trying too hard before version 1.0. Use `deprecated` attributes if needed.
  - [x] `codec/`
  - [x] `core/`
  - [x] `docs/`
  - [x] `effects/`
  - [x] `gpu/`
    - [x] `d3d/`
    - [x] `gl/`
    - [x] `mtl/`
    - [x] `vk/`
  - [x] `modules/`
    - [x] `paragraph/`
    - [x] `shaper/`
  - [x] `pathops/`
  - [x] `svg/`
  - [x] `utils/`
- [x] Review `Send` & `Sync` implementations for new wrappers.
- [x] Review `Debug` implementation for new wrapper types and functions.
- [x] Any pending changes in the Skia `chrome/m106` branch that aren't synchronized yet?
- [x] Rebase on or merge with master.
- [x] Do the `rust-skia:` commits in the `skia-bindings/skia` subdirectory match with `master`.
- [x] Update versions of `skia-bindings/Cargo.toml` and `skia-safe/Cargo.toml` and also add the version to the new `deprecated` attributes.
- [x] Do the tags/hashes in `skia-bindings/Cargo.toml` under `[package.metadata]` match the submodules `depot_tools` and `skia`?
- [ ] Test builds we don't do on the CI:
  - [ ] Compiles to Catalyst targets on macOS (#548).
    ```zsh
    make macos-qa
    ```
- [x] Do one final review of all the changes.
- [x] Run `cargo doc` with all features and fix all warnings.

