### PR TITLE
Milestone 111

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "skia"]
 	path = skia-bindings/skia
-	url = https://github.com/rust-skia/skia.git
+	url = ../skia.git
 [submodule "skia-bindings/depot_tools"]
 	path = skia-bindings/depot_tools
-	url = https://github.com/rust-skia/depot_tools.git
+	url = ../depot_tools.git

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![Windows QA](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml) [![Linux QA](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml) [![macOS QA](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml)
 
-Skia Submodule Status: chrome/m110 ([upstream changes][skia-upstream], [our changes][skia-ours]).
+Skia Submodule Status: chrome/m111 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m110-0.58.1...google:chrome/m110
-[skia-ours]: https://github.com/google/skia/compare/chrome/m110...rust-skia:m110-0.58.1
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m111-0.59.10..google:chrome/m111
+[skia-ours]: https://github.com/google/skia/compare/chrome/m111...rust-skia:m111-0.59.0
 
 ## Goals
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -33,7 +33,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m110-0.58.1"
+skia = "m111-0.59.0"
 depot_tools = "73a2624"
 
 [features]


### PR DESCRIPTION
This PR updates rust-skia to support Skia's `chrome/m111` branch.

- [x] Update `README.md` ([rendered](https://github.com/pragmatrix/rust-skia/blob/m111/README.md))  
  > Most important here is to change the Skia branch name and the current Skia submodule tag at the top of the `README.md` file.
- [ ] Diff the the following files to see if the build organization has changed significantly:
  - [ ] `/BUILD.gn`
  - [ ] `/modules/skshaper/BUILD.gn`
  - [ ] `/modules/paragraph/BUILD.gn`
- [ ] Skia builds ([release notes](https://github.com/google/skia/blob/chrome/m111/RELEASE_NOTES.txt)).
- [ ] `/skia-bindings` builds.
- [ ] `/skia-safe`: Update & add new wrappers by diffing include files.  
  > Add TODOs for everything that can not be updated right now, and attempt to stay compatible with previous versions of skia-safe without trying too hard before version 1.0. Use `deprecated` attributes if needed.
  - [ ] `codec/`
  - [ ] `core/`
  - [ ] `docs/`
  - [ ] `effects/`
  - [ ] `gpu/`
    - [ ] `d3d/`
    - [ ] `gl/`
    - [ ] `mtl/`
    - [ ] `vk/`
  - [ ] `modules/`
    - [ ] `paragraph/`
    - [ ] `shaper/`
  - [ ] `pathops/`
  - [ ] `svg/`
  - [ ] `utils/`
- [ ] Review `Send` & `Sync` implementations for new wrappers.
- [ ] Review `Debug` implementation for new wrapper types and functions.
- [ ] Any pending changes in the Skia `chrome/m111` branch that aren't synchronized yet?
- [ ] Rebase on or merge with master.
- [ ] Do the `rust-skia:` commits in the `skia-bindings/skia` subdirectory match with `master`.
- [ ] Update versions of `skia-bindings/Cargo.toml` and `skia-safe/Cargo.toml` and also add the version to the new `deprecated` attributes.
- [ ] Do the tags/hashes in `skia-bindings/Cargo.toml` under `[package.metadata]` match the submodules `depot_tools` and `skia`?
- [ ] Test builds we don't do on the CI:
  - [ ] Compiles to Catalyst targets on macOS (#548).
    ```zsh
    make macos-qa
    ```
- [ ] Do one final review of all the changes.
- [ ] Run `cargo doc` with all features and fix all warnings.

