### PR TITLE
fix: Default `thickness_multiplier` to 1.0 in `Decoration`

### DIFF
--- a/skia-safe/src/modules/paragraph/text_style.rs
+++ b/skia-safe/src/modules/paragraph/text_style.rs
@@ -69,7 +69,7 @@ impl Default for Decoration {
             mode: TextDecoration::default(),
             color: Color::default(),
             style: TextDecorationStyle::default(),
-            thickness_multiplier: 1.0
+            thickness_multiplier: 1.0,
         }
     }
 }

--- a/skia-safe/src/modules/paragraph/text_style.rs
+++ b/skia-safe/src/modules/paragraph/text_style.rs
@@ -65,11 +65,8 @@ pub struct Decoration {
 impl Default for Decoration {
     fn default() -> Self {
         Self {
-            ty: TextDecoration::default(),
-            mode: TextDecoration::default(),
-            color: Color::default(),
-            style: TextDecorationStyle::default(),
-            thickness_multiplier: 1.0
+            thickness_multiplier: 1.0,
+            ..Default::default()
         }
     }
 }

--- a/skia-safe/src/modules/paragraph/text_style.rs
+++ b/skia-safe/src/modules/paragraph/text_style.rs
@@ -53,13 +53,25 @@ fn style_type_member_naming() {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq, Default, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Decoration {
     pub ty: TextDecoration,
     pub mode: TextDecorationMode,
     pub color: Color,
     pub style: TextDecorationStyle,
     pub thickness_multiplier: scalar,
+}
+
+impl Default for Decoration {
+    fn default() -> Self {
+        Self {
+            ty: TextDecoration::default(),
+            mode: TextDecoration::default(),
+            color: Color::default(),
+            style: TextDecorationStyle::default(),
+            thickness_multiplier: 1.0
+        }
+    }
 }
 
 native_transmutable!(

--- a/skia-safe/src/modules/paragraph/text_style.rs
+++ b/skia-safe/src/modules/paragraph/text_style.rs
@@ -65,8 +65,11 @@ pub struct Decoration {
 impl Default for Decoration {
     fn default() -> Self {
         Self {
-            thickness_multiplier: 1.0,
-            ..Default::default()
+            ty: TextDecoration::default(),
+            mode: TextDecoration::default(),
+            color: Color::default(),
+            style: TextDecorationStyle::default(),
+            thickness_multiplier: 1.0
         }
     }
 }


### PR DESCRIPTION
Having a `0.0` (which is what Rust puts by default) in `thickness_multiplier` will crash the process. So, better to leave it as `1.0` which probably makes more sense, right?

![image](https://github.com/rust-skia/rust-skia/assets/38158676/37be9ec3-dc5b-4efa-b8c9-f60dff33bf94)
