### PR TITLE
Fix compilation with meta-rust in Yocto

### DIFF
--- a/skia-bindings/build_support/cargo.rs
+++ b/skia-bindings/build_support/cargo.rs
@@ -137,19 +137,29 @@ pub fn host() -> Target {
 pub fn parse_target(target_str: impl AsRef<str>) -> Target {
     let target_str = target_str.as_ref();
     let target: Vec<String> = target_str.split('-').map(|s| s.into()).collect();
-    assert!(target.len() >= 3, "Failed to parse TARGET {}", target_str);
 
-    let abi = if target.len() > 3 {
-        Some(target[3].clone())
+    if target.len() >= 3 {
+        let abi = if target.len() > 3 {
+            Some(target[3].clone())
+        } else {
+            None
+        };
+
+        Target {
+            architecture: target[0].clone(),
+            vendor: target[1].clone(),
+            system: target[2].clone(),
+            abi,
+        }
+    } else if target.len() == 2 {
+        Target {
+            architecture: target[0].clone(),
+            vendor: String::new(),
+            system: target[1].clone(),
+            abi: None,
+        }
     } else {
-        None
-    };
-
-    Target {
-        architecture: target[0].clone(),
-        vendor: target[1].clone(),
-        system: target[2].clone(),
-        abi,
+        panic!("Failed to parse TARGET {}", target_str);
     }
 }
 


### PR DESCRIPTION
When compiling in Yocto with the upstream meta-rust instead of meta-rust-bin, the Yocto target specs are used for compilation. That means the target strings aren't necessarily triplets (or longer) in the form of x86_64-unknown-linux-gnu, but they can be also short like x86_64-linux.

Therefore adjust parse_target() to accomodate that format.