### PR TITLE
Override AR when building with Emscripten

### DIFF
--- a/skia-bindings/build_support/platform/emscripten.rs
+++ b/skia-bindings/build_support/platform/emscripten.rs
@@ -9,6 +9,7 @@ impl PlatformDetails for Emscripten {
         builder
             .arg("cc", quote("emcc"))
             .arg("cxx", quote("em++"))
+            .arg("ar", quote("emar"))
             .arg("skia_gl_standard", quote("webgl"))
             .arg("skia_use_freetype", yes())
             .arg("skia_use_system_freetype2", no())


### PR DESCRIPTION
The builtin `ar` on macOS doesn't support emscripten object files so they provide an `emar` wrapper around `llvm-ar` (see [Emscripten Troubleshooting](https://emscripten.org/docs/compiling/Building-Projects.html#troubleshooting)).

While rust-skia was overriding cc and cxx with the emscripten versions, it wasn't overriding ar.

Skia does the same thing for their WASM builds: https://github.com/google/skia/blob/b238c09fe9590e0b9925fc5e4208f9e65174fa3d/gn/toolchain/BUILD.gn#L431-L446
