### PR TITLE
Use RefHandle to represent a GrBackendTexture in Rust

### DIFF
--- a/skia-bindings/src/d3d.cpp
+++ b/skia-bindings/src/d3d.cpp
@@ -29,13 +29,12 @@ extern "C" void C_GrBackendFormat_ConstructDxgi(GrBackendFormat* uninitialized, 
     new(uninitialized)GrBackendFormat(GrBackendFormat::MakeDxgi(format));
 }
 
-extern "C" void C_GrBackendTexture_ConstructD3D(
-    GrBackendTexture* uninitialized, 
-    int width, int height, 
+extern "C" GrBackendTexture* C_GrBackendTexture_NewD3D(
+    int width, int height,
     const GrD3DTextureResourceInfo* resourceInfo, 
     const char* label,
     size_t labelCount) {
-    new(uninitialized)GrBackendTexture(width, height, *resourceInfo, std::string_view(label, labelCount));
+    return new GrBackendTexture(width, height, *resourceInfo, std::string_view(label, labelCount));
 }
 
 extern "C" void C_GrBackendRenderTarget_ConstructD3D(GrBackendRenderTarget* uninitialized, int width, int height, const GrD3DTextureResourceInfo* resourceInfo) {

--- a/skia-bindings/src/gl.cpp
+++ b/skia-bindings/src/gl.cpp
@@ -173,14 +173,13 @@ extern "C" void C_GrBackendFormat_ConstructGL(GrBackendFormat* uninitialized, Gr
     new(uninitialized)GrBackendFormat(GrBackendFormat::MakeGL(format, target));
 }
 
-extern "C" void C_GrBackendTexture_ConstructGL(
-    GrBackendTexture* uninitialized, 
-    int width, int height, 
-    GrMipMapped mipMapped, 
+extern "C" GrBackendTexture* C_GrBackendTexture_NewGL(
+    int width, int height,
+    GrMipMapped mipMapped,
     const GrGLTextureInfo* glInfo,
     const char* label,
     size_t labelCount) {
-    new(uninitialized)GrBackendTexture(width, height, mipMapped, *glInfo, std::string_view(label, labelCount));
+    return new GrBackendTexture(width, height, mipMapped, *glInfo, std::string_view(label, labelCount));
 }
 
 extern "C" void C_GrBackendRenderTarget_ConstructGL(GrBackendRenderTarget* uninitialized, int width, int height, int sampleCnt, int stencilBits, const GrGLFramebufferInfo* glInfo) {

--- a/skia-bindings/src/gpu.cpp
+++ b/skia-bindings/src/gpu.cpp
@@ -73,11 +73,10 @@ extern "C" SkSurface* C_SkSurface_MakeRenderTarget2(
             budgeted).release();
 }
 
-extern "C" void C_SkSurface_getBackendTexture(
+extern "C" GrBackendTexture* C_SkSurface_getBackendTexture(
         SkSurface* self,
-        SkSurface::BackendHandleAccess handleAccess,
-        GrBackendTexture* backendTexture) {
-    *backendTexture = self->getBackendTexture(handleAccess);
+        SkSurface::BackendHandleAccess handleAccess) {
+    return new GrBackendTexture(self->getBackendTexture(handleAccess));
 }
 
 extern "C" void C_SkSurface_getBackendRenderTarget(
@@ -140,16 +139,16 @@ extern "C" void C_GrBackendRenderTarget_getBackendFormat(const GrBackendRenderTa
 
 // GrBackendTexture
 
-extern "C" void C_GrBackendTexture_Construct(GrBackendTexture* uninitialized) {
-    new(uninitialized) GrBackendTexture();
+extern "C" GrBackendTexture* C_GrBackendTexture_New() {
+    return new GrBackendTexture();
 }
 
-extern "C" void C_GrBackendTexture_CopyConstruct(GrBackendTexture* uninitialized, const GrBackendTexture* texture) {
-    new(uninitialized) GrBackendTexture(*texture);
+extern "C" GrBackendTexture* C_GrBackendTexture_Clone(const GrBackendTexture* texture) {
+    return new GrBackendTexture(*texture);
 }
 
-extern "C" void C_GrBackendTexture_destruct(const GrBackendTexture* self) {
-    self->~GrBackendTexture();
+extern "C" void C_GrBackendTexture_delete(const GrBackendTexture* self) {
+    delete self;
 }
 
 extern "C" void C_GrBackendTexture_getBackendFormat(const GrBackendTexture* self, GrBackendFormat* format) {
@@ -359,13 +358,12 @@ extern "C" SkImage *C_SkImage_MakeTextureFromCompressed(GrDirectContext *context
     return SkImage::MakeTextureFromCompressed(context, sp(data), width, height, type, mipMapped, prot).release();
 }
 
-extern "C" void C_SkImage_getBackendTexture(
+extern "C" GrBackendTexture* C_SkImage_getBackendTexture(
         const SkImage* self,
         bool flushPendingGrContextIO,
-        GrSurfaceOrigin* origin,
-        GrBackendTexture* result)
+        GrSurfaceOrigin* origin)
 {
-    *result = self->getBackendTexture(flushPendingGrContextIO, origin);
+    return new GrBackendTexture(self->getBackendTexture(flushPendingGrContextIO, origin));
 }
 
 extern "C" SkImage* C_SkImage_MakeFromTexture(

--- a/skia-bindings/src/metal.cpp
+++ b/skia-bindings/src/metal.cpp
@@ -96,14 +96,13 @@ extern "C" void C_GrBackendFormat_ConstructMtl(GrBackendFormat* uninitialized, G
 }
 
 
-extern "C" void C_GrBackendTexture_ConstructMtl(
-    GrBackendTexture* uninitialized, 
-    int width, int height, 
-    GrMipMapped mipMapped, 
+extern "C" GrBackendTexture* C_GrBackendTexture_NewMtl(
+    int width, int height,
+    GrMipMapped mipMapped,
     const GrMtlTextureInfo* mtlInfo,
     const char* label,
     size_t labelCount) {
-    new(uninitialized)GrBackendTexture(width, height, mipMapped, *mtlInfo, std::string_view(label, labelCount));
+    return new GrBackendTexture(width, height, mipMapped, *mtlInfo, std::string_view(label, labelCount));
 }
 
 extern "C" void C_GrBackendRenderTarget_ConstructMtl(GrBackendRenderTarget* uninitialized, int width, int height, int sampleCnt, const GrMtlTextureInfo* mtlInfo) {

--- a/skia-bindings/src/vulkan.cpp
+++ b/skia-bindings/src/vulkan.cpp
@@ -20,13 +20,12 @@ extern "C" void C_GrBackendFormat_ConstructVk2(GrBackendFormat* uninitialized, c
     new(uninitialized)GrBackendFormat(GrBackendFormat::MakeVk(*ycbcrInfo, willUseDRMFormatModifiers));
 }
 
-extern "C" void C_GrBackendTexture_ConstructVk(
-    GrBackendTexture* uninitialized, 
+extern "C" GrBackendTexture* C_GrBackendTexture_NewVk(
     int width, int height,
     const GrVkImageInfo* vkInfo,
     const char* label,
     size_t labelCount) {
-    new(uninitialized)GrBackendTexture(width, height, *vkInfo, std::string_view(label, labelCount));
+    return new GrBackendTexture(width, height, *vkInfo, std::string_view(label, labelCount));
 }
 
 extern "C" void C_GrBackendRenderTarget_ConstructVk(GrBackendRenderTarget* uninitialized, int width, int height, int sampleCnt, const GrVkImageInfo* vkInfo) {

--- a/skia-safe/src/core/image.rs
+++ b/skia-safe/src/core/image.rs
@@ -802,13 +802,11 @@ impl Image {
         flush_pending_gr_context_io: bool,
     ) -> Option<(gpu::BackendTexture, gpu::SurfaceOrigin)> {
         let mut origin = gpu::SurfaceOrigin::TopLeft;
-        let mut backend_texture = unsafe { sb::GrBackendTexture::new() };
         unsafe {
-            sb::C_SkImage_getBackendTexture(
+            let backend_texture = sb::C_SkImage_getBackendTexture(
                 self.native(),
                 flush_pending_gr_context_io,
                 &mut origin,
-                &mut backend_texture,
             );
             gpu::BackendTexture::from_native_if_valid(backend_texture)
         }

--- a/skia-safe/src/core/surface.rs
+++ b/skia-safe/src/core/surface.rs
@@ -290,14 +290,8 @@ impl Surface {
         handle_access: BackendHandleAccess,
     ) -> Option<gpu::BackendTexture> {
         unsafe {
-            let mut backend_texture = construct(|bt| sb::C_GrBackendTexture_Construct(bt));
-            sb::C_SkSurface_getBackendTexture(
-                self.native_mut(),
-                handle_access,
-                &mut backend_texture as _,
-            );
-
-            gpu::BackendTexture::from_native_if_valid(backend_texture)
+            let ptr = sb::C_SkSurface_getBackendTexture(self.native_mut(), handle_access);
+            gpu::BackendTexture::from_native_if_valid(ptr)
         }
     }
 

--- a/skia-safe/src/gpu/backend_surface.rs
+++ b/skia-safe/src/gpu/backend_surface.rs
@@ -447,7 +447,7 @@ impl BackendTexture {
     }
 
     pub(crate) unsafe fn native_is_valid(texture: *const GrBackendTexture) -> bool {
-        unsafe { (*texture).fIsValid }
+        (*texture).fIsValid
     }
 
     #[allow(clippy::wrong_self_convention)]

--- a/skia-safe/src/gpu/yuva_backend_textures.rs
+++ b/skia-safe/src/gpu/yuva_backend_textures.rs
@@ -130,25 +130,25 @@ impl fmt::Debug for YUVABackendTextures {
 }
 
 impl YUVABackendTextures {
-    pub fn new(
-        info: &YUVAInfo,
-        textures: &[BackendTexture],
-        texture_origin: SurfaceOrigin,
-    ) -> Option<Self> {
-        if textures.len() != info.num_planes() {
-            return None;
-        }
-        let mut textures = textures.to_vec();
-        textures.extend(
-            iter::repeat_with(BackendTexture::new_invalid)
-                .take(textures.len() - YUVAInfo::MAX_PLANES),
-        );
-        assert_eq!(textures.len(), YUVAInfo::MAX_PLANES);
-        let n = unsafe {
-            GrYUVABackendTextures::new(info.native(), textures[0].native(), texture_origin)
-        };
-        Self::native_is_valid(&n).if_true_then_some(|| Self::from_native_c(n))
-    }
+    // pub fn new(
+    //     info: &YUVAInfo,
+    //     textures: &[BackendTexture],
+    //     texture_origin: SurfaceOrigin,
+    // ) -> Option<Self> {
+    //     if textures.len() != info.num_planes() {
+    //         return None;
+    //     }
+    //     let mut textures = textures.to_vec();
+    //     textures.extend(
+    //         iter::repeat_with(BackendTexture::new_invalid)
+    //             .take(textures.len() - YUVAInfo::MAX_PLANES),
+    //     );
+    //     assert_eq!(textures.len(), YUVAInfo::MAX_PLANES);
+    //     let n = unsafe {
+    //         GrYUVABackendTextures::new(info.native(), textures[0].native(), texture_origin)
+    //     };
+    //     Self::native_is_valid(&n).if_true_then_some(|| Self::from_native_c(n))
+    // }
 
     pub fn textures(&self) -> &[BackendTexture] {
         unsafe {


### PR DESCRIPTION
First attempt to close #750.
