### PR TITLE
depot_tools: Fix crate based from source builds.

### DIFF
--- a/skia-bindings/build_support/binary_cache/download.rs
+++ b/skia-bindings/build_support/binary_cache/download.rs
@@ -121,10 +121,14 @@ fn filter_skia(p: &Path) -> bool {
             Some(Component::Normal(name)) if name == OsStr::new("infra"))
 }
 
-// Need only `ninja` from `depot_tools/`.
+// Need only `ninja` and what `ninja.py` refers to from `depot_tools/`.
 // <https://github.com/rust-skia/rust-skia/pull/165>
 fn filter_depot_tools(p: &Path) -> bool {
-    p.to_str().unwrap().starts_with("ninja")
+    if p.components().count() != 1 {
+        return false;
+    }
+    let str = p.to_str().unwrap();
+    str.starts_with("ninja") || str.ends_with(".py")
 }
 
 impl binaries_config::BinariesConfiguration {


### PR DESCRIPTION
The latest update of depot_tools in #736 caused the `make crate-bindings-build` manual pre release test to fail on macOS. The reason for that is that `ninja.py` uses python scripts, which were filtered out by the extraction code. This PR makes sure that all needed python scripts are available for ninja to do its job.