### PR TITLE
Fix build on Windows from within vcvars shell

### DIFF
--- a/skia-bindings/build_support/platform/windows.rs
+++ b/skia-bindings/build_support/platform/windows.rs
@@ -90,7 +90,10 @@ fn generic_link_libraries(features: &Features) -> Vec<String> {
 /// TODO: sophisticate: <https://github.com/alexcrichton/cc-rs/blob/master/src/windows_registry.rs0>
 fn resolve_vc() -> Option<PathBuf> {
     if let Some(install_dir) = cargo::env_var("VCINSTALLDIR") {
-        return Some(PathBuf::from(install_dir));
+        // vcvars.bat may end up setting VCINSTALLDIR to a path with trailing backslash, we
+        // invoke GN  as win_vc="the path", and we end up with "foo\", which erroneously
+        // escapes the quote instead of closing.
+        return Some(PathBuf::from(install_dir.trim_end_matches('\\')));
     }
 
     let releases = [("Program Files", "2022"), ("Program Files (x86)", "2019")];


### PR DESCRIPTION
vcvars on my machine (and in the GitHub actions VMs) sets VCINSTALLDIR to something like C:\Program Files\Microsoft Visual Studio\2022\Community\VC\, where the trailing backslash conflicts with the quote that is appended.

That results in the following GN args

 ... win_vc="C:\Program Files\Microsoft Visual Studio\2022\Community\VC\" clang_win

and this way win_vc is not properly terminated.