### PR TITLE
Add binding for SkFontMgr::RefEmpty().

### DIFF
--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1443,6 +1443,10 @@ extern "C" SkFontMgr* C_SkFontMgr_RefDefault() {
     return SkFontMgr::RefDefault().release();
 }
 
+extern "C" SkFontMgr* C_SkFontMgr_RefEmpty() {
+    return SkFontMgr::RefEmpty().release();
+}
+
 //
 // core/SkFontParameters.h
 //

--- a/skia-safe/src/core/font_mgr.rs
+++ b/skia-safe/src/core/font_mgr.rs
@@ -113,6 +113,10 @@ impl FontMgr {
         FontMgr::from_ptr(unsafe { sb::C_SkFontMgr_RefDefault() }).unwrap()
     }
 
+    pub fn empty() -> Self {
+        FontMgr::from_ptr(unsafe { sb::C_SkFontMgr_RefEmpty() }).unwrap()
+    }
+
     pub fn count_families(&self) -> usize {
         unsafe { self.native().countFamilies().try_into().unwrap() }
     }


### PR DESCRIPTION
This was added to skia in
https://github.com/google/skia/commit/5b5a06c1fb0b137b34a3427127edb7c3298dd2ea.
