### PR TITLE
add shadow flags that were missing from bitflags enum

### DIFF
--- a/skia-safe/src/utils/shadow_utils.rs
+++ b/skia-safe/src/utils/shadow_utils.rs
@@ -8,7 +8,12 @@ bitflags! {
         const TRANSPARENT_OCCLUDER = sb::SkShadowFlags_kTransparentOccluder_ShadowFlag as u32;
         #[allow(clippy::unnecessary_cast)]
         const GEOMETRIC_ONLY = sb::SkShadowFlags_kGeometricOnly_ShadowFlag as u32;
-        const ALL = Self::TRANSPARENT_OCCLUDER.bits() | Self::GEOMETRIC_ONLY.bits();
+        #[allow(clippy::unnecessary_cast)]
+        const DIRECTIONAL_LIGHT = sb::SkShadowFlags_kDirectionalLight_ShadowFlag as u32;
+        #[allow(clippy::unnecessary_cast)]
+        const CONCAVE_BLUR_ONLY = sb::SkShadowFlags_kConcaveBlurOnly_ShadowFlag as u32;
+        const ALL = Self::TRANSPARENT_OCCLUDER.bits() | Self::GEOMETRIC_ONLY.bits()
+            | Self::GEOMETRIC_ONLY.bits() | Self::CONCAVE_BLUR_ONLY.bits();
     }
 }
 

--- a/skia-safe/src/utils/shadow_utils.rs
+++ b/skia-safe/src/utils/shadow_utils.rs
@@ -13,7 +13,7 @@ bitflags! {
         #[allow(clippy::unnecessary_cast)]
         const CONCAVE_BLUR_ONLY = sb::SkShadowFlags_kConcaveBlurOnly_ShadowFlag as u32;
         const ALL = Self::TRANSPARENT_OCCLUDER.bits() | Self::GEOMETRIC_ONLY.bits()
-            | Self::GEOMETRIC_ONLY.bits() | Self::CONCAVE_BLUR_ONLY.bits();
+            | Self::DIRECTIONAL_LIGHT.bits() | Self::CONCAVE_BLUR_ONLY.bits();
     }
 }
 


### PR DESCRIPTION
This adds in the shadow utils flags that were added relatively recently.