### PR TITLE
Attempt to support docs.rs builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
-# Publishes skia-bindings and skia-safe to crates.io
-# This is temporary and should be automated.
-# prerequisites:
-#   .cargo/credentials
+doc-features-win="gl,vulkan,d3d,textlayout,webp"
+doc-features-docs-rs="gl,textlayout,webp"
 
 .PHONY: all
 all:
@@ -34,6 +32,11 @@ crate-bindings-build:
 	cd skia-bindings && cargo publish -vv --dry-run --features "gl,vulkan,textlayout,d3d"
 	cd skia-bindings && cargo publish -vv --dry-run 
 
+# Publishes skia-bindings and skia-safe to crates.io
+# This is temporary and should be automated.
+# prerequisites:
+#   .cargo/credentials
+
 .PHONY: publish
 publish: package-bindings package-safe publish-bindings wait publish-safe
 
@@ -42,7 +45,10 @@ publish-only: publish-bindings wait publish-safe
 
 .PHONY: publish-bindings
 publish-bindings:
-	cd skia-bindings && cargo publish -vv --no-verify
+	cd skia-bindings && cargo clean
+	cd skia-bindings && cargo build --features ${doc-features-docs-rs}
+	cd skia-bindings && cp src/bindings.rs bindings_docs.rs
+	cd skia-bindings && cargo publish -vv --no-verify --allow-dirty
 
 .PHONY: publish-safe
 publish-safe:
@@ -73,8 +79,6 @@ clean-packages:
 wait: 
 	@echo "published a package, Waiting for crates.io to catch up before publishing the next"
 	sleep 20
-
-doc-features-win="gl,vulkan,d3d,textlayout,webp"
 
 .PHONY: update-doc
 update-doc:

--- a/skia-bindings/.gitignore
+++ b/skia-bindings/.gitignore
@@ -1,2 +1,4 @@
 /src/bindings.rs
 /src/bindings.rs.bk
+/bindings_docs.rs
+

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -15,14 +15,15 @@ edition = "2021"
 build = "build.rs"
 links = "skia"
 include = [ 
-	"Cargo.toml", 
-	"build.rs", 
-	"build_support.rs", 
-	"build_support/**/*.rs", 
-	"src/**/*.h", 
-	"src/**/*.cpp", 
-	"src/defaults.rs", 
-	"src/icu.rs", 
+	"Cargo.toml",
+	"bindings_docs.rs",
+	"build.rs",
+	"build_support.rs",
+	"build_support/**/*.rs",
+	"src/**/*.h",
+	"src/**/*.cpp",
+	"src/defaults.rs",
+	"src/icu.rs",
 	"src/impls.rs",
 	"src/lib.rs" ]
 

--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -3,79 +3,19 @@ use build_support::{
     cargo::{self, Target},
     features, skia, skia_bindgen,
 };
+use std::{fs, io};
 
 mod build_support;
 
-/// Environment variables used by this build script.
-mod env {
-    use crate::build_support::cargo;
-    use std::path::PathBuf;
-
-    /// The path to the Skia source directory.
-    pub fn source_dir() -> Option<PathBuf> {
-        cargo::env_var("SKIA_SOURCE_DIR").map(PathBuf::from)
-    }
-
-    /// The path to where a pre-built Skia library can be found.
-    pub fn skia_lib_search_path() -> Option<PathBuf> {
-        cargo::env_var("SKIA_LIBRARY_SEARCH_PATH").map(PathBuf::from)
-    }
-
-    pub fn is_skia_debug() -> bool {
-        matches!(cargo::env_var("SKIA_DEBUG"), Some(v) if v != "0")
-    }
-}
-
-fn build_from_source(
-    features: features::Features,
-    binaries_config: &binaries_config::BinariesConfiguration,
-    skia_source_dir: &std::path::Path,
-    skia_debug: bool,
-    offline: bool,
-) -> skia::FinalBuildConfiguration {
-    let build_config = skia::BuildConfiguration::from_features(features, skia_debug);
-    let final_configuration = skia::FinalBuildConfiguration::from_build_configuration(
-        &build_config,
-        skia::env::use_system_libraries(),
-        skia_source_dir,
-    );
-
-    skia::build(
-        &final_configuration,
-        binaries_config,
-        skia::env::ninja_command(),
-        skia::env::gn_command(),
-        offline,
-    );
-
-    final_configuration
-}
-
-fn generate_bindings(
-    features: &features::Features,
-    definitions: Vec<skia_bindgen::Definition>,
-    binaries_config: &binaries_config::BinariesConfiguration,
-    skia_source_dir: &std::path::Path,
-    target: Target,
-    sysroot: Option<&str>,
-) {
-    // Emit the ninja definitions, to help debug build consistency.
-    skia_bindgen::definitions::save_definitions(&definitions, &binaries_config.output_directory)
-        .expect("failed to write Skia defines");
-
-    let bindings_config = skia_bindgen::Configuration::new(features, definitions, skia_source_dir);
-    skia_bindgen::generate_bindings(
-        &bindings_config,
-        &binaries_config.output_directory,
-        target,
-        sysroot,
-    );
-}
-
-fn main() {
+fn main() -> Result<(), io::Error> {
     // since 0.25.0
     if cfg!(feature = "shaper") {
         cargo::warning("The feature 'shaper' has been removed. To use the SkShaper bindings, enable the feature 'textlayout'.");
+    }
+
+    if env::is_docs_rs_build() {
+        println!("DETECTED DOCS_RS BUILD");
+        return fake_bindings();
     }
 
     let skia_debug = env::is_skia_debug();
@@ -176,5 +116,84 @@ fn main() {
     #[cfg(feature = "binary-cache")]
     if let Some(staging_directory) = build_support::binary_cache::should_export() {
         build_support::binary_cache::publish(&binaries_config, &staging_directory);
+    }
+
+    Ok(())
+}
+
+fn build_from_source(
+    features: features::Features,
+    binaries_config: &binaries_config::BinariesConfiguration,
+    skia_source_dir: &std::path::Path,
+    skia_debug: bool,
+    offline: bool,
+) -> skia::FinalBuildConfiguration {
+    let build_config = skia::BuildConfiguration::from_features(features, skia_debug);
+    let final_configuration = skia::FinalBuildConfiguration::from_build_configuration(
+        &build_config,
+        skia::env::use_system_libraries(),
+        skia_source_dir,
+    );
+
+    skia::build(
+        &final_configuration,
+        binaries_config,
+        skia::env::ninja_command(),
+        skia::env::gn_command(),
+        offline,
+    );
+
+    final_configuration
+}
+
+fn generate_bindings(
+    features: &features::Features,
+    definitions: Vec<skia_bindgen::Definition>,
+    binaries_config: &binaries_config::BinariesConfiguration,
+    skia_source_dir: &std::path::Path,
+    target: Target,
+    sysroot: Option<&str>,
+) {
+    // Emit the ninja definitions, to help debug build consistency.
+    skia_bindgen::definitions::save_definitions(&definitions, &binaries_config.output_directory)
+        .expect("failed to write Skia defines");
+
+    let bindings_config = skia_bindgen::Configuration::new(features, definitions, skia_source_dir);
+    skia_bindgen::generate_bindings(
+        &bindings_config,
+        &binaries_config.output_directory,
+        target,
+        sysroot,
+    );
+}
+
+/// On docs.rs, rustdoc runs inside a container with no networking, so copy a pre-generated
+/// `bindings.rs` file.
+fn fake_bindings() -> Result<(), io::Error> {
+    println!("COPYING bindings_docs.rs to src/bindings.rs");
+    fs::copy("bindings_docs.rs", "src/bindings.rs").map(|_| ())
+}
+
+/// Environment variables used by this build script.
+mod env {
+    use crate::build_support::cargo;
+    use std::path::PathBuf;
+
+    /// The path to the Skia source directory.
+    pub fn source_dir() -> Option<PathBuf> {
+        cargo::env_var("SKIA_SOURCE_DIR").map(PathBuf::from)
+    }
+
+    /// The path to where a pre-built Skia library can be found.
+    pub fn skia_lib_search_path() -> Option<PathBuf> {
+        cargo::env_var("SKIA_LIBRARY_SEARCH_PATH").map(PathBuf::from)
+    }
+
+    pub fn is_skia_debug() -> bool {
+        matches!(cargo::env_var("SKIA_DEBUG"), Some(v) if v != "0")
+    }
+
+    pub fn is_docs_rs_build() -> bool {
+        matches!(cargo::env_var("DOCS_RS"), Some(v) if v != "0")
     }
 }


### PR DESCRIPTION
Not sure if I am missing something, but it should be possible to pre-generate the `bindings.rs` file, store it in the crate and copy it to `src/bindings.rs` when `DOCS_RS` environment variable is set.

Closes #720 

Related #226 