### PR TITLE
Enable testing for build_support and add target parsing tests

### DIFF
--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -80,3 +80,15 @@ tar = { version = "0.4.26", optional = true }
 serde_json = "1.0.39"
 # For reading Cargo.toml from within a package.
 toml = "0.7.0"
+
+[dev-dependencies]
+# build dependencies duplicated for testing :(
+cc = "1.0.37"
+bindgen = "0.63.0"
+regex = "1.4.5"
+heck = "0.4.0"
+ureq = { version = "2.0.1" }
+flate2 = { version = "1.0.7" }
+tar = { version = "0.4.26" }
+serde_json = "1.0.39"
+toml = "0.7.0"

--- a/skia-bindings/build_support/cargo.rs
+++ b/skia-bindings/build_support/cargo.rs
@@ -218,3 +218,35 @@ pub fn get_metadata() -> Vec<(String, String)> {
         .map(|(a, b)| (a.clone(), b.as_str().unwrap().to_owned()))
         .collect()
 }
+
+#[test]
+fn parse_target_tests() {
+    assert_eq!(
+        parse_target("aarch64-unknown-linux-gnu"),
+        Target {
+            architecture: "aarch64".into(),
+            vendor: "unknown".into(),
+            system: "linux".into(),
+            abi: Some("gnu".into())
+        }
+    );
+    assert_eq!(
+        parse_target("aarch64-unknown-linux"),
+        Target {
+            architecture: "aarch64".into(),
+            vendor: "unknown".into(),
+            system: "linux".into(),
+            abi: None
+        }
+    );
+    assert_eq!(
+        parse_target("aarch64-linux"),
+        Target {
+            architecture: "aarch64".into(),
+            vendor: String::new(),
+            system: "linux".into(),
+            abi: None
+        }
+    );
+    assert!(std::panic::catch_unwind(|| parse_target("garbage")).is_err());
+}

--- a/skia-bindings/build_support/platform/macos.rs
+++ b/skia-bindings/build_support/platform/macos.rs
@@ -102,6 +102,6 @@ mod tests {
 
     #[test]
     fn deployment_target_6_digit_conversion() {
-        assert!(deployment_target_6("10.16"), "101600")
+        assert_eq!(deployment_target_6("10.16"), "101600")
     }
 }

--- a/skia-bindings/src/lib.rs
+++ b/skia-bindings/src/lib.rs
@@ -21,17 +21,3 @@ pub mod icu;
 #[doc(hidden)]
 #[cfg(feature = "use-system-jpeg-turbo")]
 use mozjpeg_sys;
-
-#[cfg(test)]
-#[path = "../build_support"]
-mod build_support {
-    pub mod binaries_config;
-    #[cfg(feature = "binary-cache")]
-    pub mod binary_cache;
-    pub mod cargo;
-    pub mod clang;
-    pub mod features;
-    pub mod platform;
-    pub mod skia;
-    pub mod skia_bindgen;
-}

--- a/skia-bindings/src/lib.rs
+++ b/skia-bindings/src/lib.rs
@@ -21,3 +21,17 @@ pub mod icu;
 #[doc(hidden)]
 #[cfg(feature = "use-system-jpeg-turbo")]
 use mozjpeg_sys;
+
+#[cfg(test)]
+#[path = "../build_support"]
+mod build_support {
+    pub mod binaries_config;
+    #[cfg(feature = "binary-cache")]
+    pub mod binary_cache;
+    pub mod cargo;
+    pub mod clang;
+    pub mod features;
+    pub mod platform;
+    pub mod skia;
+    pub mod skia_bindgen;
+}

--- a/skia-bindings/tests/build_support.rs
+++ b/skia-bindings/tests/build_support.rs
@@ -1,5 +1,7 @@
 #[path = "../build_support"]
 mod build_support {
+    #![allow(dead_code)]
+
     pub mod binaries_config;
     #[cfg(feature = "binary-cache")]
     pub mod binary_cache;

--- a/skia-bindings/tests/build_support.rs
+++ b/skia-bindings/tests/build_support.rs
@@ -1,0 +1,12 @@
+#[path = "../build_support"]
+mod build_support {
+    pub mod binaries_config;
+    #[cfg(feature = "binary-cache")]
+    pub mod binary_cache;
+    pub mod cargo;
+    pub mod clang;
+    pub mod features;
+    pub mod platform;
+    pub mod skia;
+    pub mod skia_bindgen;
+}


### PR DESCRIPTION
Followup to #746 from @tronical which adds and enables tests for skia-binding's build_support. This PR fixes the clippy problems and runs the tests as a separate test project.
