### PR TITLE
Convert riscv64gc to riscv64

### DIFF
--- a/skia-bindings/build_support/clang.rs
+++ b/skia-bindings/build_support/clang.rs
@@ -4,6 +4,7 @@ pub fn target_arch(arch: &str) -> &str {
         "armv7" => "arm",
         "aarch64" => "arm64",
         "i686" => "x86",
+        "riscv64gc" => "riscv64",
         arch => arch,
     }
 }


### PR DESCRIPTION
Rust and Clang's targets differ on RISC-V 64-bit platforms.