### PR TITLE
Add gl::Interface::new_load_with_cstr

### DIFF
--- a/skia-safe/src/gpu/gl/interface.rs
+++ b/skia-safe/src/gpu/gl/interface.rs
@@ -33,6 +33,18 @@ impl Interface {
         })
     }
 
+    pub fn new_load_with_cstr<F>(load_fn: F) -> Option<Self>
+    where
+        F: FnMut(&std::ffi::CStr) -> *const c_void,
+    {
+        Self::from_ptr(unsafe {
+            sb::C_GrGLInterface_MakeAssembledInterface(
+                &load_fn as *const _ as *mut c_void,
+                Some(gl_get_proc_fn_wrapper_cstr::<F>),
+            ) as _
+        })
+    }
+
     pub fn validate(&self) -> bool {
         unsafe { self.native().validate() }
     }
@@ -62,4 +74,14 @@ where
     F: FnMut(&str) -> *const c_void,
 {
     (*(ctx as *mut F))(std::ffi::CStr::from_ptr(name).to_str().unwrap())
+}
+
+unsafe extern "C" fn gl_get_proc_fn_wrapper_cstr<F>(
+    ctx: *mut c_void,
+    name: *const raw::c_char,
+) -> *const c_void
+where
+    F: FnMut(&std::ffi::CStr) -> *const c_void,
+{
+    (*(ctx as *mut F))(std::ffi::CStr::from_ptr(name))
 }


### PR DESCRIPTION
This is a kind of overload to new_load_with where the "get_proc_address" function accepts a &CStr instead of a &str. Latest glutin/glow now support get_proc_address with a &CStr, so together with this function it's possible to avoid the round-trip cstring -> str -> cstring.