### PR TITLE
Fix memory corruption when creating YUVABackendTextures

### DIFF
--- a/skia-bindings/src/gpu.cpp
+++ b/skia-bindings/src/gpu.cpp
@@ -301,6 +301,19 @@ extern "C" GrBackendApi C_GrBackendDrawableInfo_backend(const GrBackendDrawableI
 // gpu/GrYUVABackendTextures.h
 //
 
+extern "C" void C_GrYUVABackendTextures_construct(
+    GrYUVABackendTextures* uninitialized,
+    const SkYUVAInfo& yuvaInfo,
+    const GrBackendTexture* const *backend_textures,
+    GrSurfaceOrigin textureOrigin
+) {
+    GrBackendTexture textures[SkYUVAInfo::kMaxPlanes];
+    for (int i = 0; i < SkYUVAInfo::kMaxPlanes; ++i) {
+        textures[i] = *backend_textures[i];
+    }
+    new(uninitialized) GrYUVABackendTextures(yuvaInfo, textures, textureOrigin);
+}
+
 extern "C" void C_GrYUVABackendTextureInfo_destruct(GrYUVABackendTextureInfo* self) {
     self->~GrYUVABackendTextureInfo();
 }

--- a/skia-safe/src/gpu/yuva_backend_textures.rs
+++ b/skia-safe/src/gpu/yuva_backend_textures.rs
@@ -138,15 +138,25 @@ impl YUVABackendTextures {
         if textures.len() != info.num_planes() {
             return None;
         }
-        let mut textures = textures.to_vec();
-        textures.extend(
-            iter::repeat_with(BackendTexture::new_invalid)
-                .take(YUVAInfo::MAX_PLANES - textures.len()),
-        );
-        assert_eq!(textures.len(), YUVAInfo::MAX_PLANES);
-        let n = unsafe {
-            GrYUVABackendTextures::new(info.native(), textures[0].native(), texture_origin)
-        };
+        let new_invalid = BackendTexture::new_invalid();
+        let new_invalid_ptr = new_invalid.native() as *const _;
+
+        let mut texture_handles = textures
+            .iter()
+            .map(|tex| tex.native() as *const _)
+            .collect::<Vec<_>>();
+        texture_handles
+            .extend(iter::repeat(new_invalid_ptr).take(YUVAInfo::MAX_PLANES - textures.len()));
+        assert_eq!(texture_handles.len(), YUVAInfo::MAX_PLANES);
+
+        let n = construct(|cloned| unsafe {
+            sb::C_GrYUVABackendTextures_construct(
+                cloned,
+                info.native(),
+                texture_handles.as_ptr(),
+                texture_origin,
+            )
+        });
         Self::native_is_valid(&n).if_true_then_some(|| Self::from_native_c(n))
     }
 


### PR DESCRIPTION
The C++ constructor expects an array of GrBackendTexture. Since #751 the BackendTexture type in Rust is not a GrBackendTexture anymore though, but a refhandle, so we were passing a pointer.

Work around this by not calling the C++ constructor directly anymore but use a helper function in gpu.cpp that convers the array of pointers to an array of GrBackendTexture objects.