### PR TITLE
Fix Codec memory leak

### DIFF
--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -108,6 +108,10 @@ extern "C" SkCodec* C_SkCodec_MakeFromData(SkData* data) {
     return SkCodec::MakeFromData(sp(data)).release();
 }
 
+extern "C" void C_SkCodec_delete(SkCodec* self) {
+    delete self;
+}
+
 extern "C" void C_SkCodec_getInfo(const SkCodec* self, SkImageInfo* info) {
     *info = self->getInfo();
 }

--- a/skia-safe/src/codec/_codec.rs
+++ b/skia-safe/src/codec/_codec.rs
@@ -3,7 +3,7 @@ use crate::{
     IRect, ISize, Image, ImageInfo, Pixmap, YUVAPixmapInfo, YUVAPixmaps,
 };
 use ffi::CStr;
-use skia_bindings::{self as sb, SkCodec, SkCodec_Options, SkRefCntBase};
+use skia_bindings::{self as sb, SkCodec, SkCodec_Options};
 use std::{ffi, fmt, mem, ptr};
 
 pub use sb::SkCodec_Result as Result;
@@ -34,12 +34,12 @@ pub struct Options {
 pub use sb::SkCodec_SkScanlineOrder as ScanlineOrder;
 variant_name!(ScanlineOrder::BottomUp, scanline_order_naming);
 
-pub type Codec = RCHandle<SkCodec>;
+pub type Codec = RefHandle<SkCodec>;
 
-impl NativeBase<SkRefCntBase> for SkCodec {}
-
-impl NativeRefCountedBase for SkCodec {
-    type Base = SkRefCntBase;
+impl NativeDrop for SkCodec {
+    fn drop(&mut self) {
+        unsafe { sb::C_SkCodec_delete(self) }
+    }
 }
 
 impl fmt::Debug for Codec {


### PR DESCRIPTION
The wrong handle type (RCHandle instead of RefHandle) was used to encapsulate `SkCodec`, causing memory leaks as reported in #777 and potentially UB. This PR changes the handle which makes the memory leaks disappear.