### PR TITLE
Attempt to fix git's new dubious ownership errors

### DIFF
--- a/.github/workflows/linux-qa.yaml
+++ b/.github/workflows/linux-qa.yaml
@@ -23,12 +23,12 @@ jobs:
       SKIA_DEBUG: 0
     
     steps:
-    - name: Attempt to fix git dubious ownership warnings
-      run: git config --global --add safe.directory '*'
-    
     - uses: actions/checkout@v2
       with:
         submodules: true
+    
+    - name: Fix git dubious ownership errors when synchronizing Skia dependencies
+      run: git config --global --add safe.directory '*'
     
     - name: Prepare Rustup
       run: (cd /github/home && ln -s /root/.cargo)
@@ -428,12 +428,12 @@ jobs:
       SKIA_DEBUG: 0
     
     steps:
-    - name: Attempt to fix git dubious ownership warnings
-      run: git config --global --add safe.directory '*'
-    
     - uses: actions/checkout@v2
       with:
         submodules: true
+    
+    - name: Fix git dubious ownership errors when synchronizing Skia dependencies
+      run: git config --global --add safe.directory '*'
     
     - name: Prepare Rustup
       run: (cd /github/home && ln -s /root/.cargo)

--- a/.github/workflows/linux-qa.yaml
+++ b/.github/workflows/linux-qa.yaml
@@ -23,6 +23,9 @@ jobs:
       SKIA_DEBUG: 0
     
     steps:
+    - name: Attempt to fix git dubious ownership warnings
+      run: git config --global --add safe.directory '*'
+    
     - uses: actions/checkout@v2
       with:
         submodules: true
@@ -425,6 +428,9 @@ jobs:
       SKIA_DEBUG: 0
     
     steps:
+    - name: Attempt to fix git dubious ownership warnings
+      run: git config --global --add safe.directory '*'
+    
     - uses: actions/checkout@v2
       with:
         submodules: true

--- a/.github/workflows/linux-release.yaml
+++ b/.github/workflows/linux-release.yaml
@@ -18,12 +18,12 @@ jobs:
       SKIA_DEBUG: 0
     
     steps:
-    - name: Attempt to fix git dubious ownership warnings
-      run: git config --global --add safe.directory '*'
-    
     - uses: actions/checkout@v2
       with:
         submodules: true
+    
+    - name: Fix git dubious ownership errors when synchronizing Skia dependencies
+      run: git config --global --add safe.directory '*'
     
     - name: Prepare Rustup
       run: (cd /github/home && ln -s /root/.cargo)
@@ -423,12 +423,12 @@ jobs:
       SKIA_DEBUG: 0
     
     steps:
-    - name: Attempt to fix git dubious ownership warnings
-      run: git config --global --add safe.directory '*'
-    
     - uses: actions/checkout@v2
       with:
         submodules: true
+    
+    - name: Fix git dubious ownership errors when synchronizing Skia dependencies
+      run: git config --global --add safe.directory '*'
     
     - name: Prepare Rustup
       run: (cd /github/home && ln -s /root/.cargo)
@@ -828,12 +828,12 @@ jobs:
       SKIA_DEBUG: 0
     
     steps:
-    - name: Attempt to fix git dubious ownership warnings
-      run: git config --global --add safe.directory '*'
-    
     - uses: actions/checkout@v2
       with:
         submodules: true
+    
+    - name: Fix git dubious ownership errors when synchronizing Skia dependencies
+      run: git config --global --add safe.directory '*'
     
     - name: Prepare Rustup
       run: (cd /github/home && ln -s /root/.cargo)
@@ -1233,12 +1233,12 @@ jobs:
       SKIA_DEBUG: 0
     
     steps:
-    - name: Attempt to fix git dubious ownership warnings
-      run: git config --global --add safe.directory '*'
-    
     - uses: actions/checkout@v2
       with:
         submodules: true
+    
+    - name: Fix git dubious ownership errors when synchronizing Skia dependencies
+      run: git config --global --add safe.directory '*'
     
     - name: Prepare Rustup
       run: (cd /github/home && ln -s /root/.cargo)
@@ -1638,12 +1638,12 @@ jobs:
       SKIA_DEBUG: 0
     
     steps:
-    - name: Attempt to fix git dubious ownership warnings
-      run: git config --global --add safe.directory '*'
-    
     - uses: actions/checkout@v2
       with:
         submodules: true
+    
+    - name: Fix git dubious ownership errors when synchronizing Skia dependencies
+      run: git config --global --add safe.directory '*'
     
     - name: Prepare Rustup
       run: (cd /github/home && ln -s /root/.cargo)
@@ -2043,12 +2043,12 @@ jobs:
       SKIA_DEBUG: 0
     
     steps:
-    - name: Attempt to fix git dubious ownership warnings
-      run: git config --global --add safe.directory '*'
-    
     - uses: actions/checkout@v2
       with:
         submodules: true
+    
+    - name: Fix git dubious ownership errors when synchronizing Skia dependencies
+      run: git config --global --add safe.directory '*'
     
     - name: Prepare Rustup
       run: (cd /github/home && ln -s /root/.cargo)
@@ -2448,12 +2448,12 @@ jobs:
       SKIA_DEBUG: 0
     
     steps:
-    - name: Attempt to fix git dubious ownership warnings
-      run: git config --global --add safe.directory '*'
-    
     - uses: actions/checkout@v2
       with:
         submodules: true
+    
+    - name: Fix git dubious ownership errors when synchronizing Skia dependencies
+      run: git config --global --add safe.directory '*'
     
     - name: Prepare Rustup
       run: (cd /github/home && ln -s /root/.cargo)
@@ -2853,12 +2853,12 @@ jobs:
       SKIA_DEBUG: 0
     
     steps:
-    - name: Attempt to fix git dubious ownership warnings
-      run: git config --global --add safe.directory '*'
-    
     - uses: actions/checkout@v2
       with:
         submodules: true
+    
+    - name: Fix git dubious ownership errors when synchronizing Skia dependencies
+      run: git config --global --add safe.directory '*'
     
     - name: Prepare Rustup
       run: (cd /github/home && ln -s /root/.cargo)
@@ -3258,12 +3258,12 @@ jobs:
       SKIA_DEBUG: 0
     
     steps:
-    - name: Attempt to fix git dubious ownership warnings
-      run: git config --global --add safe.directory '*'
-    
     - uses: actions/checkout@v2
       with:
         submodules: true
+    
+    - name: Fix git dubious ownership errors when synchronizing Skia dependencies
+      run: git config --global --add safe.directory '*'
     
     - name: Prepare Rustup
       run: (cd /github/home && ln -s /root/.cargo)

--- a/.github/workflows/linux-release.yaml
+++ b/.github/workflows/linux-release.yaml
@@ -18,6 +18,9 @@ jobs:
       SKIA_DEBUG: 0
     
     steps:
+    - name: Attempt to fix git dubious ownership warnings
+      run: git config --global --add safe.directory '*'
+    
     - uses: actions/checkout@v2
       with:
         submodules: true
@@ -420,6 +423,9 @@ jobs:
       SKIA_DEBUG: 0
     
     steps:
+    - name: Attempt to fix git dubious ownership warnings
+      run: git config --global --add safe.directory '*'
+    
     - uses: actions/checkout@v2
       with:
         submodules: true
@@ -822,6 +828,9 @@ jobs:
       SKIA_DEBUG: 0
     
     steps:
+    - name: Attempt to fix git dubious ownership warnings
+      run: git config --global --add safe.directory '*'
+    
     - uses: actions/checkout@v2
       with:
         submodules: true
@@ -1224,6 +1233,9 @@ jobs:
       SKIA_DEBUG: 0
     
     steps:
+    - name: Attempt to fix git dubious ownership warnings
+      run: git config --global --add safe.directory '*'
+    
     - uses: actions/checkout@v2
       with:
         submodules: true
@@ -1626,6 +1638,9 @@ jobs:
       SKIA_DEBUG: 0
     
     steps:
+    - name: Attempt to fix git dubious ownership warnings
+      run: git config --global --add safe.directory '*'
+    
     - uses: actions/checkout@v2
       with:
         submodules: true
@@ -2028,6 +2043,9 @@ jobs:
       SKIA_DEBUG: 0
     
     steps:
+    - name: Attempt to fix git dubious ownership warnings
+      run: git config --global --add safe.directory '*'
+    
     - uses: actions/checkout@v2
       with:
         submodules: true
@@ -2430,6 +2448,9 @@ jobs:
       SKIA_DEBUG: 0
     
     steps:
+    - name: Attempt to fix git dubious ownership warnings
+      run: git config --global --add safe.directory '*'
+    
     - uses: actions/checkout@v2
       with:
         submodules: true
@@ -2832,6 +2853,9 @@ jobs:
       SKIA_DEBUG: 0
     
     steps:
+    - name: Attempt to fix git dubious ownership warnings
+      run: git config --global --add safe.directory '*'
+    
     - uses: actions/checkout@v2
       with:
         submodules: true
@@ -3234,6 +3258,9 @@ jobs:
       SKIA_DEBUG: 0
     
     steps:
+    - name: Attempt to fix git dubious ownership warnings
+      run: git config --global --add safe.directory '*'
+    
     - uses: actions/checkout@v2
       with:
         submodules: true

--- a/.github/workflows/supplemental-builds.yaml
+++ b/.github/workflows/supplemental-builds.yaml
@@ -46,6 +46,9 @@ jobs:
       EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
 
     steps:
+    - name: Attempt to fix git dubious ownership warnings
+      run: git config --global --add safe.directory '*'
+
     - uses: actions/checkout@v2
       with:
         submodules: true
@@ -86,6 +89,9 @@ jobs:
     runs-on: windows-2022
 
     steps:
+    - name: Attempt to fix git dubious ownership warnings
+      run: git config --global --add safe.directory '*'
+
     - uses: actions/checkout@v2
       with:
         submodules: true

--- a/.github/workflows/supplemental-builds.yaml
+++ b/.github/workflows/supplemental-builds.yaml
@@ -25,6 +25,9 @@ jobs:
       with:
         submodules: true
 
+    - name: Fix git dubious ownership errors when synchronizing Skia dependencies
+      run: git config --global --add safe.directory '*'
+
     - name: Prepare Rustup
       run: (cd /github/home && ln -s /root/.cargo)
 
@@ -46,12 +49,12 @@ jobs:
       EMCC_CFLAGS: "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s MAX_WEBGL_VERSION=2"
 
     steps:
-    - name: Attempt to fix git dubious ownership warnings
-      run: git config --global --add safe.directory '*'
-
     - uses: actions/checkout@v2
       with:
         submodules: true
+
+    - name: Fix git dubious ownership errors when synchronizing Skia dependencies
+      run: git config --global --add safe.directory '*'
 
     - name: Prepare Rustup
       run: (cd /github/home && ln -s /root/.cargo)

--- a/mk-workflows/src/templates/linux-job.yaml
+++ b/mk-workflows/src/templates/linux-job.yaml
@@ -4,6 +4,9 @@ env:
   SKIA_DEBUG: $[[skiaDebug]]
 
 steps:
+- name: Attempt to fix git dubious ownership warnings
+  run: git config --global --add safe.directory '*'
+
 - uses: actions/checkout@v2
   with:
     submodules: true

--- a/mk-workflows/src/templates/linux-job.yaml
+++ b/mk-workflows/src/templates/linux-job.yaml
@@ -4,12 +4,12 @@ env:
   SKIA_DEBUG: $[[skiaDebug]]
 
 steps:
-- name: Attempt to fix git dubious ownership warnings
-  run: git config --global --add safe.directory '*'
-
 - uses: actions/checkout@v2
   with:
     submodules: true
+
+- name: Fix git dubious ownership errors when synchronizing Skia dependencies
+  run: git config --global --add safe.directory '*'
 
 - name: Prepare Rustup
   run: (cd /github/home && ln -s /root/.cargo)


### PR DESCRIPTION
This happened in master in the step where Skia synchronizes its dependencies, most likely because of a recent regeneration of the ubuntu image in use.

```
fatal: detected dubious ownership in repository at '/__w/rust-skia/rust-skia'
  To add an exception for this directory, call:

  	git config --global --add safe.directory /__w/rust-skia/rust-skia
```