### PR TITLE
Convert riscv64gc to riscv64 in build config

### DIFF
--- a/skia-bindings/build_support/skia/config.rs
+++ b/skia-bindings/build_support/skia/config.rs
@@ -53,7 +53,7 @@ impl BuildConfiguration {
         // It's possible that the provided command line for the compiler already includes --target.
         // We assume that it's most specific/appropriate, extract and use is. It might for example include
         // a vendor infix, while cargo targets usually don't.
-        let target = cc
+        let mut target = cc
             .find("--target=")
             .map(|target_option_offset| {
                 let target_tail = &cc[(target_option_offset + "--target=".len())..];
@@ -63,6 +63,10 @@ impl BuildConfiguration {
                 cargo::parse_target(target_str)
             })
             .unwrap_or_else(cargo::target);
+
+        if target.architecture == "riscv64gc" {
+            target.architecture = "riscv64".to_string();
+        }
 
         BuildConfiguration {
             on_windows: cargo::host().is_windows(),


### PR DESCRIPTION
This is actually different from https://github.com/rust-skia/rust-skia/pull/851: armv7, aarch64, i686 actually remains the same between Rust and Clang target triples, while riscv64 still differs (GC is the non-ELF riscv64 baseline for Rust; for C compilers, -march is used).