### PR TITLE
Change winapi,wio to windows-rs

### DIFF
--- a/skia-org/Cargo.toml
+++ b/skia-org/Cargo.toml
@@ -8,7 +8,13 @@ readme = "README.md"
 # 5 max
 keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 # 6 max
-categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
+categories = [
+    "api-bindings",
+    "graphics",
+    "multimedia::images",
+    "rendering::graphics-api",
+    "visualization",
+]
 license = "MIT"
 
 version = "1.0.0"
@@ -25,7 +31,7 @@ x11 = ["gl", "skia-safe/x11"]
 wayland = ["egl", "skia-safe/wayland"]
 vulkan = ["ash", "skia-safe/vulkan"]
 metal = ["metal-rs", "foreign-types-shared", "cocoa", "objc", "skia-safe/metal"]
-d3d = ["skia-safe/d3d", "winapi", "wio"]
+d3d = ["skia-safe/d3d", "windows"]
 textlayout = ["skia-safe/textlayout"]
 webp = ["skia-safe/webp"]
 svg = ["skia-safe/svg"]
@@ -46,5 +52,12 @@ foreign-types-shared = { version = "0.1.1", optional = true }
 cocoa = { version = "0.25", optional = true }
 objc = { version = "0.2.4", optional = true }
 # d3d
-winapi = { version = "0.3.9", optional = true, features = ["d3d12", "dxgi", "winerror", "guiddef"] }
-wio = { version = "0.2.2", optional = true }
+windows = { version = "0.52.0", features = [
+    "Win32",
+    "Win32_Graphics",
+    "Win32_Graphics_Dxgi",
+    "Win32_Graphics_Direct3D12",
+    "Win32_Graphics_Direct3D",
+    "Win32_Foundation",
+    "Win32_Graphics_Dxgi_Common",
+], optional = true }

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -9,7 +9,13 @@ readme = "README.md"
 # 5 max
 keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 # 6 max
-categories = ["api-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"] 
+categories = [
+    "api-bindings",
+    "graphics",
+    "multimedia::images",
+    "rendering::graphics-api",
+    "visualization",
+]
 license = "MIT"
 
 version = "0.69.0"
@@ -20,8 +26,17 @@ edition = "2021"
 doctest = false
 
 [features]
-default = ["binary-cache", "embed-icudtl"]
-all-linux = ["gl", "egl", "vulkan", "x11", "wayland", "textlayout", "svg", "webp"]
+default = ["binary-cache", "embed-icudtl", "d3d"]
+all-linux = [
+    "gl",
+    "egl",
+    "vulkan",
+    "x11",
+    "wayland",
+    "textlayout",
+    "svg",
+    "webp",
+]
 all-windows = ["gl", "vulkan", "d3d", "textlayout", "svg", "webp"]
 all-macos = ["gl", "vulkan", "metal", "textlayout", "svg", "webp"]
 gl = ["gpu", "skia-bindings/gl"]
@@ -30,7 +45,7 @@ x11 = ["gl", "skia-bindings/x11"]
 wayland = ["egl", "skia-bindings/wayland"]
 vulkan = ["gpu", "skia-bindings/vulkan"]
 metal = ["gpu", "skia-bindings/metal"]
-d3d = ["gpu", "winapi", "wio", "skia-bindings/d3d"]
+d3d = ["gpu", "windows", "skia-bindings/d3d"]
 textlayout = ["skia-bindings/textlayout"]
 svg = ["skia-bindings/svg", "ureq", "base64"]
 webp = ["webp-encode", "webp-decode"]
@@ -50,11 +65,16 @@ bitflags = "2.0"
 lazy_static = "1.4"
 skia-bindings = { version = "=0.69.0", path = "../skia-bindings", default-features = false }
 
-# D3D types
-winapi = { version = "0.3.9", features = ["d3d12", "dxgi"], optional = true }
-
-# ComPtr
-wio = { version = "0.2.2", optional = true }
+# D3D types & ComPtr
+windows = { version = "0.52.0", features = [
+    "Win32",
+    "Win32_Graphics",
+    "Win32_Graphics_Dxgi",
+    "Win32_Graphics_Direct3D12",
+    "Win32_Graphics_Direct3D",
+    "Win32_Foundation",
+    "Win32_Graphics_Dxgi_Common",
+], optional = true }
 
 # svg
 ureq = { version = "2.8.0", optional = true }

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -26,7 +26,7 @@ edition = "2021"
 doctest = false
 
 [features]
-default = ["binary-cache", "embed-icudtl", "d3d"]
+default = ["binary-cache", "embed-icudtl"]
 all-linux = [
     "gl",
     "egl",

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -101,3 +101,17 @@ objc = "0.2.7"
 cocoa = "0.25.0"
 core-graphics-types = "0.1.1"
 foreign-types-shared = "0.1.1"
+
+# d3d-window
+[target.'cfg(target_os = "windows")'.dev-dependencies]
+anyhow = { version = "1.0.75" }
+windows = { version = "0.52.0", features = [
+    "Win32",
+    "Win32_Graphics",
+    "Win32_Graphics_Dxgi",
+    "Win32_Graphics_Direct3D12",
+    "Win32_Graphics_Direct3D",
+    "Win32_Foundation",
+    "Win32_Graphics_Dxgi_Common",
+] }
+winit = "0.29.4"

--- a/skia-safe/examples/d3d-window/main.rs
+++ b/skia-safe/examples/d3d-window/main.rs
@@ -7,12 +7,6 @@ fn main() {
 #[cfg(all(target_os = "windows", feature = "d3d"))]
 fn main() -> anyhow::Result<()> {
     // NOTE: Most of code is from https://github.com/microsoft/windows-rs/blob/02db74cf5c4796d970e6d972cdc7bc3967380079/crates/samples/windows/direct3d12/src/main.rs
-    let event_loop = winit::event_loop::EventLoop::new()?;
-    let winit_window_builder = winit::window::WindowBuilder::new()
-        .with_title("rust-skia-gl-window")
-        .with_inner_size(winit::dpi::LogicalSize::new(800, 800));
-
-    let window = winit_window_builder.build(&event_loop)?;
 
     use anyhow::Result;
     use skia_safe::Color;
@@ -43,6 +37,13 @@ fn main() -> anyhow::Result<()> {
             },
         },
     };
+
+    let event_loop = winit::event_loop::EventLoop::new()?;
+    let winit_window_builder = winit::window::WindowBuilder::new()
+        .with_title("rust-skia-gl-window")
+        .with_inner_size(winit::dpi::LogicalSize::new(800, 800));
+
+    let window = winit_window_builder.build(&event_loop)?;
 
     const FRAME_COUNT: u32 = 2;
     let id: u64 = window.id().into();
@@ -266,7 +267,7 @@ fn main() -> anyhow::Result<()> {
                 state.y += 10.0;
             }
 
-            render(&state);
+            render(state);
         }
         _ => {}
     };

--- a/skia-safe/examples/d3d-window/main.rs
+++ b/skia-safe/examples/d3d-window/main.rs
@@ -6,6 +6,7 @@ fn main() {
 
 #[cfg(all(target_os = "windows", feature = "d3d"))]
 fn main() -> anyhow::Result<()> {
+    // NOTE: Most of code is from https://github.com/microsoft/windows-rs/blob/02db74cf5c4796d970e6d972cdc7bc3967380079/crates/samples/windows/direct3d12/src/main.rs
     let event_loop = winit::event_loop::EventLoop::new()?;
     let winit_window_builder = winit::window::WindowBuilder::new()
         .with_title("rust-skia-gl-window")
@@ -135,7 +136,6 @@ fn main() -> anyhow::Result<()> {
                     window.inner_size().width as i32,
                     window.inner_size().height as i32,
                 ),
-                // &skia_safe::gpu::d3d::TextureResourceInfo::from_resource(render_targets.pop().unwrap()),
                 &skia_safe::gpu::d3d::TextureResourceInfo {
                     resource: render_target.clone(),
                     alloc: None,

--- a/skia-safe/examples/d3d-window/main.rs
+++ b/skia-safe/examples/d3d-window/main.rs
@@ -11,10 +11,6 @@ fn main() -> anyhow::Result<()> {
     use anyhow::Result;
     use skia_safe::Color;
     use std::sync::{Arc, Mutex, OnceLock};
-    use windows::Win32::Graphics::{
-        Direct3D12::D3D12_RESOURCE_STATE_COMMON,
-        Dxgi::Common::DXGI_STANDARD_MULTISAMPLE_QUALITY_PATTERN,
-    };
     use windows::{
         core::ComInterface,
         Win32::{
@@ -26,9 +22,13 @@ fn main() -> anyhow::Result<()> {
                     ID3D12Resource, D3D12_COMMAND_LIST_TYPE_DIRECT, D3D12_COMMAND_QUEUE_DESC,
                     D3D12_COMMAND_QUEUE_FLAG_NONE, D3D12_CPU_DESCRIPTOR_HANDLE,
                     D3D12_DESCRIPTOR_HEAP_DESC, D3D12_DESCRIPTOR_HEAP_TYPE_RTV,
+                    D3D12_RESOURCE_STATE_COMMON,
                 },
                 Dxgi::{
-                    Common::{DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_SAMPLE_DESC},
+                    Common::{
+                        DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_SAMPLE_DESC,
+                        DXGI_STANDARD_MULTISAMPLE_QUALITY_PATTERN,
+                    },
                     CreateDXGIFactory1, IDXGIAdapter1, IDXGIFactory4, IDXGISwapChain3,
                     DXGI_ADAPTER_FLAG, DXGI_ADAPTER_FLAG_NONE, DXGI_ADAPTER_FLAG_SOFTWARE,
                     DXGI_SWAP_CHAIN_DESC1, DXGI_SWAP_EFFECT_FLIP_DISCARD,

--- a/skia-safe/examples/d3d-window/main.rs
+++ b/skia-safe/examples/d3d-window/main.rs
@@ -55,12 +55,13 @@ fn main() -> anyhow::Result<()> {
     unsafe { D3D12CreateDevice(&adapter, D3D_FEATURE_LEVEL_11_0, &mut device) }?;
     let device = device.unwrap();
 
-    let command_queue =
-        unsafe { device.CreateCommandQueue::<ID3D12CommandQueue>(&D3D12_COMMAND_QUEUE_DESC {
+    let command_queue = unsafe {
+        device.CreateCommandQueue::<ID3D12CommandQueue>(&D3D12_COMMAND_QUEUE_DESC {
             Flags: D3D12_COMMAND_QUEUE_FLAG_NONE,
             Type: D3D12_COMMAND_LIST_TYPE_DIRECT,
             ..Default::default()
-        }) }?;
+        })
+    }?;
 
     let swap_chain_desc = DXGI_SWAP_CHAIN_DESC1 {
         BufferCount: FRAME_COUNT,

--- a/skia-safe/examples/d3d-window/main.rs
+++ b/skia-safe/examples/d3d-window/main.rs
@@ -1,0 +1,287 @@
+// #[cfg(not(all(target_os = "windows", feature = "d3d")))]
+// fn main() {
+//     println!("This example requires the `d3d` feature to be enabled on Windows.");
+//     println!("Run it with `cargo run --example d3d-window --features d3d`");
+// }
+
+// #[cfg(all(target_os = "windows", feature = "d3d"))]
+fn main() -> anyhow::Result<()> {
+    let event_loop = winit::event_loop::EventLoop::new()?;
+    let winit_window_builder = winit::window::WindowBuilder::new()
+        .with_title("rust-skia-gl-window")
+        .with_inner_size(winit::dpi::LogicalSize::new(800, 800));
+
+    let window = winit_window_builder.build(&event_loop)?;
+
+    use anyhow::Result;
+    use skia_safe::Color;
+    use std::sync::{Arc, Mutex, OnceLock};
+    use windows::Win32::Graphics::{
+        Direct3D12::D3D12_RESOURCE_STATE_COMMON,
+        Dxgi::Common::DXGI_STANDARD_MULTISAMPLE_QUALITY_PATTERN,
+    };
+    use windows::{
+        core::ComInterface,
+        Win32::{
+            Foundation::HWND,
+            Graphics::{
+                Direct3D::D3D_FEATURE_LEVEL_11_0,
+                Direct3D12::{
+                    D3D12CreateDevice, ID3D12CommandQueue, ID3D12DescriptorHeap, ID3D12Device,
+                    ID3D12Resource, D3D12_COMMAND_LIST_TYPE_DIRECT, D3D12_COMMAND_QUEUE_DESC,
+                    D3D12_COMMAND_QUEUE_FLAG_NONE, D3D12_CPU_DESCRIPTOR_HANDLE,
+                    D3D12_DESCRIPTOR_HEAP_DESC, D3D12_DESCRIPTOR_HEAP_TYPE_RTV,
+                },
+                Dxgi::{
+                    Common::{DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_SAMPLE_DESC},
+                    CreateDXGIFactory1, IDXGIAdapter1, IDXGIFactory4, IDXGISwapChain3,
+                    DXGI_ADAPTER_FLAG, DXGI_ADAPTER_FLAG_NONE, DXGI_ADAPTER_FLAG_SOFTWARE,
+                    DXGI_SWAP_CHAIN_DESC1, DXGI_SWAP_EFFECT_FLIP_DISCARD,
+                    DXGI_USAGE_RENDER_TARGET_OUTPUT,
+                },
+            },
+        },
+    };
+
+    const FRAME_COUNT: u32 = 2;
+    let id: u64 = window.id().into();
+    let hwnd = HWND(id as isize);
+
+    let factory = unsafe { CreateDXGIFactory1::<IDXGIFactory4>() }?;
+    let adapter = get_hardware_adapter(&factory)?;
+
+    let mut device: Option<ID3D12Device> = None;
+    unsafe { D3D12CreateDevice(&adapter, D3D_FEATURE_LEVEL_11_0, &mut device) }?;
+    let device = device.unwrap();
+
+    let command_queue =
+        unsafe { device.CreateCommandQueue::<ID3D12CommandQueue>(&D3D12_COMMAND_QUEUE_DESC {
+            Flags: D3D12_COMMAND_QUEUE_FLAG_NONE,
+            Type: D3D12_COMMAND_LIST_TYPE_DIRECT,
+            ..Default::default()
+        }) }?;
+
+    let swap_chain_desc = DXGI_SWAP_CHAIN_DESC1 {
+        BufferCount: FRAME_COUNT,
+        Width: window.inner_size().width,
+        Height: window.inner_size().height,
+        Format: DXGI_FORMAT_R8G8B8A8_UNORM,
+        BufferUsage: DXGI_USAGE_RENDER_TARGET_OUTPUT,
+        SwapEffect: DXGI_SWAP_EFFECT_FLIP_DISCARD,
+        SampleDesc: DXGI_SAMPLE_DESC {
+            Count: 1,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let swap_chain: IDXGISwapChain3 = unsafe {
+        factory.CreateSwapChainForHwnd(&command_queue, hwnd, &swap_chain_desc, None, None)?
+    }
+    .cast()?;
+
+    let frame_index = unsafe { swap_chain.GetCurrentBackBufferIndex() };
+
+    let rtv_heap: ID3D12DescriptorHeap = unsafe {
+        device.CreateDescriptorHeap(&D3D12_DESCRIPTOR_HEAP_DESC {
+            NumDescriptors: FRAME_COUNT,
+            Type: D3D12_DESCRIPTOR_HEAP_TYPE_RTV,
+            ..Default::default()
+        })
+    }?;
+
+    let rtv_descriptor_size =
+        unsafe { device.GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV) } as usize;
+
+    let rtv_handle = D3D12_CPU_DESCRIPTOR_HANDLE {
+        ptr: unsafe { rtv_heap.GetCPUDescriptorHandleForHeapStart() }.ptr
+            + frame_index as usize * rtv_descriptor_size,
+    };
+
+    let render_targets: Vec<ID3D12Resource> = {
+        let mut render_targets = vec![];
+        for i in 0..FRAME_COUNT {
+            let render_target: ID3D12Resource = unsafe { swap_chain.GetBuffer(i)? };
+            unsafe {
+                device.CreateRenderTargetView(
+                    &render_target,
+                    None,
+                    D3D12_CPU_DESCRIPTOR_HANDLE {
+                        ptr: rtv_handle.ptr + i as usize * rtv_descriptor_size,
+                    },
+                )
+            };
+            render_targets.push(render_target);
+        }
+        render_targets
+    };
+
+    let backend_context = skia_safe::gpu::d3d::BackendContext {
+        adapter,
+        device: device.clone(),
+        queue: command_queue,
+        memory_allocator: None,
+        protected_context: skia_safe::gpu::Protected::No,
+    };
+
+    let mut context =
+        unsafe { skia_safe::gpu::DirectContext::new_d3d(&backend_context, None).unwrap() };
+
+    let mut surfaces = render_targets
+        .iter()
+        .map(|render_target| {
+            let backend_render_target = skia_safe::gpu::BackendRenderTarget::new_d3d(
+                (
+                    window.inner_size().width as i32,
+                    window.inner_size().height as i32,
+                ),
+                // &skia_safe::gpu::d3d::TextureResourceInfo::from_resource(render_targets.pop().unwrap()),
+                &skia_safe::gpu::d3d::TextureResourceInfo {
+                    resource: render_target.clone(),
+                    alloc: None,
+                    resource_state: D3D12_RESOURCE_STATE_COMMON,
+                    format: DXGI_FORMAT_R8G8B8A8_UNORM,
+                    sample_count: 1,
+                    level_count: 0,
+                    sample_quality_pattern: DXGI_STANDARD_MULTISAMPLE_QUALITY_PATTERN,
+                    protected: skia_safe::gpu::Protected::No,
+                },
+            );
+
+            skia_safe::gpu::surfaces::wrap_backend_render_target(
+                &mut context,
+                &backend_render_target,
+                skia_safe::gpu::SurfaceOrigin::BottomLeft,
+                skia_safe::ColorType::RGBA8888,
+                None,
+                None,
+            )
+            .ok_or(anyhow::anyhow!("wrap_backend_render_target failed"))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    fn get_hardware_adapter(factory: &IDXGIFactory4) -> Result<IDXGIAdapter1> {
+        for i in 0.. {
+            let adapter = unsafe { factory.EnumAdapters1(i)? };
+
+            let mut desc = Default::default();
+            unsafe { adapter.GetDesc1(&mut desc)? };
+
+            if (DXGI_ADAPTER_FLAG(desc.Flags as i32) & DXGI_ADAPTER_FLAG_SOFTWARE)
+                != DXGI_ADAPTER_FLAG_NONE
+            {
+                // Don't select the Basic Render Driver adapter. If you want a
+                // software adapter, pass in "/warp" on the command line.
+                continue;
+            }
+
+            // Check to see whether the adapter supports Direct3D 12, but don't
+            // create the actual device yet.
+            if unsafe {
+                D3D12CreateDevice(
+                    &adapter,
+                    D3D_FEATURE_LEVEL_11_0,
+                    std::ptr::null_mut::<Option<ID3D12Device>>(),
+                )
+            }
+            .is_ok()
+            {
+                return Ok(adapter);
+            }
+        }
+
+        unreachable!()
+    }
+
+    let mut skia_context = context;
+
+    println!("cool. skia inited");
+
+    let mut render = |state: &State| {
+        // I believe you can do better than this. It's very rough code.
+        static NEXT_SURFACE_INDEX: OnceLock<Arc<Mutex<usize>>> = OnceLock::new();
+        let mut surface_index = NEXT_SURFACE_INDEX
+            .get_or_init(|| Arc::new(Mutex::new(0)))
+            .lock()
+            .unwrap();
+        {
+            let this_index = *surface_index;
+            *surface_index += 1;
+            if *surface_index >= surfaces.len() {
+                *surface_index = 0;
+            }
+            let surface = &mut surfaces[this_index];
+            let canvas = surface.canvas();
+
+            canvas.clear(skia_safe::Color::BLUE);
+
+            let mut paint = skia_safe::Paint::default();
+            paint.set_color(Color::RED);
+            paint.set_style(skia_safe::paint::Style::StrokeAndFill);
+            paint.set_anti_alias(true);
+            paint.set_stroke_width(10.0);
+
+            canvas.draw_rect(
+                skia_safe::Rect::from_xywh(state.x, state.y, 200.0, 200.0),
+                &paint,
+            );
+            skia_context.flush_surface(surface);
+        }
+
+        skia_context.submit(None);
+
+        unsafe { swap_chain.Present(1, 0).ok().unwrap() };
+
+        // NOTE: If you get some error when you render, you can check it with:
+        // unsafe {
+        //     device.GetDeviceRemovedReason().ok().unwrap();
+        // }
+    };
+
+    let mut handle_event = |event, state: &mut State| match event {
+        winit::event::WindowEvent::RedrawRequested => {
+            render(state);
+        }
+        winit::event::WindowEvent::KeyboardInput {
+            device_id: _,
+            event,
+            is_synthetic: _,
+        } => {
+            if event.logical_key
+                == winit::keyboard::Key::Named(winit::keyboard::NamedKey::ArrowLeft)
+            {
+                state.x -= 10.0;
+            } else if event.logical_key
+                == winit::keyboard::Key::Named(winit::keyboard::NamedKey::ArrowRight)
+            {
+                state.x += 10.0;
+            } else if event.logical_key
+                == winit::keyboard::Key::Named(winit::keyboard::NamedKey::ArrowUp)
+            {
+                state.y -= 10.0;
+            } else if event.logical_key
+                == winit::keyboard::Key::Named(winit::keyboard::NamedKey::ArrowDown)
+            {
+                state.y += 10.0;
+            }
+
+            render(&state);
+        }
+        _ => {}
+    };
+
+    struct State {
+        x: f32,
+        y: f32,
+    }
+
+    let mut state = State { x: 100.0, y: 100.0 };
+
+    event_loop.run(move |event, _| {
+        if let winit::event::Event::WindowEvent { event, .. } = event {
+            handle_event(event, &mut state);
+        }
+    })?;
+
+    Ok(())
+}

--- a/skia-safe/examples/d3d-window/main.rs
+++ b/skia-safe/examples/d3d-window/main.rs
@@ -1,10 +1,10 @@
-// #[cfg(not(all(target_os = "windows", feature = "d3d")))]
-// fn main() {
-//     println!("This example requires the `d3d` feature to be enabled on Windows.");
-//     println!("Run it with `cargo run --example d3d-window --features d3d`");
-// }
+#[cfg(not(all(target_os = "windows", feature = "d3d")))]
+fn main() {
+    println!("This example requires the `d3d` feature to be enabled on Windows.");
+    println!("Run it with `cargo run --example d3d-window --features d3d`");
+}
 
-// #[cfg(all(target_os = "windows", feature = "d3d"))]
+#[cfg(all(target_os = "windows", feature = "d3d"))]
 fn main() -> anyhow::Result<()> {
     let event_loop = winit::event_loop::EventLoop::new()?;
     let winit_window_builder = winit::window::WindowBuilder::new()

--- a/skia-safe/src/gpu/d3d.rs
+++ b/skia-safe/src/gpu/d3d.rs
@@ -1,5 +1,4 @@
 use skia_bindings as sb;
-use winapi::{shared::dxgi, shared::dxgiformat, um::d3d12};
 
 mod backend_context;
 pub use backend_context::*;
@@ -11,11 +10,11 @@ pub use types::*;
 
 pub use sb::GrD3DResourceStateEnum as ResourceStateEnum;
 
-pub use d3d12::ID3D12CommandQueue;
-pub use d3d12::ID3D12Device;
-pub use d3d12::ID3D12Resource;
-pub use d3d12::D3D12_RESOURCE_STATES;
-pub use dxgi::IDXGIAdapter1;
-pub use dxgiformat::DXGI_FORMAT;
+pub use windows::Win32::Graphics::Direct3D12::ID3D12CommandQueue;
+pub use windows::Win32::Graphics::Direct3D12::ID3D12Device;
+pub use windows::Win32::Graphics::Direct3D12::ID3D12Resource;
+pub use windows::Win32::Graphics::Direct3D12::D3D12_RESOURCE_STATES;
+pub use windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT;
+pub use windows::Win32::Graphics::Dxgi::IDXGIAdapter1;
 
-native_transmutable!(sb::DXGI_FORMAT, dxgiformat::DXGI_FORMAT, dxgi_format_layout);
+native_transmutable!(sb::DXGI_FORMAT, DXGI_FORMAT, dxgi_format_layout);

--- a/skia-safe/src/gpu/d3d/backend_context.rs
+++ b/skia-safe/src/gpu/d3d/backend_context.rs
@@ -1,13 +1,13 @@
-use super::{cp, ID3D12CommandQueue, ID3D12Device, IDXGIAdapter1, MemoryAllocator};
+use super::{ID3D12CommandQueue, ID3D12Device, IDXGIAdapter1, MemoryAllocator};
 use crate::gpu;
 use skia_bindings::GrD3DBackendContext;
 
 #[repr(C)]
 #[derive(Clone, Debug)]
 pub struct BackendContext {
-    pub adapter: cp<IDXGIAdapter1>,
-    pub device: cp<ID3D12Device>,
-    pub queue: cp<ID3D12CommandQueue>,
+    pub adapter: IDXGIAdapter1,
+    pub device: ID3D12Device,
+    pub queue: ID3D12CommandQueue,
     pub memory_allocator: Option<MemoryAllocator>,
     pub protected_context: gpu::Protected,
 }

--- a/skia-safe/src/gpu/d3d/backend_context.rs
+++ b/skia-safe/src/gpu/d3d/backend_context.rs
@@ -11,6 +11,5 @@ pub struct BackendContext {
     pub memory_allocator: Option<MemoryAllocator>,
     pub protected_context: gpu::Protected,
 }
-unsafe impl Send for BackendContext {}
 
 native_transmutable!(GrD3DBackendContext, BackendContext, backend_context_layout);

--- a/skia-safe/tests/send_sync.rs
+++ b/skia-safe/tests/send_sync.rs
@@ -236,9 +236,7 @@ mod gpu {
     mod d3d {
         use skia_safe::gpu::d3d::*;
         use static_assertions::*;
-        // not sure if BackendContext is Sync, so we'd set it to Send only for now.
-        assert_impl_all!(BackendContext: Send);
-        assert_not_impl_any!(BackendContext: Sync);
+        assert_impl_all!(BackendContext: Send, Sync);
         assert_impl_all!(TextureResourceInfo: Send, Sync);
         assert_impl_all!(FenceInfo: Send, Sync);
         assert_impl_all!(SurfaceInfo: Send, Sync);


### PR DESCRIPTION
closes #893 

I changed winapi and wio with windows-rs which Microsoft maintains, unlike winapi and wio.

I could create d3d example with Microsoft's (https://github.com/microsoft/windows-rs/blob/master/crates/samples/windows/direct3d12/src/main.rs)
