### PR TITLE
Support building not from a git repo

### DIFF
--- a/skia-bindings/build_support/binary_cache/download.rs
+++ b/skia-bindings/build_support/binary_cache/download.rs
@@ -100,7 +100,7 @@ fn download_dependencies() {
     }
 }
 
-fn dir_not_empty(dir_path: &PathBuf) -> bool {
+fn dir_not_empty(dir_path: &Path) -> bool {
     dir_path
         .read_dir()
         .map(|mut contents| contents.next().is_some())

--- a/skia-bindings/build_support/binary_cache/download.rs
+++ b/skia-bindings/build_support/binary_cache/download.rs
@@ -101,11 +101,9 @@ fn download_dependencies() {
 }
 
 fn dir_not_empty(dir_path: &PathBuf) -> bool {
-    dir_path.read_dir()
-        .map(|mut contents| contents
-            .next()
-            .is_some()
-        )
+    dir_path
+        .read_dir()
+        .map(|mut contents| contents.next().is_some())
         .unwrap_or(false)
 }
 

--- a/skia-bindings/build_support/binary_cache/download.rs
+++ b/skia-bindings/build_support/binary_cache/download.rs
@@ -20,16 +20,21 @@ pub fn resolve_dependencies() {
     }
 
     // Not in a crate, assuming a git repo. Update all submodules.
-    assert!(
-        Command::new("git")
-            .args(["submodule", "update", "--init", "--depth", "1"])
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit())
-            .status()
-            .unwrap()
-            .success(),
-        "`git submodule update` failed"
-    );
+    let submodules_updated = Command::new("git")
+        .args(["submodule", "update", "--init", "--depth", "1"])
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .unwrap()
+        .success();
+
+    // If `git submodule update` failed, either git is not installed,
+    // or we're not building from a git repo.
+    // This can happen if the repo is downloaded as a ZIP archive.
+    if !submodules_updated {
+        println!("`git submodule update` failed. Falling back to HTTP download");
+        download_dependencies();
+    }
 }
 
 /// Downloads the `skia` and `depot_tools` from their repositories.
@@ -44,8 +49,12 @@ fn download_dependencies() {
 
         let dir = PathBuf::from(repo_name);
 
-        // Directory exists => assume that the download of the archive was successful.
-        if dir.exists() {
+        // If the repo is downloaded from GitHub as a ZIP archive,
+        // the directories for submodules will exist but will be empty.
+        // If the directory exists and is not empty,
+        // assume the download has succeeded in previous build runs,
+        // so we can skip it.
+        if dir_not_empty(&dir) {
             continue;
         }
 
@@ -89,6 +98,15 @@ fn download_dependencies() {
         // Move unpack directory to the target repository directory
         fs::rename(unpack_dir, repo_name).expect("failed to move directory");
     }
+}
+
+fn dir_not_empty(dir_path: &PathBuf) -> bool {
+    dir_path.read_dir()
+        .map(|mut contents| contents
+            .next()
+            .is_some()
+        )
+        .unwrap_or(false)
 }
 
 // Specifies where to download Skia and Depot Tools archives from.


### PR DESCRIPTION
Added support for building and running examples when the repo is not cloned using git but downloaded as a ZIP archive instead.

Currently the build script assumes that if we're not building as a crate, we must be in a git repo and tries to run the `git submodules update` command. If that fails, the build script panics.
The merge request checks the exit code of the git command and, in case of a failure, falls back to downloading the dependencies as TAR archives.

Another problem was, when the repo is downloaded as a ZIP, the directories for dependencies (`skia` and `depot_tools`) exist but are empty, so I added a check to make sure they also contain something.