### PR TITLE
Expect a shared Canvas reference in the remaining Canvas impl blocks

### DIFF
--- a/skia-safe/src/core/annotation.rs
+++ b/skia-safe/src/core/annotation.rs
@@ -40,27 +40,19 @@ pub mod annotate {
 
 impl Canvas {
     // TODO: accept str or the Url type from the url crate?
-    pub fn annotate_rect_with_url(&mut self, rect: impl AsRef<Rect>, data: &Data) -> &mut Self {
+    pub fn annotate_rect_with_url(&self, rect: impl AsRef<Rect>, data: &Data) -> &Self {
         annotate::rect_with_url(self, rect, data);
         self
     }
 
     // TODO: is data a string here, and if so, of what encoding?
-    pub fn annotate_named_destination(
-        &mut self,
-        point: impl Into<Point>,
-        data: &Data,
-    ) -> &mut Self {
+    pub fn annotate_named_destination(&self, point: impl Into<Point>, data: &Data) -> &Self {
         annotate::named_destination(self, point, data);
         self
     }
 
     // TODO: use str?
-    pub fn annotate_link_to_destination(
-        &mut self,
-        rect: impl AsRef<Rect>,
-        data: &Data,
-    ) -> &mut Self {
+    pub fn annotate_link_to_destination(&self, rect: impl AsRef<Rect>, data: &Data) -> &Self {
         annotate::link_to_destination(self, rect, data);
         self
     }

--- a/skia-safe/src/utils/text_utils.rs
+++ b/skia-safe/src/utils/text_utils.rs
@@ -1,5 +1,4 @@
 use crate::{prelude::*, Canvas, Font, Paint, Path, Point, TextEncoding};
-use core::borrow::BorrowMut;
 use skia_bindings::SkTextUtils;
 
 pub use skia_bindings::SkTextUtils_Align as Align;
@@ -32,14 +31,14 @@ pub fn draw_str(
 
 impl Canvas {
     pub fn draw_str_align(
-        &mut self,
+        &self,
         text: impl AsRef<str>,
         p: impl Into<Point>,
         font: &Font,
         paint: &Paint,
         align: Align,
-    ) -> &mut Self {
-        draw_str(self.borrow_mut(), text, p, font, paint, align);
+    ) -> &Self {
+        draw_str(self, text, p, font, paint, align);
         self
     }
 }


### PR DESCRIPTION
This is a follow up PR to #876 and #816. Some Canvas references in impl blocks outside the `canvas.rs` module were not converted from expecting exclusive references to shared ones.