### PR TITLE
default curl and manual parsing. feature gate ureq and toml

### DIFF
--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -51,9 +51,14 @@ use-system-jpeg-turbo = ["mozjpeg-sys"]
 # `textlayout` because `SkSVGTextContext::SkSVGTextContext()` invokes `SkShaper::Make`.
 svg = ["textlayout"]
 shaper = ["textlayout"]
-binary-cache = ["ureq", "flate2", "tar"]
+# will use curl to download binaries
+binary-cache = ["flate2", "tar"]
 embed-icudtl = ["lazy_static"]
 embed-freetype = []
+# will use ureq to download binaries. 
+no-curl = ["ureq", "binary-cache"]
+# will use toml crate to parse Cargo.toml
+use-toml = ["dep:toml"]
 
 [dependencies]
 mozjpeg-sys = { version = "2", features = ["with_simd"], optional = true }
@@ -74,9 +79,9 @@ tar = { version = "0.4.26", optional = true }
 
 # For reading .cargo.vcs_info.json to get the repository sha1 that is used to download
 # the matching prebuilt binaries.
-serde_json = "1.0.39"
-# For reading Cargo.toml from within a package.
-toml = "0.8.0"
+tinyjson = "2"
+# For reading Cargo.toml from within a package when manual parsing fails.
+toml = { version = "0.8", optional = true }
 
 [dev-dependencies]
 # build dependencies duplicated for testing :(
@@ -87,5 +92,5 @@ heck = "0.4.0"
 ureq = { version = "2.8.0" }
 flate2 = { version = "1.0.7" }
 tar = { version = "0.4.26" }
-serde_json = "1.0.39"
-toml = "0.8.0"
+tinyjson = "2"
+toml = "0.8"

--- a/skia-bindings/build_support/binary_cache/utils.rs
+++ b/skia-bindings/build_support/binary_cache/utils.rs
@@ -19,14 +19,55 @@ pub fn download(url: impl AsRef<str>) -> io::Result<Vec<u8>> {
         return Err(Error::from(ErrorKind::Unsupported));
     }
 
-    let resp = ureq::get(url).call();
-    match resp {
-        Ok(resp) => {
-            let mut reader = resp.into_reader();
-            let mut data = Vec::new();
-            reader.read_to_end(&mut data)?;
-            Ok(data)
+    #[cfg(feature = "no-curl")]
+    {
+        println!("using ureq to download {url}");
+        let resp = ureq::get(url).call();
+        return match resp {
+            Ok(resp) => {
+                let mut reader = resp.into_reader();
+                let mut data = Vec::new();
+                reader.read_to_end(&mut data)?;
+                Ok(data)
+            }
+            Err(error) => Err(io::Error::new(io::ErrorKind::Other, error.to_string())),
+        };
+    }
+    #[cfg(not(feature = "no-curl"))]
+    {
+        println!("using curl to download {url}");
+        let resp = std::process::Command::new("curl")
+            // follow redirects
+            .arg("-L")
+            // fail fast with no "error pages" output. more of a hint though, so we might still get error on stdout.
+            // so make sure to check the actual status returned.
+            .arg("-f")
+            // silent. no progress or error messages. only pure "response data"
+            .arg("-s")
+            .arg(&url)
+            .output();
+        match resp {
+            Ok(out) => {
+                // ideally, we would redirect response to a file directly, but lets take it one step at a time.
+                let result = out.stdout;
+                if out.status.success() {
+                    println!("curl success");
+                    Ok(result)
+                } else {
+                    Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        format!(
+                            "curl error code: {:?}\ncurl stderr: {:?}",
+                            out.status.code(),
+                            std::str::from_utf8(&out.stderr)
+                        ),
+                    ))
+                }
+            }
+            Err(e) => Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("curl command error : {e:#?}"),
+            )),
         }
-        Err(error) => Err(io::Error::new(io::ErrorKind::Other, error.to_string())),
     }
 }

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -40,6 +40,9 @@ use-system-jpeg-turbo = ["skia-bindings/use-system-jpeg-turbo"]
 binary-cache = ["skia-bindings/binary-cache"]
 embed-icudtl = ["skia-bindings/embed-icudtl"]
 embed-freetype = ["skia-bindings/embed-freetype"]
+# uses ureq to download binary artefacts. enable this if you don't have curl installed
+no-curl = ["skia-bindings/no-curl"]
+use-toml = ["skia-bindings/use-toml"]
 
 # implied only, do not use
 gpu = []


### PR DESCRIPTION
most of the discussion is at https://github.com/rust-skia/rust-skia/discussions/897


To test the compile times
1. clone this repo 
2. switch to this branch
3. `git reset "HEAD^"` to "uncommit" the last commit. This will set the HEAD to the same commit as skia binaries and will avoid full skia builds
4. create a temporary project with this local path as dependency and forward the necessary features to skia-safe
5. `cargo clean && FORCE_SKIA_BINARIES_DOWNLOAD=1 cargo build -p skia_temp --release --timings --jobs 1 --features use-toml,no-curl`
6. The above command will give you timings for the usual build. remove the `features` option, to use curl and manual parsing.

The file with cargo_timings zip, if you just want to see *where* we are spending so much time.
[cargo_timings.zip](https://github.com/rust-skia/rust-skia/files/13659427/cargo_timings.zip)
