### PR TITLE
Fix cross-compiling with system freetype libraries

### DIFF
--- a/skia-bindings/build_support/platform.rs
+++ b/skia-bindings/build_support/platform.rs
@@ -33,10 +33,17 @@ pub fn link_libraries(features: &Features, target: &Target) -> Vec<String> {
     details(target).link_libraries(features)
 }
 
+pub fn filter_features(target: &Target, features: Features) -> Features {
+    details(target).filter_platform_features(features)
+}
+
 pub trait PlatformDetails {
     fn gn_args(&self, config: &BuildConfiguration, builder: &mut GnArgsBuilder);
     fn bindgen_args(&self, _target: &Target, _builder: &mut BindgenArgsBuilder) {}
     fn link_libraries(&self, features: &Features) -> Vec<String>;
+    fn filter_platform_features(&self, features: Features) -> Features {
+        features
+    }
 }
 
 #[allow(clippy::type_complexity)]

--- a/skia-bindings/build_support/platform.rs
+++ b/skia-bindings/build_support/platform.rs
@@ -33,15 +33,23 @@ pub fn link_libraries(features: &Features, target: &Target) -> Vec<String> {
     details(target).link_libraries(features)
 }
 
-pub fn filter_features(target: &Target, features: Features) -> Features {
-    details(target).filter_platform_features(features)
+pub fn filter_features(
+    target: &Target,
+    use_system_libraries: bool,
+    features: Features,
+) -> Features {
+    details(target).filter_platform_features(use_system_libraries, features)
 }
 
 pub trait PlatformDetails {
     fn gn_args(&self, config: &BuildConfiguration, builder: &mut GnArgsBuilder);
     fn bindgen_args(&self, _target: &Target, _builder: &mut BindgenArgsBuilder) {}
     fn link_libraries(&self, features: &Features) -> Vec<String>;
-    fn filter_platform_features(&self, features: Features) -> Features {
+    fn filter_platform_features(
+        &self,
+        _use_system_libraries: bool,
+        features: Features,
+    ) -> Features {
         features
     }
 }
@@ -65,25 +73,19 @@ fn details(target: &Target) -> Box<dyn PlatformDetails> {
 #[derive(Debug)]
 pub struct GnArgsBuilder {
     target_arch: String,
-    use_system_libraries: bool,
     target_str: Option<String>,
     gn_args: Vec<(String, String)>,
     skia_cflags: Vec<String>,
 }
 
 impl GnArgsBuilder {
-    pub fn new(target: &Target, use_system_libraries: bool) -> Self {
+    pub fn new(target: &Target) -> Self {
         Self {
             target_arch: target.architecture.clone(),
-            use_system_libraries,
             target_str: Some(target.to_string()),
             gn_args: Vec::default(),
             skia_cflags: Vec::default(),
         }
-    }
-
-    pub fn use_system_libraries(&self) -> bool {
-        self.use_system_libraries
     }
 
     /// Overwrite the default target.

--- a/skia-bindings/build_support/platform/android.rs
+++ b/skia-bindings/build_support/platform/android.rs
@@ -20,13 +20,6 @@ impl PlatformDetails for Android {
             .arg("target_cpu", quote(clang::target_arch(arch)))
             .arg("skia_enable_fontmgr_android", yes());
 
-        if !config.features.embed_freetype {
-            builder.arg(
-                "skia_use_system_freetype2",
-                yes_if(builder.use_system_libraries()),
-            );
-        }
-
         let major = ndk_major_version(Path::new(&ndk));
         let mut extra_skia_cflags = extra_skia_cflags();
 
@@ -52,6 +45,18 @@ impl PlatformDetails for Android {
             .iter()
             .map(|l| l.to_string())
             .collect()
+    }
+
+    fn filter_platform_features(
+        &self,
+        use_system_libraries: bool,
+        mut features: Features,
+    ) -> Features {
+        if !features.embed_freetype {
+            features.embed_freetype = !use_system_libraries;
+        }
+
+        features
     }
 }
 

--- a/skia-bindings/build_support/platform/emscripten.rs
+++ b/skia-bindings/build_support/platform/emscripten.rs
@@ -12,7 +12,6 @@ impl PlatformDetails for Emscripten {
             .arg("ar", quote("emar"))
             .arg("skia_gl_standard", quote("webgl"))
             .arg("skia_use_freetype", yes())
-            .arg("skia_use_system_freetype2", no())
             .arg("skia_use_webgl", yes_if(features.gpu()))
             .arg("target_cpu", quote("wasm"));
 
@@ -55,5 +54,10 @@ impl PlatformDetails for Emscripten {
 
     fn link_libraries(&self, features: &Features) -> Vec<String> {
         generic::link_libraries(features)
+    }
+
+    fn filter_platform_features(&self, mut features: Features) -> Features {
+        features.embed_freetype = true;
+        features
     }
 }

--- a/skia-bindings/build_support/platform/emscripten.rs
+++ b/skia-bindings/build_support/platform/emscripten.rs
@@ -56,7 +56,11 @@ impl PlatformDetails for Emscripten {
         generic::link_libraries(features)
     }
 
-    fn filter_platform_features(&self, mut features: Features) -> Features {
+    fn filter_platform_features(
+        &self,
+        _use_system_libraries: bool,
+        mut features: Features,
+    ) -> Features {
         features.embed_freetype = true;
         features
     }

--- a/skia-bindings/build_support/skia/config.rs
+++ b/skia-bindings/build_support/skia/config.rs
@@ -188,6 +188,18 @@ impl FinalBuildConfiguration {
 
             if features.embed_freetype {
                 builder.arg("skia_use_system_freetype2", no());
+            } else {
+                // third_party/freetype2/BUILD.gn hard-codes /usr/include/freetype2
+                // as include path. When cross-compiling against a sysroot, we don't
+                // want the host directory, we want the path from the sysroot, so prepend
+                // a `=` to substitute the sysroot if present.
+                // Ideally we'd overwrite the skia_system_freetype2_include_path
+                // argument, but somehow that doesn't accept a `=`. So change it to
+                // a non-existent path, append a sysroot prefixed include path, as well
+                // as the previous fallback that's used if no sysroot is specified.
+                builder.arg("skia_system_freetype2_include_path", "\"/does/not/exist\"");
+                builder.cflag("-I=/usr/include/freetype2");
+                builder.cflag("-I/usr/include/freetype2");
             }
 
             // target specific gn args.

--- a/skia-bindings/build_support/skia/config.rs
+++ b/skia-bindings/build_support/skia/config.rs
@@ -106,14 +106,15 @@ impl FinalBuildConfiguration {
         use_system_libraries: bool,
         skia_source_dir: &Path,
     ) -> FinalBuildConfiguration {
-        let features = platform::filter_features(&build.target, build.features.clone());
+        let features =
+            platform::filter_features(&build.target, use_system_libraries, build.features.clone());
 
         // `SDKROOT` is the environment variable used on macOS to specify the sysroot.
         // `SDKTARGETSYSROOT` is the environment variable set in Yocto Linux SDKs when
         // cross-compiling.
         let sysroot = cargo::env_var("SDKTARGETSYSROOT").or_else(|| cargo::env_var("SDKROOT"));
 
-        let mut builder = GnArgsBuilder::new(&build.target, use_system_libraries);
+        let mut builder = GnArgsBuilder::new(&build.target);
 
         let gn_args = {
             builder

--- a/skia-bindings/build_support/skia/config.rs
+++ b/skia-bindings/build_support/skia/config.rs
@@ -106,7 +106,7 @@ impl FinalBuildConfiguration {
         use_system_libraries: bool,
         skia_source_dir: &Path,
     ) -> FinalBuildConfiguration {
-        let features = &build.features;
+        let features = platform::filter_features(&build.target, build.features.clone());
 
         // `SDKROOT` is the environment variable used on macOS to specify the sysroot.
         // `SDKTARGETSYSROOT` is the environment variable set in Yocto Linux SDKs when


### PR DESCRIPTION
Override the system freetype include path to make sure it's picked up from the sysroot (via = prefix).