### PR TITLE
Milestone 112

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Skia Submodule Status: chrome/m112 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m112-0.60.0..google:chrome/m112
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m112-0.60.0...google:chrome/m112
 [skia-ours]: https://github.com/google/skia/compare/chrome/m112...rust-skia:m112-0.60.0
 
 ## Goals

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![Windows QA](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml) [![Linux QA](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml) [![macOS QA](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml)
 
-Skia Submodule Status: chrome/m111 ([upstream changes][skia-upstream], [our changes][skia-ours]).
+Skia Submodule Status: chrome/m112 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m111-0.59.0..google:chrome/m111
-[skia-ours]: https://github.com/google/skia/compare/chrome/m111...rust-skia:m111-0.59.0
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m112-0.60.0..google:chrome/m112
+[skia-ours]: https://github.com/google/skia/compare/chrome/m112...rust-skia:m112-0.60.0
 
 ## Goals
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -33,7 +33,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m111-0.59.0"
+skia = "m112-0.60.0"
 depot_tools = "73a2624"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.60.0"
+version = "0.61.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2021"
 build = "build.rs"

--- a/skia-bindings/build_support/skia_bindgen.rs
+++ b/skia-bindings/build_support/skia_bindgen.rs
@@ -566,7 +566,7 @@ const ENUM_TABLE: &[EnumEntry] = &[
     ("GrGLFormat", rewrite::k_xxx),
     ("GrSurfaceOrigin", rewrite::k_xxx_name),
     ("GrBackendApi", rewrite::k_xxx),
-    ("GrMipmapped", rewrite::k_xxx),
+    ("Mipmapped", rewrite::k_xxx),
     ("GrRenderable", rewrite::k_xxx),
     ("GrProtected", rewrite::k_xxx),
     //

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -20,6 +20,7 @@
 #include "include/core/SkDeferredDisplayListRecorder.h"
 #include "include/core/SkDrawable.h"
 #include "include/core/SkDocument.h"
+#include "include/core/SkEncodedImageFormat.h"
 #include "include/core/SkFlattenable.h"
 #include "include/core/SkFont.h"
 #include "include/core/SkFontArguments.h"

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1,6 +1,7 @@
 #include <cassert>
 #include <tuple>
 #include <vector>
+#include <memory>
 
 #include "bindings.h"
 // codec/
@@ -1993,6 +1994,10 @@ extern "C" SkShader* C_SkShaders_Blend(SkBlender* blender, SkShader* dst, SkShad
     return SkShaders::Blend(sp(blender), sp(dst), sp(src)).release();
 }
 
+extern "C" SkShader* C_SkShaders_CoordClamp(SkShader* shader, const SkRect* subset) {
+    return SkShaders::CoordClamp(sp(shader), *subset).release();
+}
+
 extern "C" SkShader* C_SkShader_Deserialize(const void* data, size_t length) {
     // note: dynamic_cast may lead to a linker error here on iOS x86_64
     // https://github.com/rust-skia/rust-skia/issues/146
@@ -2817,6 +2822,10 @@ extern "C" SkTypeface *C_SkCustomTypefaceBuilder_detach(SkCustomTypefaceBuilder 
 extern "C" void
 C_SkCustomTypefaceBuilder_setGlyph(SkCustomTypefaceBuilder *self, SkGlyphID glyph, float advance, SkDrawable* drawable, const SkRect* bounds) {
     self->setGlyph(glyph, advance, sp(drawable), *bounds);
+}
+
+extern "C" SkTypeface* C_SkCustomTypefaceBuilder_FromData(SkData* data, const SkFontArguments* fontArguments) {
+    return SkCustomTypefaceBuilder::MakeFromStream(SkMemoryStream::Make(sp(data)), *fontArguments).release();
 }
 
 extern "C" SkCanvas* C_SkMakeNullCanvas() {

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
 license = "MIT"
 
-version = "0.60.0"
+version = "0.61.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2021"
 
@@ -48,7 +48,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 [dependencies]
 bitflags = "2.0"
 lazy_static = "1.4"
-skia-bindings = { version = "=0.60.0", path = "../skia-bindings", default-features = false }
+skia-bindings = { version = "=0.61.0", path = "../skia-bindings", default-features = false }
 
 # D3D types
 winapi = { version = "0.3.9", features = ["d3d12", "dxgi"], optional = true }

--- a/skia-safe/src/core/bitmap.rs
+++ b/skia-safe/src/core/bitmap.rs
@@ -733,6 +733,8 @@ impl Bitmap {
             .if_true_then_some(|| pixmap.borrows(self))
     }
 
+    /// Make a shader with the specified tiling, matrix and sampling.  
+    /// Defaults to clamp in both X and Y.
     pub fn to_shader<'a>(
         &self,
         tile_modes: impl Into<Option<(TileMode, TileMode)>>,

--- a/skia-safe/src/core/color_type.rs
+++ b/skia-safe/src/core/color_type.rs
@@ -16,6 +16,7 @@ pub enum ColorType {
     BGRA1010102 = SkColorType::kBGRA_1010102_SkColorType as _,
     RGB101010x = SkColorType::kRGB_101010x_SkColorType as _,
     BGR101010x = SkColorType::kBGR_101010x_SkColorType as _,
+    BGR101010xXR = SkColorType::kBGR_101010x_XR_SkColorType as _,
     Gray8 = SkColorType::kGray_8_SkColorType as _,
     RGBAF16Norm = SkColorType::kRGBA_F16Norm_SkColorType as _,
     RGBAF16 = SkColorType::kRGBA_F16_SkColorType as _,

--- a/skia-safe/src/core/graphics.rs
+++ b/skia-safe/src/core/graphics.rs
@@ -82,7 +82,6 @@ pub fn set_flags(flags: impl AsRef<str>) {
 
 // TODO: ImageGeneratorFromEncodedDataFactory
 // TODO: SetOpenTypeSVGDecoderFactory & GetOpenTypeSVGDecoderFactory
-// TODO: SetVariableColrV1EnabledFunc & GetVariableColrV1Enabled
 
 pub fn allow_jit() {
     unsafe { SkGraphics::AllowJIT() }

--- a/skia-safe/src/core/milestone.rs
+++ b/skia-safe/src/core/milestone.rs
@@ -1,1 +1,1 @@
-pub const MILESTONE: usize = 111;
+pub const MILESTONE: usize = 112;

--- a/skia-safe/src/core/shader.rs
+++ b/skia-safe/src/core/shader.rs
@@ -97,7 +97,7 @@ impl Shader {
 }
 
 pub mod shaders {
-    use crate::{prelude::*, Blender, Color, Color4f, ColorSpace, Shader};
+    use crate::{prelude::*, Blender, Color, Color4f, ColorSpace, Rect, Shader};
     use skia_bindings as sb;
 
     pub fn empty() -> Shader {
@@ -129,5 +129,11 @@ pub mod shaders {
             )
         })
         .unwrap()
+    }
+
+    pub fn coord_clamp(shader: impl Into<Shader>, rect: impl AsRef<Rect>) -> Option<Shader> {
+        Shader::from_ptr(unsafe {
+            sb::C_SkShaders_CoordClamp(shader.into().into_ptr(), rect.as_ref().native())
+        })
     }
 }

--- a/skia-safe/src/core/typeface.rs
+++ b/skia-safe/src/core/typeface.rs
@@ -3,7 +3,7 @@ use crate::{
     font_parameters::VariationAxis,
     interop::{self, MemoryStream, NativeStreamBase, StreamAsset},
     prelude::*,
-    Data, FontArguments, FontStyle, GlyphId, Rect, TextEncoding, Unichar,
+    Data, FontArguments, FontStyle, FourByteTag, GlyphId, Rect, TextEncoding, Unichar,
 };
 use skia_bindings::{self as sb, SkRefCntBase, SkTypeface, SkTypeface_LocalizedStrings};
 use std::{ffi, fmt, mem, ptr};
@@ -21,6 +21,8 @@ pub struct LocalizedString {
     pub string: String,
     pub language: String,
 }
+
+pub type FactoryId = FourByteTag;
 
 pub type Typeface = RCHandle<SkTypeface>;
 unsafe_send_sync!(Typeface);
@@ -49,7 +51,6 @@ impl fmt::Debug for Typeface {
 }
 
 impl Typeface {
-    // Canonical new:
     pub fn new(family_name: impl AsRef<str>, font_style: FontStyle) -> Option<Self> {
         Self::from_name(family_name, font_style)
     }
@@ -294,6 +295,8 @@ impl Typeface {
     pub fn bounds(&self) -> Rect {
         Rect::from_native_c(unsafe { sb::C_SkTypeface_getBounds(self.native()) })
     }
+
+    // TODO: Register()
 }
 
 pub type LocalizedStringsIter = RefHandle<SkTypeface_LocalizedStrings>;

--- a/skia-safe/src/core/types.rs
+++ b/skia-safe/src/core/types.rs
@@ -6,7 +6,7 @@ use std::ops::Deref;
 // FourByteTag
 //
 
-#[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Default, Debug)]
 #[repr(transparent)]
 pub struct FourByteTag(SkFourByteTag);
 

--- a/skia-safe/src/effects/runtime_effect.rs
+++ b/skia-safe/src/effects/runtime_effect.rs
@@ -435,4 +435,5 @@ impl ChildPtr {
     }
 }
 
-// TODO: wrap SkRuntimeEffectBuilder, SkRuntimeShaderBuilder, SkRuntimeBlendBuilder
+// TODO: wrap SkRuntimeEffectBuilder, SkRuntimeShaderBuilder, SkRuntimeColorFilterBuilder,
+// SkRuntimeBlendBuilder

--- a/skia-safe/src/utils/custom_typeface.rs
+++ b/skia-safe/src/utils/custom_typeface.rs
@@ -1,4 +1,7 @@
-use crate::{prelude::*, Drawable, FontMetrics, FontStyle, GlyphId, Path, Rect, Typeface};
+use crate::{
+    prelude::*, typeface::FactoryId, Data, Drawable, FontArguments, FontMetrics, FontStyle,
+    GlyphId, Path, Rect, Typeface,
+};
 use skia_bindings::{self as sb, SkCustomTypefaceBuilder};
 use std::fmt;
 
@@ -63,6 +66,17 @@ impl CustomTypefaceBuilder {
 
     pub fn detach(&mut self) -> Option<Typeface> {
         Typeface::from_ptr(unsafe { sb::C_SkCustomTypefaceBuilder_detach(self.native_mut()) })
+    }
+
+    pub const FACTORY_ID: FactoryId = FactoryId::from_chars('u', 's', 'e', 'r');
+
+    // TODO: MakeFromStream
+    // TODO: This is a stand-in for `from_stream`.
+
+    pub fn from_data(data: impl Into<Data>, font_arguments: &FontArguments) -> Option<Typeface> {
+        Typeface::from_ptr(unsafe {
+            sb::C_SkCustomTypefaceBuilder_FromData(data.into().into_ptr(), font_arguments.native())
+        })
     }
 }
 


### PR DESCRIPTION
This PR updates rust-skia to support Skia's `chrome/m112` branch.

- [x] Update `README.md` ([rendered](https://github.com/pragmatrix/rust-skia/blob/m112/README.md))  
  > Most important here is to change the Skia branch name and the current Skia submodule tag at the top of the `README.md` file.
- [x] Diff the the following files to see if the build organization has changed significantly:
  - [x] `/BUILD.gn`
  - [x] `/modules/skshaper/BUILD.gn`
  - [x] `/modules/paragraph/BUILD.gn`
- [x] Skia builds ([release notes](https://github.com/google/skia/blob/chrome/m112/RELEASE_NOTES.txt)).
- [x] `/skia-bindings` builds.
- [x] `/skia-safe`: Update & add new wrappers by diffing include files.  
  > Add TODOs for everything that can not be updated right now, and attempt to stay compatible with previous versions of skia-safe without trying too hard before version 1.0. Use `deprecated` attributes if needed.
  - [x] `codec/`
  - [x] `core/`
  - [x] `docs/`
  - [x] `effects/`
  - [x] `gpu/`
    - [x] `d3d/`
    - [x] `gl/`
    - [x] `mtl/`
    - [x] `vk/`
  - [x] `modules/`
    - [x] `paragraph/`
    - [x] `shaper/`
  - [x] `pathops/`
  - [x] `svg/`
  - [x] `utils/`
- [x] Review `Send` & `Sync` implementations for new wrappers.
- [x] Review `Debug` implementation for new wrapper types and functions.
- [x] Any pending changes in the Skia `chrome/m112` branch that aren't synchronized yet?
- [x] Rebase on or merge with master.
- [x] Do the `rust-skia:` commits in the `skia-bindings/skia` subdirectory match with `master`.
- [x] Update versions of `skia-bindings/Cargo.toml` and `skia-safe/Cargo.toml` and also add the version to the new `deprecated` attributes.
- [x] Do the tags/hashes in `skia-bindings/Cargo.toml` under `[package.metadata]` match the submodules `depot_tools` and `skia`?
- [ ] Test builds we don't do on the CI:
  - [ ] Compiles to Catalyst targets on macOS (#548).
    ```zsh
    make macos-qa
    ```
- [x] Do one final review of all the changes.
- [x] Run `cargo doc` with all features and fix all warnings.

