### PR TITLE
Fix external library linkage (freetype, etc.) when building against Yocto

### DIFF
--- a/skia-bindings/build_support/platform.rs
+++ b/skia-bindings/build_support/platform.rs
@@ -50,7 +50,7 @@ fn details(target: &Target) -> Box<dyn PlatformDetails> {
         (_, _, "windows", Some("msvc")) if host.is_windows() => Box::new(windows::Msvc),
         (_, _, "windows", _) => Box::new(windows::Generic),
         (_, "unknown", "linux", Some("musl")) => Box::new(alpine::Musl),
-        (_, "unknown", "linux", _) => Box::new(linux::Linux),
+        (_, _, "linux", _) => Box::new(linux::Linux),
         _ => Box::new(generic::Generic),
     }
 }


### PR DESCRIPTION
A typical target spec when building against Yocto is the poky distribution, which is the vendor (so "aarch64-poky-linux"). When building with meta-rust, instead of meta-rust-bin, that's used instead of the previous aarch64-unknown-linux-gnu style. This results in the target determination in platform.rs to think it's a generic system, which means that we don't end up linking fontconfig and freetype. Those however are a "must". Therefore soften up the match for Linux to allow for any vendor, instead of just "unknown".