### PR TITLE
Fixes for Mac Catalyst 

### DIFF
--- a/mk-workflows/src/config.rs
+++ b/mk-workflows/src/config.rs
@@ -165,11 +165,6 @@ fn macos_targets() -> Vec<Target> {
             ..Default::default()
         },
         Target {
-            target: "x86_64-apple-ios-macabi",
-            platform_features: "metal".into(),
-            ..Default::default()
-        },
-        Target {
             target: "aarch64-apple-darwin",
             platform_features: "metal".into(),
             ..Default::default()

--- a/mk-workflows/src/config.rs
+++ b/mk-workflows/src/config.rs
@@ -165,6 +165,11 @@ fn macos_targets() -> Vec<Target> {
             ..Default::default()
         },
         Target {
+            target: "x86_64-apple-ios-macabi",
+            platform_features: "metal".into(),
+            ..Default::default()
+        },
+        Target {
             target: "aarch64-apple-darwin",
             platform_features: "metal".into(),
             ..Default::default()

--- a/skia-bindings/build_support/platform.rs
+++ b/skia-bindings/build_support/platform.rs
@@ -45,6 +45,7 @@ fn details(target: &Target) -> Box<dyn PlatformDetails> {
     match target.as_strs() {
         ("wasm32", "unknown", "emscripten", _) => Box::new(emscripten::Emscripten),
         (_, "linux", "android", _) | (_, "linux", "androideabi", _) => Box::new(android::Android),
+        ("x86_64", "apple", "ios", Some("macabi")) => Box::new(macos::MacOs),
         (_, "apple", "darwin", _) => Box::new(macos::MacOs),
         (_, "apple", "ios", _) => Box::new(ios::Ios),
         (_, _, "windows", Some("msvc")) if host.is_windows() => Box::new(windows::Msvc),


### PR DESCRIPTION
VIA some minor tweaks I was able to get rust to build rust-skia for the `x86_64-apple-ios-macabi` target. But when I link it from Xcode, Xcode complains 

```
ld: in lib/file.a(libskia.SkPaint.o), building for Mac Catalyst, but linking in object file built for macOS, for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

I don’t get what I’m doing wrong?

Rust compiled it just fine, and the underlying architecture is x86_64, but Xcode thinks that it’s built for MacOS. 

<hr>

Anyway I though I’d open this WIP PR in the hope that I may get feedback of some kind that can translate to getting rust-skia building for catalyst. 