### PR TITLE
replace dependency ureq with reqwest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ target/
 /cmake-build-debug/
 .direnv/
 /tmp/
-
+.idea/

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -32,7 +32,7 @@ vulkan = ["gpu", "skia-bindings/vulkan"]
 metal = ["gpu", "skia-bindings/metal"]
 d3d = ["gpu", "winapi", "wio", "skia-bindings/d3d"]
 textlayout = ["skia-bindings/textlayout"]
-svg = ["skia-bindings/svg", "ureq", "base64"]
+svg = ["skia-bindings/svg", "reqwest", "base64"]
 webp = ["webp-encode", "webp-decode"]
 webp-encode = ["skia-bindings/webp-encode"]
 webp-decode = ["skia-bindings/webp-decode"]
@@ -57,7 +57,7 @@ winapi = { version = "0.3.9", features = ["d3d12", "dxgi"], optional = true }
 wio = { version = "0.2.2", optional = true }
 
 # svg
-ureq = { version = "2.3.0", optional = true }
+reqwest = { version = "0.11.22", optional = true, features = ["blocking"] }
 base64 = { version = "0.21.0", optional = true }
 
 [dev-dependencies]

--- a/skia-safe/src/modules/svg.rs
+++ b/skia-safe/src/modules/svg.rs
@@ -1,7 +1,7 @@
 use std::{
     error::Error,
     fmt,
-    io::{self, Read},
+    io::{self},
     str::FromStr,
 };
 
@@ -117,15 +117,9 @@ extern "C" fn handle_load(
                 Ok(response) => {
                     match response.bytes() {
                         Ok(bytes) => {
-                            let mut reader = bytes.as_ref();
-                            let mut data = Vec::new();
-                            return if let Err(_) = reader.read_to_end(&mut data) {
-                                let data = Data::new_empty();
-                                data.into_ptr()
-                            } else {
-                                let data = Data::new_copy(data.as_slice());
-                                data.into_ptr()
-                            }
+                            let reader = bytes.as_ref();
+                            let data = Data::new_copy(reader);
+                            data.into_ptr()
                         }
                         Err(_) => {
                             let data = Data::new_empty();

--- a/skia-safe/src/modules/svg.rs
+++ b/skia-safe/src/modules/svg.rs
@@ -113,9 +113,9 @@ extern "C" fn handle_load(
                 )
             };
 
-            match ureq::get(&path).call() {
+            match reqwest::blocking::get(&path) {
                 Ok(response) => {
-                    let mut reader = response.into_reader();
+                    let mut reader = response.bytes().unwrap().as_ref();
                     let mut data = Vec::new();
                     if reader.read_to_end(&mut data).is_err() {
                         data.clear();


### PR DESCRIPTION
Replaced ureq with reqwest since the ureq upstream ring dependency does not compile under wasm.
 
The svg modules unit test has passed, but the wasm build test has not, and I have no idea how the project tests wasm.
 
2023/10/24: upstream ring already supports wasm, but ureq is not updated at the moment

fix: #845 