### PR TITLE
feat: add Codec::get_frame_info() and export Codec::NoFrame

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,7 @@
         "emsdk",
         "fembed",
         "Fira",
+        "frameinfo",
         "fvisibility",
         "heightmaps",
         "isystem",

--- a/skia-bindings/build_support/skia_bindgen.rs
+++ b/skia-bindings/build_support/skia_bindgen.rs
@@ -633,6 +633,9 @@ const ENUM_TABLE: &[EnumEntry] = &[
     ("ColorSpace", rewrite::k_xxx),
     // m109: SkGradientShader::Interpolation::HueMethod
     ("HueMethod", rewrite::k_xxx),
+    // SkCodecAnimation
+    ("DisposalMethod", rewrite::k_xxx),
+    ("Blend", rewrite::k_xxx),
 ];
 
 pub(crate) mod rewrite {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -7,6 +7,7 @@
 // codec/
 #include "include/codec/SkEncodedOrigin.h"
 #include "include/codec/SkCodec.h"
+#include "include/codec/SkCodecAnimation.h"
 // core/
 #include "include/core/SkAnnotation.h"
 #include "include/core/SkBlendMode.h"

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -166,6 +166,10 @@ extern "C" int C_SkCodec_getFrameCount(SkCodec* self) {
     return self->getFrameCount();
 }
 
+extern "C" void C_SkFrameInfo_Construct(SkCodec::FrameInfo* uninitialized) {
+    new (uninitialized) SkCodec::FrameInfo();
+}
+
 extern "C" bool C_SkCodec_getFrameInfo(SkCodec* self, int index, SkCodec::FrameInfo* info) {
     return self->getFrameInfo(index, info);
 }

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -166,6 +166,10 @@ extern "C" int C_SkCodec_getFrameCount(SkCodec* self) {
     return self->getFrameCount();
 }
 
+extern "C" bool C_SkCodec_getFrameInfo(SkCodec* self, int index, SkCodec::FrameInfo* info) {
+    return self->getFrameInfo(index, info);
+}
+
 extern "C" int C_SkCodec_getRepetitionCount(SkCodec* self) {
     return self->getRepetitionCount();
 }

--- a/skia-safe/src/codec.rs
+++ b/skia-safe/src/codec.rs
@@ -1,6 +1,7 @@
 // TODO: wrap SkAndroidCodec.h, SkCodecAnimation.h
 
 mod _codec;
+pub mod codec_animation;
 pub use _codec::*;
 
 mod encoded_origin;

--- a/skia-safe/src/codec/_codec.rs
+++ b/skia-safe/src/codec/_codec.rs
@@ -3,7 +3,7 @@ use crate::{
     IRect, ISize, Image, ImageInfo, Pixmap, YUVAPixmapInfo, YUVAPixmaps,
 };
 use ffi::CStr;
-use skia_bindings::{self as sb, SkCodec, SkCodec_Options, SkCodec_FrameInfo, SkAlphaType};
+use skia_bindings::{self as sb, SkAlphaType, SkCodec, SkCodec_FrameInfo, SkCodec_Options};
 use std::{ffi, fmt, mem, ptr};
 
 pub use sb::SkCodec_Result as Result;
@@ -32,18 +32,18 @@ pub struct Options {
     pub prior_frame: i32,
 }
 
-#[repr(C)] 
-#[derive(Copy, Clone, Debug)] 
-pub struct FrameInfo { 
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct FrameInfo {
     pub required_frame: i32,
     pub duration: i32,
     pub fully_received: bool,
     pub alpha_type: SkAlphaType,
     pub has_alpha_within_bounds: bool,
     pub rect: IRect,
-} 
- 
-native_transmutable!(SkCodec_FrameInfo, FrameInfo, frameinfo_layout); 
+}
+
+native_transmutable!(SkCodec_FrameInfo, FrameInfo, frameinfo_layout);
 
 impl Default for FrameInfo {
     fn default() -> Self {

--- a/skia-safe/src/codec/_codec.rs
+++ b/skia-safe/src/codec/_codec.rs
@@ -29,8 +29,7 @@ pub struct Options {
     pub zero_initialized: ZeroInitialized,
     pub subset: Option<IRect>,
     pub frame_index: usize,
-    // allow `SkCodec_kNoFrame`
-    pub prior_frame: i32,
+    pub prior_frame: Option<usize>,
 }
 
 #[repr(C)]
@@ -56,8 +55,6 @@ impl Default for FrameInfo {
 
 pub use sb::SkCodec_SkScanlineOrder as ScanlineOrder;
 variant_name!(ScanlineOrder::BottomUp);
-
-pub use sb::SkCodec_kNoFrame as NoFrame;
 
 pub type Codec = RefHandle<SkCodec>;
 
@@ -179,7 +176,10 @@ impl Codec {
             fZeroInitialized: options.zero_initialized,
             fSubset: options.subset.native().as_ptr_or_null(),
             fFrameIndex: options.frame_index.try_into().unwrap(),
-            fPriorFrame: options.prior_frame,
+            fPriorFrame: match options.prior_frame {
+                None => sb::SkCodec_kNoFrame,
+                Some(frame) => frame.try_into().expect("invalid prior frame"),
+            },
         }
     }
 

--- a/skia-safe/src/codec/_codec.rs
+++ b/skia-safe/src/codec/_codec.rs
@@ -176,7 +176,7 @@ impl Codec {
             fZeroInitialized: options.zero_initialized,
             fSubset: options.subset.native().as_ptr_or_null(),
             fFrameIndex: options.frame_index.try_into().unwrap(),
-            fPriorFrame: options.prior_frame.try_into().unwrap(),
+            fPriorFrame: options.prior_frame,
         }
     }
 

--- a/skia-safe/src/codec/_codec.rs
+++ b/skia-safe/src/codec/_codec.rs
@@ -1,9 +1,9 @@
 use crate::{
-    prelude::*, yuva_pixmap_info::SupportedDataTypes, Data, EncodedImageFormat, EncodedOrigin,
-    IRect, ISize, Image, ImageInfo, Pixmap, YUVAPixmapInfo, YUVAPixmaps,
+    prelude::*, yuva_pixmap_info::SupportedDataTypes, AlphaType, Data, EncodedImageFormat,
+    EncodedOrigin, IRect, ISize, Image, ImageInfo, Pixmap, YUVAPixmapInfo, YUVAPixmaps,
 };
 use ffi::CStr;
-use skia_bindings::{self as sb, SkAlphaType, SkCodec, SkCodec_FrameInfo, SkCodec_Options};
+use skia_bindings::{self as sb, SkCodec, SkCodec_FrameInfo, SkCodec_Options};
 use std::{ffi, fmt, mem, ptr};
 
 pub use sb::SkCodec_Result as Result;
@@ -38,7 +38,7 @@ pub struct FrameInfo {
     pub required_frame: i32,
     pub duration: i32,
     pub fully_received: bool,
-    pub alpha_type: SkAlphaType,
+    pub alpha_type: AlphaType,
     pub has_alpha_within_bounds: bool,
     pub rect: IRect,
 }

--- a/skia-safe/src/codec/_codec.rs
+++ b/skia-safe/src/codec/_codec.rs
@@ -1,3 +1,4 @@
+use super::codec_animation;
 use crate::{
     prelude::*, yuva_pixmap_info::SupportedDataTypes, AlphaType, Data, EncodedImageFormat,
     EncodedOrigin, IRect, ISize, Image, ImageInfo, Pixmap, YUVAPixmapInfo, YUVAPixmaps,
@@ -40,6 +41,8 @@ pub struct FrameInfo {
     pub fully_received: bool,
     pub alpha_type: AlphaType,
     pub has_alpha_within_bounds: bool,
+    pub disposal_method: codec_animation::DisposalMethod,
+    pub blend: codec_animation::Blend,
     pub rect: IRect,
 }
 
@@ -304,19 +307,15 @@ impl Codec {
     }
 
     pub fn get_frame_info(&mut self, index: usize) -> Option<FrameInfo> {
-        let mut infos = FrameInfo::default();
-        let has_frame = unsafe {
+        let mut info = FrameInfo::default();
+        unsafe {
             sb::C_SkCodec_getFrameInfo(
                 self.native_mut(),
                 index.try_into().unwrap(),
-                infos.native_mut(),
+                info.native_mut(),
             )
-        };
-        if has_frame {
-            Some(infos)
-        } else {
-            None
         }
+        .then_some(info)
     }
 
     pub fn get_repetition_count(&mut self) -> Option<usize> {

--- a/skia-safe/src/codec/_codec.rs
+++ b/skia-safe/src/codec/_codec.rs
@@ -303,10 +303,14 @@ impl Codec {
             .unwrap()
     }
 
-    pub fn get_frame_info(&mut self, index: i32) -> FrameInfo {
+    pub fn get_frame_info(&mut self, index: usize) -> Option<FrameInfo> {
         let mut infos = FrameInfo::default();
-        unsafe { sb::C_SkCodec_getFrameInfo(self.native_mut(), index, infos.native_mut()) };
-        infos
+        let has_frame = unsafe { sb::C_SkCodec_getFrameInfo(self.native_mut(), index.try_into().unwrap(), infos.native_mut()) };
+        if has_frame {
+            Some(infos)
+        } else {
+            None
+        }
     }
 
     pub fn get_repetition_count(&mut self) -> Option<usize> {

--- a/skia-safe/src/codec/_codec.rs
+++ b/skia-safe/src/codec/_codec.rs
@@ -3,7 +3,7 @@ use crate::{
     IRect, ISize, Image, ImageInfo, Pixmap, YUVAPixmapInfo, YUVAPixmaps,
 };
 use ffi::CStr;
-use skia_bindings::{self as sb, SkCodec, SkCodec_Options};
+use skia_bindings::{self as sb, SkCodec, SkCodec_Options, SkCodec_FrameInfo};
 use std::{ffi, fmt, mem, ptr};
 
 pub use sb::SkCodec_Result as Result;
@@ -28,11 +28,14 @@ pub struct Options {
     pub zero_initialized: ZeroInitialized,
     pub subset: Option<IRect>,
     pub frame_index: usize,
-    pub prior_frame: usize,
+    // allow `SkCodec_kNoFrame`
+    pub prior_frame: u64,
 }
 
 pub use sb::SkCodec_SkScanlineOrder as ScanlineOrder;
 variant_name!(ScanlineOrder::BottomUp);
+
+pub use sb::SkCodec_kNoFrame as NoFrame;
 
 pub type Codec = RefHandle<SkCodec>;
 
@@ -281,8 +284,9 @@ impl Codec {
             .unwrap()
     }
 
-    // TODO: FrameInfo
-    // TODO: getFrameInfo
+    pub fn get_frame_info(&mut self) -> SkCodec_FrameInfo {
+        unsafe { sb::SkCodec_getFrameInfo(self.native_mut()) }
+    }
 
     pub fn get_repetition_count(&mut self) -> Option<usize> {
         const REPETITION_COUNT_INFINITE: i32 = -1;

--- a/skia-safe/src/codec/_codec.rs
+++ b/skia-safe/src/codec/_codec.rs
@@ -305,7 +305,13 @@ impl Codec {
 
     pub fn get_frame_info(&mut self, index: usize) -> Option<FrameInfo> {
         let mut infos = FrameInfo::default();
-        let has_frame = unsafe { sb::C_SkCodec_getFrameInfo(self.native_mut(), index.try_into().unwrap(), infos.native_mut()) };
+        let has_frame = unsafe {
+            sb::C_SkCodec_getFrameInfo(
+                self.native_mut(),
+                index.try_into().unwrap(),
+                infos.native_mut(),
+            )
+        };
         if has_frame {
             Some(infos)
         } else {

--- a/skia-safe/src/codec/_codec.rs
+++ b/skia-safe/src/codec/_codec.rs
@@ -284,8 +284,10 @@ impl Codec {
             .unwrap()
     }
 
-    pub fn get_frame_info(&mut self) -> SkCodec_FrameInfo {
-        unsafe { sb::SkCodec_getFrameInfo(self.native_mut()) }
+    pub fn get_frame_info(&mut self, index: i32) -> SkCodec_FrameInfo {
+        let infos = SkCodec_FrameInfo {};
+        unsafe { sb::C_SkCodec_getFrameInfo(self.native_mut(), index, &mut infos) };
+        infos
     }
 
     pub fn get_repetition_count(&mut self) -> Option<usize> {

--- a/skia-safe/src/codec/codec_animation.rs
+++ b/skia-safe/src/codec/codec_animation.rs
@@ -1,0 +1,7 @@
+use skia_bindings as sb;
+
+pub type Blend = sb::SkCodecAnimation_Blend;
+variant_name!(Blend::SrcOver);
+
+pub type DisposalMethod = sb::SkCodecAnimation_DisposalMethod;
+variant_name!(DisposalMethod::Keep);


### PR DESCRIPTION
Hello, 

I've started to add missing methods from `SkCodec` to be able to use it for decoding GIF formats. 

I've exported `SkCodec_kNoFrame` and updated `Options.prior_frame` to be able to use it when using `get_image` on a GIF. 

I've also tried to export `get_frame_info` method (skia reference [here](https://skia.googlesource.com/skia/+/refs/heads/chrome/m112/src/codec/SkCodec.cpp#793)) but generated bindings export the wrong return type:

```rust
extern "C" {
    #[link_name = "\u{1}__ZN7SkCodec12getFrameInfoEv"]
    pub fn SkCodec_getFrameInfo(this: *mut SkCodec) -> u8;
}
```

I haven't really used `binding` so if you know how to resolve this, I'm listening

Thank you