### PR TITLE
fix(android): disable outline atomics when using ndk 23+ arm64

### DIFF
--- a/skia-bindings/build_support/platform/android.rs
+++ b/skia-bindings/build_support/platform/android.rs
@@ -12,9 +12,10 @@ impl PlatformDetails for Android {
     fn gn_args(&self, config: &BuildConfiguration, builder: &mut GnArgsBuilder) {
         // TODO: this may belong into BuildConfiguration
         let (arch, _) = config.target.arch_abi();
+        let ndk = ndk();
 
         builder
-            .arg("ndk", quote(&ndk()))
+            .arg("ndk", quote(&ndk))
             .arg("ndk_api", API_LEVEL)
             .arg("target_cpu", quote(clang::target_arch(arch)))
             .arg("skia_enable_fontmgr_android", yes());
@@ -26,16 +27,12 @@ impl PlatformDetails for Android {
             );
         }
 
-        let ndk = ndk();
-
         let major = ndk_major_version(Path::new(&ndk));
-
         let mut extra_skia_cflags = extra_skia_cflags();
 
         // Version 23 is the first version using llvm 12
         // https://github.com/android/ndk/wiki/Changelog-r23#r23b
         // https://releases.llvm.org/12.0.0/tools/clang/docs/ReleaseNotes.html#new-compiler-flags
-
         if major >= 23 && arch == "aarch64" {
             extra_skia_cflags.push("-mno-outline-atomics".to_string());
         }

--- a/skia-bindings/build_support/platform/android.rs
+++ b/skia-bindings/build_support/platform/android.rs
@@ -35,9 +35,9 @@ impl PlatformDetails for Android {
         // Version 23 is the first version using llvm 12
         // https://github.com/android/ndk/wiki/Changelog-r23#r23b
         // https://releases.llvm.org/12.0.0/tools/clang/docs/ReleaseNotes.html#new-compiler-flags
-        
+
         if major >= 23 && arch == "aarch64" {
-           extra_skia_cflags.push("-mno-outline-atomics".to_string());
+            extra_skia_cflags.push("-mno-outline-atomics".to_string());
         }
 
         builder.cflags(extra_skia_cflags);

--- a/skia-bindings/build_support/platform/android.rs
+++ b/skia-bindings/build_support/platform/android.rs
@@ -26,7 +26,21 @@ impl PlatformDetails for Android {
             );
         }
 
-        builder.cflags(extra_skia_cflags());
+        let ndk = ndk();
+
+        let major = ndk_major_version(Path::new(&ndk));
+
+        let mut extra_skia_cflags = extra_skia_cflags();
+
+        // Version 23 is the first version using llvm 12
+        // https://github.com/android/ndk/wiki/Changelog-r23#r23b
+        // https://releases.llvm.org/12.0.0/tools/clang/docs/ReleaseNotes.html#new-compiler-flags
+        
+        if major >= 23 && arch == "aarch64" {
+           extra_skia_cflags.push("-mno-outline-atomics".to_string());
+        }
+
+        builder.cflags(extra_skia_cflags);
     }
 
     fn bindgen_args(&self, target: &Target, builder: &mut BindgenArgsBuilder) {


### PR DESCRIPTION
When building with the newer ndk (23+) running on android with an arm64 it fails with the following `cannot locate symbol "__aarch64_ldadd4_acq_rel"` error, seems like it is due to them enabling the flag by [default ](https://reviews.llvm.org/D93585).

I've found similar issues irc they reverted to an older sdk or disabled it

[Flutter](https://github.com/flutter/flutter/issues/75348)
[Chromium](https://chromium.googlesource.com/chromium/src.git/+/refs/heads/main/build/config/compiler/BUILD.gn#1252) (they went a step further) 