### PR TITLE
Add support for precompiled Windows binaries that have D3D, GL and textlayout enabled

### DIFF
--- a/.github/workflows/windows-release.yaml
+++ b/.github/workflows/windows-release.yaml
@@ -929,3 +929,105 @@ jobs:
         artifactErrorsFailBuild: true
         token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
         prerelease: true
+  windows-release-release-d3d-gl-textlayout:
+    runs-on: windows-2022
+    # Containers are not supported on Windows.
+    # container: ghcr.io/pragmatrix/rust-skia-windows:latest
+    env: 
+      SKIA_DEBUG: 0
+    
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    
+    - name: Install Rust
+      uses: hecrj/setup-rust-action@master
+      with:
+        rust-version: stable
+    
+    - name: Install Clippy
+      run: rustup component add clippy
+      shell: bash
+    
+    - name: Python Version
+      run: python --version
+    
+    - name: Install LLVM
+      run: choco install llvm
+    - name: 'Install Rust target x86_64-pc-windows-msvc'
+      shell: bash
+      run: |
+        rustup target add x86_64-pc-windows-msvc
+    
+    - name: 'Build all targets in skia-safe for x86_64-pc-windows-msvc with features d3d,gl,textlayout'
+      shell: bash
+      run: |
+        if [ "false" == "true" ]; then
+          TARGET=x86_64-pc-windows-msvc
+          TARGET=${TARGET//-/_}
+          export CC_${TARGET}=x86_64-pc-windows-msvc26-clang.exe
+          export CXX_${TARGET}=x86_64-pc-windows-msvc26-clang++.exe
+          TARGET_UPPERCASE=`echo "${TARGET}" | tr [a-z] [A-Z]`
+          export CARGO_TARGET_${TARGET_UPPERCASE}_LINKER=x86_64-pc-windows-msvc26-clang.exe
+          echo "Set CC, CXX, and CARGO_LINKER target specific environment variables for Android"
+        fi
+        if [ "false" == "true" ]; then
+          source /emsdk/emsdk_env.sh
+        fi
+        cargo clean
+        cargo build -p skia-safe --all-targets --release --features "d3d,gl,textlayout" --target x86_64-pc-windows-msvc
+        echo "SKIA_BINARIES_TAG=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/tag.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_BINARIES_KEY=$(cat "${BUILD_ARTIFACTSTAGINGDIRECTORY}/skia-binaries/key.txt")" >> ${GITHUB_ENV}
+        echo "SKIA_STAGING_PATH=${BUILD_ARTIFACTSTAGINGDIRECTORY}" >> ${GITHUB_ENV}
+      env:
+        BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ runner.temp }}
+        EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
+    
+    - name: 'Run Clippy'
+      shell: bash
+      if: true
+      run: |
+        cargo clippy --release --features "d3d,gl,textlayout" --all-targets --target x86_64-pc-windows-msvc -- -D warnings
+    
+    - name: 'Test all workspace projects'
+      shell: bash
+      if: true
+      run: |
+        cargo test --all --release --features "d3d,gl,textlayout" --all-targets --target x86_64-pc-windows-msvc -- --nocapture
+      
+    - name: 'Generate skia-org example images'
+      shell: bash
+      if: false
+      run: |
+        cargo run --release --features "d3d,gl,textlayout" --target x86_64-pc-windows-msvc "${{ env.SKIA_STAGING_PATH }}/skia-org" 
+    
+    - name: 'Upload skia-org example images'
+      if: false
+      uses: actions/upload-artifact@v2
+      with:
+        name: skia-org-images-x86_64-pc-windows-msvc
+        path: ${{ env.SKIA_STAGING_PATH }}/skia-org
+    
+    - name: 'Compress binaries'
+      if: true
+      uses: master-atul/tar-action@v1.0.2
+      with:
+        command: c
+        cwd: '${{ env.SKIA_STAGING_PATH }}'
+        files: 'skia-binaries'
+        outPath: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+    
+    - name: 'Release binaries'
+      if: true
+      uses: pragmatrix/release-action@exp
+      with:
+        owner: rust-skia
+        repo: skia-binaries
+        allowUpdates: true
+        replacesArtifacts: true
+        tag: '${{ env.SKIA_BINARIES_TAG }}'
+        artifacts: '${{ runner.temp }}/skia-binaries-${{ env.SKIA_BINARIES_KEY }}.tar.gz'
+        artifactErrorsFailBuild: true
+        token: ${{ secrets.RUST_SKIA_RELEASE_TOKEN }}
+        prerelease: true

--- a/mk-workflows/src/config.rs
+++ b/mk-workflows/src/config.rs
@@ -89,6 +89,7 @@ pub fn release_jobs(workflow: &Workflow) -> Vec<Job> {
         HostOS::Windows => {
             jobs.push(job("release-d3d", "d3d"));
             jobs.push(job("release-d3d-textlayout", "d3d,textlayout"));
+            jobs.push(job("release-d3d-gl-textlayout", "d3d,gl,textlayout"));
         }
         HostOS::Linux => {
             jobs.push(job("release-gl-x11", "gl,x11"));


### PR DESCRIPTION
I know that there are infinite combinations of features :-)

For Slint we use Skia's text layout feature (naturally) and we default to using D3D. We have a use-case where somebody wants to develop an app that embeds some OpenGL code and combine that with the Skia renderer (for good text rendering quality), on Windows and Linux. They are okay with depending on OpenGL drivers on Windows and the Skia GL backend works well already. But the Rust Skia bindings are of course complicated by the fact that for this combination no binaries are available, and especially on Windows the Skia build is ... complicated :-). Hence this attempt at a compromise.

I would've filed this as a "wish list" issue first, but I realise that with your mk-workflows helper this is actually quite easy to do, so I just made a patch. But feel free to close this PR if you disagree with this or if this makes the binaries overall too big.

In case this is okay, then the only part I'm uncertain about is if the order (d3d,gl) is correct or if it should be the other way around, to correctly match what the download will attempt when it constructs the file name/url.