### PR TITLE
Milestone 121

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m121 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m121-0.69.0...google:chrome/m121
-[skia-ours]: https://github.com/google/skia/compare/chrome/m121...rust-skia:m121-0.69.0
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m121-0.69.1...google:chrome/m121
+[skia-ours]: https://github.com/google/skia/compare/chrome/m121...rust-skia:m121-0.69.1
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![Windows QA](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml) [![Linux QA](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml) [![macOS QA](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml)
 
-Skia Submodule Status: chrome/m120 ([upstream changes][skia-upstream], [our changes][skia-ours]).
+Skia Submodule Status: chrome/m121 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m120-0.68.1...google:chrome/m120
-[skia-ours]: https://github.com/google/skia/compare/chrome/m120...rust-skia:m120-0.68.1
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m121-0.69.0...google:chrome/m121
+[skia-ours]: https://github.com/google/skia/compare/chrome/m121...rust-skia:m121-0.69.0
 
 ## About
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -30,7 +30,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m121-0.69.0"
+skia = "m121-0.69.1"
 depot_tools = "73a2624"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.69.0"
+version = "0.70.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2021"
 build = "build.rs"

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -30,7 +30,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m120-0.68.1"
+skia = "m121-0.69.0"
 depot_tools = "73a2624"
 
 [features]

--- a/skia-bindings/build_support/skia/config.rs
+++ b/skia-bindings/build_support/skia/config.rs
@@ -283,6 +283,7 @@ pub fn build(
                 // accidentally resolving an absolute directory for `GIT_SYNC_DEPS_PATH` when MingW
                 // Python 3 runs on Windows under MSys.
                 .env("GIT_SYNC_DEPS_PATH", "skia/DEPS")
+                .env("GIT_SYNC_DEPS_SKIP_EMSDK", "1")
                 .arg("skia/tools/git-sync-deps")
                 .stdout(Stdio::inherit())
                 .stderr(Stdio::inherit())

--- a/skia-bindings/build_support/skia_bindgen.rs
+++ b/skia-bindings/build_support/skia_bindgen.rs
@@ -440,6 +440,8 @@ const OPAQUE_TYPES: &[&str] = &[
     "FILE",
     // m114: Results in wrongly sized template specializations.
     "skia_private::THashMap",
+    // m121:
+    "skgpu::MutableTextureState",
 ];
 
 const BLOCKLISTED_TYPES: &[&str] = &[

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -206,6 +206,10 @@ extern "C" int C_SkCodec_getRepetitionCount(SkCodec* self) {
 
 // SkCodecs
 
+extern "C" void C_SkCodecs_Decoder_CopyConstruct(SkCodecs::Decoder* uninitialized, const SkCodecs::Decoder* decoder) {
+    new (uninitialized) SkCodecs::Decoder(*decoder);
+}
+
 extern "C" const char* C_SkCodecs_Decoder_getId(const SkCodecs::Decoder* decoder, size_t* len) {
     *len = decoder->id.size();
     return decoder->id.data();

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -196,6 +196,57 @@ extern "C" int C_SkCodec_getRepetitionCount(SkCodec* self) {
     return self->getRepetitionCount();
 }
 
+// SkCodecs
+
+extern "C" const char* C_SkCodecs_Decoder_getId(const SkCodecs::Decoder* decoder, size_t* len) {
+    *len = decoder->id.size();
+    return decoder->id.data();
+}
+
+extern "C" SkCodec* C_SkCodecs_Decoder_MakeFromStream(const SkCodecs::Decoder* decoder, SkStream* stream, SkCodec::Result* result, SkCodecs::DecodeContext context) {
+    return decoder->makeFromStream(std::unique_ptr<SkStream>(stream), result, context).release();
+}
+
+extern "C" void C_SkCodecs_Decoder_destruct(SkCodecs::Decoder* decoder) {
+    decoder->~Decoder();
+}
+
+//
+// codec/*Decoder.h
+//
+
+extern "C" void C_SkBmpDecoder_Decoder(SkCodecs::Decoder* uninitialized) {
+    new (uninitialized) SkCodecs::Decoder(SkBmpDecoder::Decoder());
+}
+
+extern "C" void C_SkGifDecoder_Decoder(SkCodecs::Decoder* uninitialized) {
+    new (uninitialized) SkCodecs::Decoder(SkGifDecoder::Decoder());
+}
+
+extern "C" void C_SkIcoDecoder_Decoder(SkCodecs::Decoder* uninitialized) {
+    new (uninitialized) SkCodecs::Decoder(SkIcoDecoder::Decoder());
+}
+
+extern "C" void C_SkJpegDecoder_Decoder(SkCodecs::Decoder* uninitialized) {
+    new (uninitialized) SkCodecs::Decoder(SkJpegDecoder::Decoder());
+}
+
+extern "C" void C_SkPngDecoder_Decoder(SkCodecs::Decoder* uninitialized) {
+    new (uninitialized) SkCodecs::Decoder(SkPngDecoder::Decoder());
+}
+
+extern "C" void C_SkWbmpDecoder_Decoder(SkCodecs::Decoder* uninitialized) {
+    new (uninitialized) SkCodecs::Decoder(SkWbmpDecoder::Decoder());
+}
+
+#if defined(SK_CODEC_DECODES_WEBP)
+
+extern "C" void C_SkWebpDecoder_Decoder(SkCodecs::Decoder* uninitialized) {
+    new (uninitialized) SkCodecs::Decoder(SkWebpDecoder::Decoder());
+}
+
+#endif
+
 //
 // codec/SkEncodedOrigin.h
 //
@@ -215,71 +266,6 @@ extern "C" bool C_SkPixmapUtils_Orient(SkPixmap& dst, const SkPixmap& src, SkEnc
 extern "C" void C_SkPixmapUtils_SwapWidthHeight(SkImageInfo* uninitialized, const SkImageInfo& info) {
     new (uninitialized) SkImageInfo(SkPixmapUtils::SwapWidthHeight(info));
 }
-
-//
-// codec/*Decoder.h
-//
-
-extern "C" bool C_SkBmpDecoder_IsBmp(const char* buf, size_t size) {
-    return SkBmpDecoder::IsBmp(buf, size);
-}
-
-
-extern "C" SkCodec* C_SkBmpDecoder_Decode(SkStream* stream, SkCodec::Result* result) {
-    return SkBmpDecoder::Decode(std::unique_ptr<SkStream>(stream), result, nullptr).release();
-}
-
-extern "C" bool C_SkGifDecoder_IsGif(const char* buf, size_t size) {
-    return SkGifDecoder::IsGif(buf, size);
-}
-
-extern "C" SkCodec* C_SkGifDecoder_Decode(SkStream* stream, SkCodec::Result* result) {
-    return SkGifDecoder::Decode(std::unique_ptr<SkStream>(stream), result, nullptr).release();
-}
-
-extern "C" bool C_SkIcoDecoder_IsIco(const char* buf, size_t size) {
-    return SkIcoDecoder::IsIco(buf, size);
-}
-
-extern "C" SkCodec* C_SkIcoDecoder_Decode(SkStream* stream, SkCodec::Result* result) {
-    return SkIcoDecoder::Decode(std::unique_ptr<SkStream>(stream), result, nullptr).release();
-}
-
-extern "C" bool C_SkJpegDecoder_IsJpeg(const char* buf, size_t size) {
-    return SkJpegDecoder::IsJpeg(buf, size);
-}
-
-extern "C" SkCodec* C_SkJpegDecoder_Decode(SkStream* stream, SkCodec::Result* result) {
-    return SkJpegDecoder::Decode(std::unique_ptr<SkStream>(stream), result, nullptr).release();
-}
-
-extern "C" bool C_SkPngDecoder_IsPng(const char* buf, size_t size) {
-    return SkPngDecoder::IsPng(buf, size);
-}
-
-extern "C" SkCodec* C_SkPngDecoder_Decode(SkStream* stream, SkCodec::Result* result) {
-    return SkPngDecoder::Decode(std::unique_ptr<SkStream>(stream), result, nullptr).release();
-}
-
-extern "C" bool C_SkWbmpDecoder_IsWbmp(const char* buf, size_t size) {
-    return SkWbmpDecoder::IsWbmp(buf, size);
-}
-
-extern "C" SkCodec* C_SkWbmpDecoder_Decode(SkStream* stream, SkCodec::Result* result) {
-    return SkWbmpDecoder::Decode(std::unique_ptr<SkStream>(stream), result, nullptr).release();
-}
-
-#if defined(SK_CODEC_DECODES_WEBP)
-
-extern "C" bool C_SkWebpDecoder_IsWebp(const char* buf, size_t size) {
-    return SkWebpDecoder::IsWebp(buf, size);
-}
-
-extern "C" SkCodec* C_SkWebpDecoder_Decode(SkStream* stream, SkCodec::Result* result) {
-    return SkWebpDecoder::Decode(std::unique_ptr<SkStream>(stream), result, nullptr).release();
-}
-
-#endif
 
 //
 // core/

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1332,10 +1332,6 @@ extern "C" bool C_SkTypeface_isItalic(const SkTypeface* self) {
     return self->isItalic();
 }
 
-extern "C" SkTypeface* C_SkTypeface_MakeDefault() {
-    return SkTypeface::MakeDefault().release();
-}
-
 extern "C" SkTypeface* C_SkTypeface_MakeFromName(const char familyName[], SkFontStyle fontStyle) {
     return SkTypeface::MakeFromName(familyName, fontStyle).release();
 }
@@ -1412,16 +1408,16 @@ extern "C" SkData* C_SkFlattenable_serialize(const SkFlattenable* self) {
 // core/SkFont.h
 //
 
-extern "C" void C_SkFont_ConstructFromTypeface(SkFont* uninitialized, SkTypeface* typeface) {
-    new(uninitialized) SkFont(sp(typeface));
+extern "C" void C_SkFont_ConstructFromTypeface(SkFont* uninitialized, SkTypeface* typeface_) {
+    new(uninitialized) SkFont(sp(typeface_));
 }
 
-extern "C" void C_SkFont_ConstructFromTypefaceWithSize(SkFont* uninitialized, SkTypeface* typeface, SkScalar size) {
-    new(uninitialized) SkFont(sp(typeface), size);
+extern "C" void C_SkFont_ConstructFromTypefaceWithSize(SkFont* uninitialized, SkTypeface* typeface_, SkScalar size) {
+    new(uninitialized) SkFont(sp(typeface_), size);
 }
 
-extern "C" void C_SkFont_ConstructFromTypefaceWithSizeScaleAndSkew(SkFont* uninitialized, SkTypeface* typeface, SkScalar size, SkScalar scaleX, SkScalar skewX) {
-    new(uninitialized) SkFont(sp(typeface), size, scaleX, skewX);
+extern "C" void C_SkFont_ConstructFromTypefaceWithSizeScaleAndSkew(SkFont* uninitialized, SkTypeface* typeface_, SkScalar size, SkScalar scaleX, SkScalar skewX) {
+    new(uninitialized) SkFont(sp(typeface_), size, scaleX, skewX);
 }
 
 extern "C" void C_SkFont_CopyConstruct(SkFont* uninitialized, const SkFont* font) {
@@ -1553,6 +1549,10 @@ extern "C" SkTypeface* C_SkFontMgr_matchFamilyStyleCharacter(
 // note: this function _consumes_ / deletes the stream.
 extern "C" SkTypeface* C_SkFontMgr_makeFromStream(const SkFontMgr* self, SkStreamAsset* stream, int ttcIndex) {
     return self->makeFromStream(std::unique_ptr<SkStreamAsset>(stream), ttcIndex).release();
+}
+
+extern "C" SkTypeface* C_SkFontMgr_legacyMakeTypeface(const SkFontMgr* self, const char familyName[], SkFontStyle style) {
+    return self->legacyMakeTypeface(familyName, style).release();
 }
 
 extern "C" SkFontMgr* C_SkFontMgr_RefDefault() {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -132,6 +132,10 @@ extern "C" SkCodec* C_SkCodec_MakeFromData(SkData* data) {
     return SkCodec::MakeFromData(sp(data)).release();
 }
 
+extern "C" SkCodec* C_SkCodec_MakeFromData2(SkData* data, const SkCodecs::Decoder* decoders, size_t decodersCount) {
+    return SkCodec::MakeFromData(sp(data), SkSpan(decoders, decodersCount)).release();
+}
+
 extern "C" void C_SkCodec_delete(SkCodec* self) {
     delete self;
 }

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -124,6 +124,10 @@ extern "C" void C_Bindings_Types(Sink<bool>) {}
 // codec/SkCodec.h
 //
 
+extern "C" SkCodec* C_SkCodec_MakeFromStream(SkStream* stream, const SkCodecs::Decoder* decoders, size_t decodersCount, SkCodec::Result* result, SkCodec::SelectionPolicy selectionPolicy) {
+    return SkCodec::MakeFromStream(std::unique_ptr<SkStream>(stream), SkSpan(decoders, decodersCount), result, nullptr, selectionPolicy).release();
+}
+
 extern "C" SkCodec* C_SkCodec_MakeFromData(SkData* data) {
     return SkCodec::MakeFromData(sp(data)).release();
 }

--- a/skia-bindings/src/gl.cpp
+++ b/skia-bindings/src/gl.cpp
@@ -180,7 +180,7 @@ extern "C" GrGLenum C_GrBackendFormats_AsGLFormatEnum(const GrBackendFormat* for
 
 extern "C" GrBackendTexture* C_GrBackendTextures_newGL(
     int width, int height,
-    GrMipMapped mipMapped,
+    skgpu::Mipmapped mipMapped,
     const GrGLTextureInfo* glInfo,
     const char* label,
     size_t labelCount) {

--- a/skia-bindings/src/gpu.cpp
+++ b/skia-bindings/src/gpu.cpp
@@ -97,16 +97,12 @@ extern "C" void C_GrBackendFormat_makeTexture2D(const GrBackendFormat* self, GrB
 // gpu/MutableTextureState.h
 //
 
-extern "C" void C_MutableTextureState_Construct(skgpu::MutableTextureState* uninitialized) {
-    new(uninitialized)skgpu::MutableTextureState();
+extern "C" skgpu::MutableTextureState* C_MutableTextureState_Construct() {
+    return new skgpu::MutableTextureState();
 }
 
-extern "C" void C_MutableTextureState_CopyConstruct(skgpu::MutableTextureState* uninitialized, const skgpu::MutableTextureState* state) {
-    new(uninitialized)skgpu::MutableTextureState(*state);
-}
-
-extern "C" void C_MutableTextureState_destruct(skgpu::MutableTextureState* self) {
-    self->~MutableTextureState();
+extern "C" skgpu::MutableTextureState* C_MutableTextureState_CopyConstruct(const skgpu::MutableTextureState* state) {
+    return new skgpu::MutableTextureState(*state);
 }
 
 extern "C" skgpu::BackendApi C_MutableTextureState_backend(const skgpu::MutableTextureState* self) {
@@ -313,7 +309,7 @@ extern "C" SkImage* C_SkImages_CrossContextTextureFromPixmap(
 }
 
 extern "C" SkImage *C_SkImages_TextureFromCompressedTextureData(GrDirectContext *context, SkData *data, int width, int height,
-                                                SkTextureCompressionType type, GrMipMapped mipMapped,
+                                                SkTextureCompressionType type, skgpu::Mipmapped mipMapped,
                                                 GrProtected prot) {
     return SkImages::TextureFromCompressedTextureData(context, sp(data), width, height, type, mipMapped, prot).release();
 }
@@ -321,7 +317,7 @@ extern "C" SkImage *C_SkImages_TextureFromCompressedTextureData(GrDirectContext 
 extern "C" SkImage* C_SkImages_TextureFromImage(
         GrDirectContext* context,
         const SkImage* self,
-        GrMipMapped mipMapped,
+        skgpu::Mipmapped mipMapped,
         skgpu::Budgeted budgeted) {
     return SkImages::TextureFromImage(context, self, mipMapped, budgeted).release();
 }
@@ -329,7 +325,7 @@ extern "C" SkImage* C_SkImages_TextureFromImage(
 extern "C" SkImage* C_SkImages_TextureFromYUVAPixmaps(
     GrRecordingContext* context,
     const SkYUVAPixmaps* pixmaps,
-    GrMipmapped buildMips,
+    skgpu::Mipmapped buildMips,
     bool limitToMaxTextureSize,
     SkColorSpace* imageColorSpace
 ) {

--- a/skia-bindings/src/metal.cpp
+++ b/skia-bindings/src/metal.cpp
@@ -60,12 +60,12 @@ extern "C" GrDirectContext *C_GrContext_MakeMetal(
 //
 
 extern "C" void C_GrMtlBackendContext_Construct(
-    GrMtlBackendContext* unintialized, 
+    GrMtlBackendContext* uninitialized, 
     const void* device, const void* queue, const void* binaryArchive) {
-    new (unintialized) GrMtlBackendContext();
-    unintialized->fDevice.retain(device);
-    unintialized->fQueue.retain(queue);
-    unintialized->fBinaryArchive.retain(binaryArchive);
+    new (uninitialized) GrMtlBackendContext();
+    uninitialized->fDevice.retain(device);
+    uninitialized->fQueue.retain(queue);
+    uninitialized->fBinaryArchive.retain(binaryArchive);
 }
 
 extern "C" void C_GrMtlBackendContext_Destruct(GrMtlBackendContext* self) {
@@ -76,9 +76,9 @@ extern "C" void C_GrMtlBackendContext_Destruct(GrMtlBackendContext* self) {
 // gpu/mtl/GrMtlTypes.h
 //
 
-extern "C" void C_GrMtlTextureInfo_Construct(GrMtlTextureInfo* unintialized, const void* texture) {
-    new (unintialized) GrMtlTextureInfo();
-    unintialized->fTexture.retain(texture);
+extern "C" void C_GrMtlTextureInfo_Construct(GrMtlTextureInfo* uninitialized, const void* texture) {
+    new (uninitialized) GrMtlTextureInfo();
+    uninitialized->fTexture.retain(texture);
 }
 
 extern "C" void C_GrMtlTextureInfo_Destruct(GrMtlTextureInfo* self) {
@@ -100,7 +100,7 @@ extern "C" void C_GrBackendFormat_ConstructMtl(GrBackendFormat* uninitialized, G
 
 extern "C" GrBackendTexture* C_GrBackendTexture_newMtl(
     int width, int height,
-    GrMipMapped mipMapped,
+    skgpu::Mipmapped mipMapped,
     const GrMtlTextureInfo* mtlInfo,
     const char* label,
     size_t labelCount) {

--- a/skia-bindings/src/paragraph.cpp
+++ b/skia-bindings/src/paragraph.cpp
@@ -107,6 +107,10 @@ extern "C" {
         return self->defaultFallback().release();
     }
 
+    SkTypeface* C_FontCollection_defaultEmojiFallback(FontCollection* self, SkUnichar emojiStart, SkFontStyle fontStyle, const SkString* locale) {
+        return self->defaultEmojiFallback(emojiStart, fontStyle, *locale).release();
+    }
+
     bool C_FontCollection_fontFallbackEnabled(const FontCollection* self) {
         return const_cast<FontCollection*>(self)->fontFallbackEnabled();
     }

--- a/skia-bindings/src/vulkan.cpp
+++ b/skia-bindings/src/vulkan.cpp
@@ -11,6 +11,7 @@
 #include "include/gpu/vk/GrVkTypes.h"
 #include "include/gpu/vk/GrVkBackendContext.h"
 #include "include/gpu/vk/GrVkExtensions.h"
+#include "include/gpu/vk/VulkanMutableTextureState.h"
 
 // Additional types not yet referenced.
 extern "C" void C_GrVkTypes(GrVkSurfaceInfo *) {};
@@ -103,22 +104,6 @@ extern "C" bool C_GrVkYcbcrConversionInfo_Equals(const GrVkYcbcrConversionInfo* 
 }
 
 //
-// gpu/MutableTextureState.h
-//
-
-extern "C" skgpu::MutableTextureState* C_MutableTextureState_ConstructVK(VkImageLayout layout, uint32_t queueFamilyIndex) {
-    return new skgpu::MutableTextureState(layout, queueFamilyIndex);
-}
-
-extern "C" VkImageLayout C_MutableTextureState_getVkImageLayout(const skgpu::MutableTextureState* self) {
-    return self->getVkImageLayout();
-}
-
-extern "C" uint32_t C_MutableTextureState_getQueueFamilyIndex(const skgpu::MutableTextureState* self) {
-    return self->getQueueFamilyIndex();
-}
-
-//
 // gpu/ganesh/vk
 //
 
@@ -153,4 +138,27 @@ extern "C" GrDirectContext* C_GrDirectContexts_MakeVulkan(
         return GrDirectContexts::MakeVulkan(*vkBackendContext, *options).release();
     }
     return GrDirectContexts::MakeVulkan(*vkBackendContext).release();
+}
+
+// MutableTextureState.h
+
+
+extern "C" skgpu::MutableTextureState* C_MutableTextureStates_ConstructVulkan(VkImageLayout layout, uint32_t queueFamilyIndex) {
+    return new skgpu::MutableTextureState(layout, queueFamilyIndex);
+}
+
+extern "C" VkImageLayout C_MutableTextureState_getVkImageLayout(const skgpu::MutableTextureState* self) {
+    return self->getVkImageLayout();
+}
+
+extern "C" VkImageLayout C_MutableTextureStates_getVkImageLayout(const skgpu::MutableTextureState* self) {
+    return skgpu::MutableTextureStates::GetVkImageLayout(self);
+}
+
+extern "C" uint32_t C_MutableTextureState_getQueueFamilyIndex(const skgpu::MutableTextureState* self) {
+    return self->getQueueFamilyIndex();
+}
+
+extern "C" uint32_t C_MutableTextureStates_getVkQueueFamilyIndex(const skgpu::MutableTextureState* self) {
+    return skgpu::MutableTextureStates::GetVkQueueFamilyIndex(self);
 }

--- a/skia-bindings/src/vulkan.cpp
+++ b/skia-bindings/src/vulkan.cpp
@@ -7,6 +7,7 @@
 #include "include/gpu/GrDirectContext.h"
 #include "include/gpu/MutableTextureState.h"
 #include "include/gpu/ganesh/vk/GrVkBackendSurface.h"
+#include "include/gpu/ganesh/vk/GrVkDirectContext.h"
 #include "include/gpu/vk/GrVkTypes.h"
 #include "include/gpu/vk/GrVkBackendContext.h"
 #include "include/gpu/vk/GrVkExtensions.h"
@@ -89,15 +90,6 @@ extern "C" void C_GrVkBackendContext_setMaxAPIVersion(GrVkBackendContext *self, 
     self->fMaxAPIVersion = maxAPIVersion;
 }
 
-extern "C" GrDirectContext* C_GrDirectContext_MakeVulkan(
-    const GrVkBackendContext* vkBackendContext,
-    const GrContextOptions* options) {
-    if (options) {
-        return GrDirectContext::MakeVulkan(*vkBackendContext, *options).release();
-    }
-    return GrDirectContext::MakeVulkan(*vkBackendContext).release();
-}
-
 //
 // GrVkTypes.h
 //
@@ -114,8 +106,8 @@ extern "C" bool C_GrVkYcbcrConversionInfo_Equals(const GrVkYcbcrConversionInfo* 
 // gpu/MutableTextureState.h
 //
 
-extern "C" void C_MutableTextureState_ConstructVK(skgpu::MutableTextureState* uninitialized, VkImageLayout layout, uint32_t queueFamilyIndex) {
-    new(uninitialized)skgpu::MutableTextureState(layout, queueFamilyIndex);
+extern "C" skgpu::MutableTextureState* C_MutableTextureState_ConstructVK(VkImageLayout layout, uint32_t queueFamilyIndex) {
+    return new skgpu::MutableTextureState(layout, queueFamilyIndex);
 }
 
 extern "C" VkImageLayout C_MutableTextureState_getVkImageLayout(const skgpu::MutableTextureState* self) {
@@ -152,4 +144,13 @@ extern "C" bool C_GrBackendRenderTargets_GetVkImageInfo(const GrBackendRenderTar
 
 extern "C" void C_GrBackendRenderTargets_SetVkImageLayout(GrBackendRenderTarget* renderTarget, VkImageLayout imageLayout) {
     GrBackendRenderTargets::SetVkImageLayout(renderTarget, imageLayout);
+}
+
+extern "C" GrDirectContext* C_GrDirectContexts_MakeVulkan(
+    const GrVkBackendContext* vkBackendContext,
+    const GrContextOptions* options) {
+    if (options) {
+        return GrDirectContexts::MakeVulkan(*vkBackendContext, *options).release();
+    }
+    return GrDirectContexts::MakeVulkan(*vkBackendContext).release();
 }

--- a/skia-org/Cargo.toml
+++ b/skia-org/Cargo.toml
@@ -61,3 +61,6 @@ windows = { version = "0.52.0", features = [
     "Win32_Foundation",
     "Win32_Graphics_Dxgi_Common",
 ], optional = true }
+# default typeface
+once_cell = { version = "1.19.0" }
+

--- a/skia-org/src/helper.rs
+++ b/skia-org/src/helper.rs
@@ -1,0 +1,16 @@
+use once_cell::sync::OnceCell;
+
+use skia_safe::{FontMgr, FontStyle, Typeface};
+
+pub fn default_typeface() -> Typeface {
+    DEFAULT_TYPEFACE
+        .get_or_init(|| {
+            let font_mgr = FontMgr::new();
+            font_mgr
+                .legacy_make_typeface(None, FontStyle::default())
+                .unwrap()
+        })
+        .clone()
+}
+
+static DEFAULT_TYPEFACE: OnceCell<Typeface> = OnceCell::new();

--- a/skia-org/src/main.rs
+++ b/skia-org/src/main.rs
@@ -16,6 +16,7 @@ extern crate objc;
 
 mod artifact;
 mod drivers;
+mod helper;
 mod skcanvas_overview;
 mod skpaint_overview;
 #[cfg(feature = "textlayout")]

--- a/skia-org/src/skcanvas_overview.rs
+++ b/skia-org/src/skcanvas_overview.rs
@@ -1,8 +1,10 @@
-use crate::{resources, DrawingDriver};
-use skia_safe::{
-    paint, scalar, BlendMode, Canvas, Color, Font, Paint, Path, RRect, Rect, TextBlob, Typeface,
-};
 use std::path;
+
+use skia_safe::{
+    paint, scalar, BlendMode, Canvas, Color, Font, Paint, Path, RRect, Rect, TextBlob,
+};
+
+use crate::{helper::default_typeface, resources, DrawingDriver};
 
 pub fn draw(driver: &mut impl DrawingDriver, path: &path::Path) {
     let path = path.join("SkCanvas-Overview");
@@ -81,7 +83,7 @@ fn draw_hello_skia(canvas: &Canvas) {
 
     let text = TextBlob::from_str(
         "Hello, Skia!",
-        &Font::from_typeface(&Typeface::default(), 18.0),
+        &Font::from_typeface(default_typeface(), 18.0),
     )
     .unwrap();
     canvas.draw_text_blob(&text, (50, 25), &paint2);

--- a/skia-org/src/skpaint_overview.rs
+++ b/skia-org/src/skpaint_overview.rs
@@ -1,11 +1,13 @@
-use crate::{resources, DrawingDriver};
+use std::path;
+
 use skia_safe::{
     color_filters, corner_path_effect, dash_path_effect, discrete_path_effect, gradient_shader,
     line_2d_path_effect, paint, path_1d_path_effect, path_2d_path_effect, scalar, shaders,
-    AutoCanvasRestore, BlendMode, BlurStyle, Canvas, Color, Font, MaskFilter, Matrix, Paint, Path,
-    PathEffect, Point, Rect, SamplingOptions, TextBlob, TileMode, Typeface,
+    AutoCanvasRestore, BlendMode, BlurStyle, Canvas, Color, Font, FontMgr, FontStyle, MaskFilter,
+    Matrix, Paint, Path, PathEffect, Point, Rect, SamplingOptions, TextBlob, TileMode,
 };
-use std::path;
+
+use crate::{helper::default_typeface, resources, DrawingDriver};
 
 pub fn draw(driver: &mut impl DrawingDriver, path: &path::Path) {
     let path = &path.join("SkPaint-Overview");
@@ -74,12 +76,12 @@ fn draw_three_paints(canvas: &Canvas) {
 
     let blob1 = TextBlob::from_str(
         "Skia!",
-        &Font::from_typeface_with_params(Typeface::default(), 64.0, 1.0, 0.0),
+        &Font::from_typeface_with_params(default_typeface(), 64.0, 1.0, 0.0),
     )
     .unwrap();
     let blob2 = TextBlob::from_str(
         "Skia!",
-        &Font::from_typeface_with_params(Typeface::default(), 64.0, 1.5, 0.0),
+        &Font::from_typeface_with_params(default_typeface(), 64.0, 1.5, 0.0),
     )
     .unwrap();
 
@@ -104,7 +106,12 @@ fn draw_fill_and_stroke(canvas: &Canvas) {
     stroke_paint.set_stroke_width(5.0);
     canvas.draw_oval(Rect::from_point_and_size((150, 10), (60, 20)), stroke_paint);
 
-    let blob = TextBlob::from_str("SKIA", &Font::from_typeface(Typeface::default(), 80.0)).unwrap();
+    let font_mgr = FontMgr::default();
+    let default_typeface = font_mgr
+        .legacy_make_typeface(None, FontStyle::normal())
+        .unwrap();
+
+    let blob = TextBlob::from_str("SKIA", &Font::from_typeface(default_typeface, 80.0)).unwrap();
 
     fill_paint.set_color(Color::from_argb(0xFF, 0xFF, 0x00, 0x00));
     canvas.draw_text_blob(&blob, (20, 120), fill_paint);
@@ -172,7 +179,7 @@ fn draw_transfer_modes(canvas: &Canvas) {
         &mut Paint::default(),
     );
     stroke.set_style(paint::Style::Stroke);
-    let font = &Font::from_typeface(Typeface::default(), 24.0);
+    let font = &Font::from_typeface(default_typeface(), 24.0);
     let src_points: (Point, Point) = ((0.0, 0.0).into(), (64.0, 0.0).into());
     let src_colors = [Color::MAGENTA & 0x00_FF_FF_FF, Color::MAGENTA];
     src.set_shader(gradient_shader::linear(
@@ -317,8 +324,7 @@ fn draw_mask_filter(canvas: &Canvas) {
     );
     let paint = &mut Paint::default();
     paint.set_mask_filter(MaskFilter::blur(BlurStyle::Normal, 5.0, None));
-    let blob =
-        TextBlob::from_str("Skia", &Font::from_typeface(Typeface::default(), 120.0)).unwrap();
+    let blob = TextBlob::from_str("Skia", &Font::from_typeface(default_typeface(), 120.0)).unwrap();
     canvas.draw_text_blob(blob, (0, 160), paint);
 }
 

--- a/skia-org/src/skpaint_overview.rs
+++ b/skia-org/src/skpaint_overview.rs
@@ -106,12 +106,7 @@ fn draw_fill_and_stroke(canvas: &Canvas) {
     stroke_paint.set_stroke_width(5.0);
     canvas.draw_oval(Rect::from_point_and_size((150, 10), (60, 20)), stroke_paint);
 
-    let font_mgr = FontMgr::default();
-    let default_typeface = font_mgr
-        .legacy_make_typeface(None, FontStyle::normal())
-        .unwrap();
-
-    let blob = TextBlob::from_str("SKIA", &Font::from_typeface(default_typeface, 80.0)).unwrap();
+    let blob = TextBlob::from_str("SKIA", &Font::from_typeface(default_typeface(), 80.0)).unwrap();
 
     fill_paint.set_color(Color::from_argb(0xFF, 0xFF, 0x00, 0x00));
     canvas.draw_text_blob(&blob, (20, 120), fill_paint);

--- a/skia-org/src/skpaint_overview.rs
+++ b/skia-org/src/skpaint_overview.rs
@@ -3,8 +3,8 @@ use std::path;
 use skia_safe::{
     color_filters, corner_path_effect, dash_path_effect, discrete_path_effect, gradient_shader,
     line_2d_path_effect, paint, path_1d_path_effect, path_2d_path_effect, scalar, shaders,
-    AutoCanvasRestore, BlendMode, BlurStyle, Canvas, Color, Font, FontMgr, FontStyle, MaskFilter,
-    Matrix, Paint, Path, PathEffect, Point, Rect, SamplingOptions, TextBlob, TileMode,
+    AutoCanvasRestore, BlendMode, BlurStyle, Canvas, Color, Font, MaskFilter, Matrix, Paint, Path,
+    PathEffect, Point, Rect, SamplingOptions, TextBlob, TileMode,
 };
 
 use crate::{helper::default_typeface, resources, DrawingDriver};

--- a/skia-org/src/skshaper_example.rs
+++ b/skia-org/src/skshaper_example.rs
@@ -1,6 +1,8 @@
-use crate::DrawingDriver;
-use skia_safe::{Canvas, Font, Paint, Point, Shaper, Typeface};
 use std::path;
+
+use skia_safe::{Canvas, Font, FontMgr, Paint, Point, Shaper};
+
+use crate::{helper::default_typeface, DrawingDriver};
 
 pub fn draw(driver: &mut impl DrawingDriver, path: &path::Path) {
     let path = path.join("SkShaper-Example");
@@ -16,9 +18,9 @@ fn draw_rtl_shaped(canvas: &Canvas) {
     let mut paint = Paint::default();
     paint.set_anti_alias(true);
 
-    let font = &Font::from_typeface(Typeface::default(), 64.0);
+    let font = &Font::from_typeface(default_typeface(), 64.0);
 
-    let shaper = Shaper::new(None);
+    let shaper = Shaper::new(FontMgr::new());
     if let Some((blob, _)) =
         shaper.shape_text_blob(RTL_TEXT, font, false, 10000.0, Point::default())
     {
@@ -30,7 +32,7 @@ fn draw_rtl_unshaped(canvas: &Canvas) {
     let mut paint = Paint::default();
     paint.set_anti_alias(true);
 
-    let font = &Font::from_typeface(Typeface::default(), 64.0);
+    let font = &Font::from_typeface(default_typeface(), 64.0);
 
     let shaper = Shaper::new_primitive();
     if let Some((blob, _)) =

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -18,7 +18,7 @@ categories = [
 ]
 license = "MIT"
 
-version = "0.69.0"
+version = "0.70.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2021"
 
@@ -54,7 +54,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 [dependencies]
 bitflags = "2.0"
 lazy_static = "1.4"
-skia-bindings = { version = "=0.69.0", path = "../skia-bindings", default-features = false }
+skia-bindings = { version = "=0.70.0", path = "../skia-bindings", default-features = false }
 
 # D3D types & ComPtr
 windows = { version = "0.52.0", features = [

--- a/skia-safe/src/codec/_codec.rs
+++ b/skia-safe/src/codec/_codec.rs
@@ -414,6 +414,12 @@ pub mod codecs {
         }
     }
 
+    impl NativeClone for SkCodecs_Decoder {
+        fn clone(&self) -> Self {
+            construct(|d| unsafe { sb::C_SkCodecs_Decoder_CopyConstruct(d, self) })
+        }
+    }
+
     impl Decoder {
         pub fn id(&self) -> &'static str {
             let mut len: usize = 0;

--- a/skia-safe/src/codec/_codec.rs
+++ b/skia-safe/src/codec/_codec.rs
@@ -116,8 +116,22 @@ impl Codec<'_> {
 
     // TODO: wrap from_data with SkPngChunkReader
 
+    // TODO: Deprecated in Skia
     pub fn from_data(data: impl Into<Data>) -> Option<Codec<'static>> {
         Self::from_ptr(unsafe { sb::C_SkCodec_MakeFromData(data.into().into_ptr()) })
+    }
+
+    pub fn from_data_with_decoders(
+        data: impl Into<Data>,
+        decoders: &[codecs::Decoder],
+    ) -> Option<Codec<'static>> {
+        Self::from_ptr(unsafe {
+            sb::C_SkCodec_MakeFromData2(
+                data.into().into_ptr(),
+                decoders.as_ptr() as _,
+                decoders.len(),
+            )
+        })
     }
 
     pub fn info(&self) -> ImageInfo {

--- a/skia-safe/src/codec/decoders.rs
+++ b/skia-safe/src/codec/decoders.rs
@@ -1,112 +1,98 @@
-use std::{io, result};
+pub mod bmp_decoder {
+    use std::{io, result};
 
-use skia_bindings as sb;
+    use crate::{codec::codecs::Decoder, codec::Result, Codec};
 
-use super::{decode_stream, Codec, Decoder, Result};
-
-#[derive(Debug)]
-pub struct BmpDecoder;
-
-impl Decoder for BmpDecoder {
-    const ID: &'static str = "bmp";
-
-    fn is_format(data: &[u8]) -> bool {
-        unsafe { sb::C_SkBmpDecoder_IsBmp(data.as_ptr() as _, data.len()) }
+    pub fn decode_stream(stream: &mut impl io::Read) -> result::Result<Codec, Result> {
+        decoder().from_stream(stream)
     }
 
-    fn decode_stream(stream: &mut impl io::Read) -> result::Result<Codec, Result> {
-        decode_stream(stream, sb::C_SkBmpDecoder_Decode)
+    pub fn decoder() -> Decoder {
+        Decoder::construct(|decoder| unsafe { skia_bindings::C_SkBmpDecoder_Decoder(decoder) })
     }
 }
 
-#[derive(Debug)]
-pub struct GifDecoder;
+pub mod gif_decoder {
+    use std::{io, result};
 
-impl Decoder for GifDecoder {
-    const ID: &'static str = "gif";
+    use crate::{codec::codecs::Decoder, codec::Result, Codec};
 
-    fn is_format(data: &[u8]) -> bool {
-        unsafe { sb::C_SkGifDecoder_IsGif(data.as_ptr() as _, data.len()) }
+    pub fn decode_stream(stream: &mut impl io::Read) -> result::Result<Codec, Result> {
+        decoder().from_stream(stream)
     }
 
-    fn decode_stream(stream: &mut impl io::Read) -> result::Result<Codec, Result> {
-        decode_stream(stream, sb::C_SkGifDecoder_Decode)
-    }
-}
-
-#[derive(Debug)]
-pub struct IcoDecoder;
-
-impl Decoder for IcoDecoder {
-    const ID: &'static str = "ico";
-
-    fn is_format(data: &[u8]) -> bool {
-        unsafe { sb::C_SkIcoDecoder_IsIco(data.as_ptr() as _, data.len()) }
-    }
-
-    fn decode_stream(stream: &mut impl io::Read) -> result::Result<Codec, Result> {
-        decode_stream(stream, sb::C_SkIcoDecoder_Decode)
+    pub fn decoder() -> Decoder {
+        Decoder::construct(|decoder| unsafe { skia_bindings::C_SkGifDecoder_Decoder(decoder) })
     }
 }
 
-#[derive(Debug)]
-pub struct JpegDecoder;
+pub mod ico_decoder {
+    use std::{io, result};
 
-impl Decoder for JpegDecoder {
-    const ID: &'static str = "jpeg";
+    use crate::{codec::codecs::Decoder, codec::Result, Codec};
 
-    fn is_format(data: &[u8]) -> bool {
-        unsafe { sb::C_SkJpegDecoder_IsJpeg(data.as_ptr() as _, data.len()) }
+    pub fn decode_stream(stream: &mut impl io::Read) -> result::Result<Codec, Result> {
+        decoder().from_stream(stream)
     }
 
-    fn decode_stream(stream: &mut impl io::Read) -> result::Result<Codec, Result> {
-        decode_stream(stream, sb::C_SkJpegDecoder_Decode)
-    }
-}
-
-#[derive(Debug)]
-pub struct PngDecoder;
-
-impl Decoder for PngDecoder {
-    const ID: &'static str = "png";
-
-    fn is_format(data: &[u8]) -> bool {
-        unsafe { sb::C_SkPngDecoder_IsPng(data.as_ptr() as _, data.len()) }
-    }
-
-    fn decode_stream(stream: &mut impl io::Read) -> result::Result<Codec, Result> {
-        decode_stream(stream, sb::C_SkPngDecoder_Decode)
+    pub fn decoder() -> Decoder {
+        Decoder::construct(|decoder| unsafe { skia_bindings::C_SkIcoDecoder_Decoder(decoder) })
     }
 }
 
-#[derive(Debug)]
-pub struct WbmpDecoder;
+pub mod jpeg_decoder {
+    use std::{io, result};
 
-impl Decoder for WbmpDecoder {
-    const ID: &'static str = "Wbmp";
+    use crate::{codec::codecs::Decoder, codec::Result, Codec};
 
-    fn is_format(data: &[u8]) -> bool {
-        unsafe { sb::C_SkWbmpDecoder_IsWbmp(data.as_ptr() as _, data.len()) }
+    pub fn decode_stream(stream: &mut impl io::Read) -> result::Result<Codec, Result> {
+        decoder().from_stream(stream)
     }
 
-    fn decode_stream(stream: &mut impl io::Read) -> result::Result<Codec, Result> {
-        decode_stream(stream, sb::C_SkWbmpDecoder_Decode)
+    pub fn decoder() -> Decoder {
+        Decoder::construct(|decoder| unsafe { skia_bindings::C_SkJpegDecoder_Decoder(decoder) })
+    }
+}
+
+pub mod png_decoder {
+    use std::{io, result};
+
+    use crate::{codec::codecs::Decoder, codec::Result, Codec};
+
+    pub fn decode_stream(stream: &mut impl io::Read) -> result::Result<Codec, Result> {
+        decoder().from_stream(stream)
+    }
+
+    pub fn decoder() -> Decoder {
+        Decoder::construct(|decoder| unsafe { skia_bindings::C_SkPngDecoder_Decoder(decoder) })
+    }
+}
+
+pub mod wbmp_decoder {
+    use std::{io, result};
+
+    use crate::{codec::codecs::Decoder, codec::Result, Codec};
+
+    pub fn decode_stream(stream: &mut impl io::Read) -> result::Result<Codec, Result> {
+        decoder().from_stream(stream)
+    }
+
+    pub fn decoder() -> Decoder {
+        Decoder::construct(|decoder| unsafe { skia_bindings::C_SkWbmpDecoder_Decoder(decoder) })
     }
 }
 
 #[cfg(feature = "webp-decode")]
-#[derive(Debug)]
-pub struct WebpDecoder;
+pub mod webp_decoder {
+    use std::{io, result};
 
-#[cfg(feature = "webp-decode")]
-impl Decoder for WebpDecoder {
-    const ID: &'static str = "Webp";
+    use crate::{codec::codecs::Decoder, codec::Result, Codec};
 
-    fn is_format(data: &[u8]) -> bool {
-        unsafe { sb::C_SkWebpDecoder_IsWebp(data.as_ptr() as _, data.len()) }
+    pub fn decode_stream(stream: &mut impl io::Read) -> result::Result<Codec, Result> {
+        decoder().from_stream(stream)
     }
 
-    fn decode_stream(stream: &mut impl io::Read) -> result::Result<Codec, Result> {
-        decode_stream(stream, sb::C_SkWebpDecoder_Decode)
+    pub fn decoder() -> Decoder {
+        Decoder::construct(|decoder| unsafe { skia_bindings::C_SkWebpDecoder_Decoder(decoder) })
     }
 }

--- a/skia-safe/src/core/font.rs
+++ b/skia-safe/src/core/font.rs
@@ -425,17 +425,28 @@ impl Font {
     }
 }
 
-#[test]
-fn test_flags() {
-    let mut font = Font::new(Typeface::default(), 10.0);
+#[cfg(test)]
+mod tests {
+    use crate::{FontMgr, FontStyle};
 
-    font.set_force_auto_hinting(true);
-    assert!(font.is_force_auto_hinting());
-    font.set_force_auto_hinting(false);
-    assert!(!font.is_force_auto_hinting());
+    use super::*;
 
-    font.set_embolden(true);
-    assert!(font.is_embolden());
-    font.set_embolden(false);
-    assert!(!font.is_embolden());
+    #[test]
+    fn test_flags() {
+        let font_mgr = FontMgr::new();
+        let typeface = font_mgr
+            .legacy_make_typeface(None, FontStyle::normal())
+            .unwrap();
+        let mut font = Font::new(typeface, 10.0);
+
+        font.set_force_auto_hinting(true);
+        assert!(font.is_force_auto_hinting());
+        font.set_force_auto_hinting(false);
+        assert!(!font.is_force_auto_hinting());
+
+        font.set_embolden(true);
+        assert!(font.is_embolden());
+        font.set_embolden(false);
+        assert!(!font.is_embolden());
+    }
 }

--- a/skia-safe/src/core/font_mgr.rs
+++ b/skia-safe/src/core/font_mgr.rs
@@ -1,11 +1,11 @@
+use skia_bindings::{self as sb, SkFontMgr, SkFontStyleSet, SkRefCntBase};
+use std::{ffi::CString, fmt, mem, os::raw::c_char, ptr};
+
 use crate::{
     interop::{self, DynamicMemoryWStream},
     prelude::*,
     FontStyle, Typeface, Unichar,
 };
-use core::fmt;
-use skia_bindings::{self as sb, SkFontMgr, SkFontStyleSet, SkRefCntBase};
-use std::{ffi::CString, mem, os::raw::c_char};
 
 pub type FontStyleSet = RCHandle<SkFontStyleSet>;
 
@@ -211,6 +211,24 @@ impl FontMgr {
                 self.native(),
                 stream_ptr,
                 ttc_index.into().unwrap_or_default().try_into().unwrap(),
+            )
+        })
+    }
+
+    pub fn legacy_make_typeface<'a>(
+        &self,
+        family_name: impl Into<Option<&'a str>>,
+        style: FontStyle,
+    ) -> Option<Typeface> {
+        let family_name: Option<CString> = family_name
+            .into()
+            .and_then(|family_name| CString::new(family_name).ok());
+
+        Typeface::from_ptr(unsafe {
+            sb::C_SkFontMgr_legacyMakeTypeface(
+                self.native(),
+                family_name.map(|n| n.as_ptr()).unwrap_or(ptr::null()),
+                style.into_native(),
             )
         })
     }

--- a/skia-safe/src/core/font_types.rs
+++ b/skia-safe/src/core/font_types.rs
@@ -23,8 +23,8 @@ native_transmutable!(SkTextEncoding, TextEncoding, text_encoding_layout);
 /// UTF-8 encoded text. In addition to that, &[u16], [u16], or &[GlyphId], [GlyphId], are
 /// interpreted as `GlyphId` slices.
 ///
-/// To use UTF16 or UTF32 encodings, use [`skia_safe::as_utf16_unchecked`] or
-/// [`skia_safe::as_utf32_unchecked`].
+/// To use UTF16 or UTF32 encodings, use [`as_utf16_unchecked`] or
+/// [`as_utf32_unchecked`].
 pub trait EncodedText {
     fn as_raw(&self) -> (*const ffi::c_void, usize, TextEncoding);
 }

--- a/skia-safe/src/core/milestone.rs
+++ b/skia-safe/src/core/milestone.rs
@@ -1,1 +1,1 @@
-pub const MILESTONE: usize = 120;
+pub const MILESTONE: usize = 121;

--- a/skia-safe/src/core/surface_props.rs
+++ b/skia-safe/src/core/surface_props.rs
@@ -1,6 +1,8 @@
-use crate::prelude::*;
-use skia_bindings::{self as sb, SkPixelGeometry, SkSurfaceProps};
 use std::fmt;
+
+use skia_bindings::{self as sb, SkPixelGeometry, SkSurfaceProps};
+
+use crate::prelude::*;
 
 // TODO: use the enum rewriter and strip underscores?
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]

--- a/skia-safe/src/core/typeface.rs
+++ b/skia-safe/src/core/typeface.rs
@@ -1,4 +1,4 @@
-use std::{ffi, fmt, io, ptr};
+use std::{ffi, fmt, io, mem, ptr};
 
 use skia_bindings::{self as sb, SkRefCntBase, SkTypeface, SkTypeface_LocalizedStrings};
 
@@ -11,8 +11,6 @@ use crate::{
 };
 
 pub type TypefaceId = skia_bindings::SkTypefaceID;
-#[deprecated(since = "0.49.0", note = "use TypefaceId")]
-pub type FontId = TypefaceId;
 pub type FontTableTag = skia_bindings::SkFontTableTag;
 
 pub use skia_bindings::SkTypeface_SerializeBehavior as SerializeBehavior;

--- a/skia-safe/src/core/typeface.rs
+++ b/skia-safe/src/core/typeface.rs
@@ -1,4 +1,4 @@
-use std::{ffi, fmt, io, mem, ptr};
+use std::{ffi, fmt, io, ptr};
 
 use skia_bindings::{self as sb, SkRefCntBase, SkTypeface, SkTypeface_LocalizedStrings};
 

--- a/skia-safe/src/gpu.rs
+++ b/skia-safe/src/gpu.rs
@@ -63,6 +63,8 @@ pub mod backend_render_targets {
 pub mod direct_contexts {
     #[cfg(feature = "gl")]
     pub use super::ganesh::gl::direct_contexts::*;
+    #[cfg(feature = "vulkan")]
+    pub use super::ganesh::vk::direct_contexts::*;
 }
 
 #[cfg(test)]

--- a/skia-safe/src/gpu/backend_surface.rs
+++ b/skia-safe/src/gpu/backend_surface.rs
@@ -1,8 +1,6 @@
 use std::fmt;
 
-use skia_bindings::{
-    self as sb, GrBackendFormat, GrBackendRenderTarget, GrBackendTexture, GrMipmapped,
-};
+use skia_bindings::{self as sb, GrBackendFormat, GrBackendRenderTarget, GrBackendTexture};
 
 #[cfg(feature = "d3d")]
 use super::d3d;
@@ -338,7 +336,7 @@ impl BackendTexture {
     }
 
     pub fn has_mipmaps(&self) -> bool {
-        self.native().fMipmapped == GrMipmapped::Yes
+        self.native().fMipmapped == Mipmapped::Yes
     }
 
     pub fn backend(&self) -> BackendAPI {

--- a/skia-safe/src/gpu/direct_context.rs
+++ b/skia-safe/src/gpu/direct_context.rs
@@ -97,15 +97,7 @@ impl DirectContext {
         backend_context: &vk::BackendContext,
         options: impl Into<Option<&'a ContextOptions>>,
     ) -> Option<DirectContext> {
-        unsafe {
-            let end_resolving = backend_context.begin_resolving();
-            let context = DirectContext::from_ptr(sb::C_GrDirectContext_MakeVulkan(
-                backend_context.native.as_ptr() as _,
-                options.into().native_ptr_or_null(),
-            ));
-            drop(end_resolving);
-            context
-        }
+        crate::gpu::direct_contexts::make_vulkan(backend_context, options)
     }
 
     #[cfg(feature = "metal")]

--- a/skia-safe/src/gpu/ganesh/vk.rs
+++ b/skia-safe/src/gpu/ganesh/vk.rs
@@ -1,3 +1,5 @@
 mod vk_backend_surface;
+mod vk_direct_context;
 
 pub use vk_backend_surface::*;
+pub use vk_direct_context::*;

--- a/skia-safe/src/gpu/ganesh/vk/vk_direct_context.rs
+++ b/skia-safe/src/gpu/ganesh/vk/vk_direct_context.rs
@@ -1,0 +1,23 @@
+pub mod direct_contexts {
+    use skia_bindings as sb;
+
+    use crate::{
+        gpu::{vk, ContextOptions, DirectContext},
+        prelude::*,
+    };
+
+    pub fn make_vulkan<'a>(
+        backend_context: &vk::BackendContext,
+        options: impl Into<Option<&'a ContextOptions>>,
+    ) -> Option<DirectContext> {
+        unsafe {
+            let end_resolving = backend_context.begin_resolving();
+            let context = DirectContext::from_ptr(sb::C_GrDirectContexts_MakeVulkan(
+                backend_context.native.as_ptr() as _,
+                options.into().native_ptr_or_null(),
+            ));
+            drop(end_resolving);
+            context
+        }
+    }
+}

--- a/skia-safe/src/gpu/mutable_texture_state.rs
+++ b/skia-safe/src/gpu/mutable_texture_state.rs
@@ -1,26 +1,20 @@
-use super::BackendApi;
-use crate::prelude::*;
-use skia_bindings::{self as sb, skgpu_MutableTextureState};
 use std::fmt;
 
-pub type MutableTextureState = Handle<skgpu_MutableTextureState>;
+use skia_bindings::{self as sb, skgpu_MutableTextureState, SkRefCntBase};
+
+use super::BackendApi;
+use crate::prelude::*;
+
+pub type MutableTextureState = RCHandle<skgpu_MutableTextureState>;
 unsafe_send_sync!(MutableTextureState);
 
-impl NativeDrop for skgpu_MutableTextureState {
-    fn drop(&mut self) {
-        unsafe { sb::C_MutableTextureState_destruct(self) }
-    }
-}
-
-impl NativeClone for skgpu_MutableTextureState {
-    fn clone(&self) -> Self {
-        construct(|s| unsafe { sb::C_MutableTextureState_CopyConstruct(s, self) })
-    }
+impl NativeRefCountedBase for skgpu_MutableTextureState {
+    type Base = SkRefCntBase;
 }
 
 impl Default for MutableTextureState {
     fn default() -> Self {
-        Self::construct(|s| unsafe { sb::C_MutableTextureState_Construct(s) })
+        MutableTextureState::from_ptr(unsafe { sb::C_MutableTextureState_Construct() }).unwrap()
     }
 }
 
@@ -37,12 +31,19 @@ impl fmt::Debug for MutableTextureState {
 }
 
 impl MutableTextureState {
+    pub fn copied(&self) -> Self {
+        MutableTextureState::from_ptr(unsafe {
+            sb::C_MutableTextureState_CopyConstruct(self.native())
+        })
+        .unwrap()
+    }
+
     #[cfg(feature = "vulkan")]
     pub fn new_vk(layout: crate::gpu::vk::ImageLayout, queue_family_index: u32) -> Self {
-        Self::construct(|ptr| unsafe {
-            sb::C_MutableTextureState_ConstructVK(ptr, layout, queue_family_index)
-        })
+        Self::from_ptr(unsafe { sb::C_MutableTextureState_ConstructVK(layout, queue_family_index) })
+            .unwrap()
     }
+
     #[cfg(feature = "vulkan")]
     pub fn vk_image_layout(&self) -> sb::VkImageLayout {
         unsafe { sb::C_MutableTextureState_getVkImageLayout(self.native()) }

--- a/skia-safe/src/gpu/mutable_texture_state.rs
+++ b/skia-safe/src/gpu/mutable_texture_state.rs
@@ -40,8 +40,7 @@ impl MutableTextureState {
 
     #[cfg(feature = "vulkan")]
     pub fn new_vk(layout: crate::gpu::vk::ImageLayout, queue_family_index: u32) -> Self {
-        Self::from_ptr(unsafe { sb::C_MutableTextureState_ConstructVK(layout, queue_family_index) })
-            .unwrap()
+        crate::gpu::vk::mutable_texture_states::new_vulkan(layout, queue_family_index)
     }
 
     #[cfg(feature = "vulkan")]

--- a/skia-safe/src/gpu/types.rs
+++ b/skia-safe/src/gpu/types.rs
@@ -5,7 +5,7 @@ pub use skia_bindings::GrBackendApi as BackendAPI;
 variant_name!(BackendAPI::OpenGL);
 
 #[deprecated(since = "0.35.0", note = "Use Mipmapped (with a lowercase 'm')")]
-pub use skia_bindings::GrMipmapped as MipMapped;
+pub use skia_bindings::skgpu_Mipmapped as MipMapped;
 variant_name!(MipMapped::Yes);
 
 pub use skia_bindings::GrSurfaceOrigin as SurfaceOrigin;

--- a/skia-safe/src/gpu/types.rs
+++ b/skia-safe/src/gpu/types.rs
@@ -4,10 +4,6 @@ use std::ptr;
 pub use skia_bindings::GrBackendApi as BackendAPI;
 variant_name!(BackendAPI::OpenGL);
 
-#[deprecated(since = "0.35.0", note = "Use Mipmapped (with a lowercase 'm')")]
-pub use skia_bindings::skgpu_Mipmapped as MipMapped;
-variant_name!(MipMapped::Yes);
-
 pub use skia_bindings::GrSurfaceOrigin as SurfaceOrigin;
 variant_name!(SurfaceOrigin::BottomLeft);
 

--- a/skia-safe/src/gpu/vk.rs
+++ b/skia-safe/src/gpu/vk.rs
@@ -1,11 +1,13 @@
+use std::{ops::Deref, ptr};
+
 use skia_bindings as sb;
-use std::ops::Deref;
-use std::ptr;
 
 mod backend_context;
-pub use backend_context::*;
-
+mod mutable_texture_state;
 mod types;
+
+pub use backend_context::*;
+pub use mutable_texture_state::*;
 pub use types::*;
 
 //

--- a/skia-safe/src/gpu/vk/mutable_texture_state.rs
+++ b/skia-safe/src/gpu/vk/mutable_texture_state.rs
@@ -1,0 +1,23 @@
+pub mod mutable_texture_states {
+    use skia_bindings as sb;
+
+    use crate::{
+        gpu::{vk::ImageLayout, MutableTextureState},
+        prelude::*,
+    };
+
+    pub fn new_vulkan(layout: ImageLayout, queue_family_index: u32) -> MutableTextureState {
+        MutableTextureState::from_ptr(unsafe {
+            sb::C_MutableTextureStates_ConstructVulkan(layout, queue_family_index)
+        })
+        .unwrap()
+    }
+
+    pub fn get_vk_image_layout(state: &MutableTextureState) -> sb::VkImageLayout {
+        unsafe { sb::C_MutableTextureStates_getVkImageLayout(state.native()) }
+    }
+
+    pub fn get_vk_queue_family_index(state: &MutableTextureState) -> u32 {
+        unsafe { sb::C_MutableTextureStates_getVkQueueFamilyIndex(state.native()) }
+    }
+}

--- a/skia-safe/src/lib.rs
+++ b/skia-safe/src/lib.rs
@@ -10,7 +10,7 @@ mod macros;
 pub mod codec;
 #[deprecated(since = "0.33.1", note = "use codec::Result")]
 pub use codec::Result as CodecResult;
-pub use codec::{Codec, EncodedImageFormat, EncodedOrigin};
+pub use codec::{codecs, Codec, EncodedImageFormat, EncodedOrigin};
 
 mod core;
 mod docs;

--- a/skia-safe/src/modules/paragraph/font_collection.rs
+++ b/skia-safe/src/modules/paragraph/font_collection.rs
@@ -167,6 +167,23 @@ impl FontCollection {
         Typeface::from_ptr(unsafe { sb::C_FontCollection_defaultFallback2(self.native_mut()) })
     }
 
+    pub fn default_emoji_fallback(
+        &mut self,
+        emoji_start: Unichar,
+        font_style: FontStyle,
+        locale: impl AsRef<str>,
+    ) -> Option<Typeface> {
+        let locale = interop::String::from_str(locale.as_ref());
+        Typeface::from_ptr(unsafe {
+            sb::C_FontCollection_defaultEmojiFallback(
+                self.native_mut(),
+                emoji_start,
+                font_style.into_native(),
+                locale.native(),
+            )
+        })
+    }
+
     pub fn disable_font_fallback(&mut self) {
         unsafe { self.native_mut().disableFontFallback() }
     }

--- a/skia-safe/src/modules/paragraph/typeface_font_provider.rs
+++ b/skia-safe/src/modules/paragraph/typeface_font_provider.rs
@@ -137,7 +137,7 @@ mod tests {
     use crate::{
         prelude::{NativeAccess, NativeRefCounted, NativeRefCountedBase},
         textlayout::FontCollection,
-        Typeface,
+        FontMgr, FontStyle,
     };
 
     #[test]
@@ -146,7 +146,9 @@ mod tests {
         let mut style_set = TypefaceFontStyleSet::new("");
         assert_eq!(style_set.native().ref_counted_base()._ref_cnt(), 1);
 
-        let tf = Typeface::default();
+        let tf = FontMgr::new()
+            .legacy_make_typeface(None, FontStyle::default())
+            .unwrap();
         let base_cnt = tf.native().ref_counted_base()._ref_cnt();
 
         let tfclone = tf.clone();
@@ -164,7 +166,9 @@ mod tests {
     #[serial_test::serial]
     fn treat_font_provider_as_font_mgr() {
         let mut font_collection = FontCollection::new();
-        let typeface = Typeface::default();
+        let typeface = FontMgr::new()
+            .legacy_make_typeface(None, FontStyle::default())
+            .unwrap();
         let mut manager = TypefaceFontProvider::new();
         manager.register_typeface(typeface, Some("AlArabiya"));
         assert_eq!(font_collection.font_managers_count(), 0);

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -728,7 +728,6 @@ impl Shaper {
 }
 
 pub mod icu {
-
     /// On Windows, and if the default feature "embed-icudtl" is _not_ set, this function writes the
     /// file `icudtl.dat` into the current executable's directory making sure that it's available
     /// when text shaping is used in Skia.
@@ -752,7 +751,7 @@ pub mod icu {
         let mut text_blob_builder_run_handler =
             crate::shaper::TextBlobBuilderRunHandler::new(str, crate::Point::default());
 
-        let shaper = crate::Shaper::new(None);
+        let shaper = crate::Shaper::new(crate::FontMgr::new());
 
         shaper.shape(
             "العربية",

--- a/skia-safe/src/prelude.rs
+++ b/skia-safe/src/prelude.rs
@@ -584,10 +584,9 @@ impl<N: NativeRefCounted> RCHandle<N> {
 mod rc_handle_tests {
     use std::ptr;
 
-    use skia_bindings::SkTypeface;
+    use skia_bindings::{SkFontMgr, SkTypeface};
 
-    use crate::prelude::NativeAccess;
-    use crate::Typeface;
+    use crate::{prelude::NativeAccess, FontMgr, Typeface};
 
     #[test]
     fn rc_native_ref_null() {
@@ -598,9 +597,9 @@ mod rc_handle_tests {
 
     #[test]
     fn rc_native_ref_non_null() {
-        let mut tf = Typeface::default();
-        let f: *mut SkTypeface = tf.native_mut();
-        let r = Typeface::from_unshared_ptr(f);
+        let mut font_mgr = FontMgr::new();
+        let f: *mut SkFontMgr = font_mgr.native_mut();
+        let r = FontMgr::from_unshared_ptr(f);
         assert!(r.is_some())
     }
 }

--- a/skia-safe/tests/codec.rs
+++ b/skia-safe/tests/codec.rs
@@ -3,7 +3,7 @@ use std::io;
 
 use skia_safe::{
     codec::{self, codecs::Decoder},
-    Bitmap, Data, EncodedImageFormat,
+    Bitmap, Codec, Data, EncodedImageFormat,
 };
 
 /// The supported encoders.
@@ -69,6 +69,24 @@ fn test_supported_decoders() {
         .collect();
 
     assert_eq!(supported, supported_decoders());
+}
+
+#[test]
+fn test_from_stream() {
+    let all_decoders: Vec<_> = DECODER_TESTS
+        .iter()
+        .map(|(_, decoder_fn, _)| decoder_fn())
+        .collect();
+
+    for (format, _, bytes) in DECODER_TESTS {
+        let mut cursor = io::Cursor::new(*bytes);
+        match Codec::from_stream(&mut cursor, &all_decoders, None) {
+            Ok(codec) => assert_eq!(codec.encoded_format(), *format),
+            Err(err) => {
+                panic!("Stream decoding of {format:?} failed: {err:?}");
+            }
+        }
+    }
 }
 
 type DecoderTest = (EncodedImageFormat, fn() -> Decoder, &'static [u8]);

--- a/skia-safe/tests/codec.rs
+++ b/skia-safe/tests/codec.rs
@@ -2,7 +2,7 @@
 use std::io;
 
 use skia_safe::{
-    codec::{self, Decoder},
+    codec::{self, codecs::Decoder},
     Bitmap, Data, EncodedImageFormat,
 };
 
@@ -56,8 +56,8 @@ fn test_supported_encoders() {
 fn test_supported_decoders() {
     let supported: Vec<EncodedImageFormat> = DECODER_TESTS
         .iter()
-        .filter(|(format, test_decoder, bytes)| {
-            test_decoder(bytes);
+        .filter(|(format, decoder_f, bytes)| {
+            test_decoder(decoder_f(), bytes);
             let data = Data::new_copy(bytes);
             if let Some(codec) = codec::Codec::from_data(data) {
                 codec.encoded_format() == *format
@@ -71,56 +71,54 @@ fn test_supported_decoders() {
     assert_eq!(supported, supported_decoders());
 }
 
-type DecoderTest = (EncodedImageFormat, fn(bytes: &[u8]), &'static [u8]);
+type DecoderTest = (EncodedImageFormat, fn() -> Decoder, &'static [u8]);
 
 // image files copied from skia/resources/images
 const DECODER_TESTS: &[DecoderTest] = &[
     (
         EncodedImageFormat::BMP,
-        test_decoder::<codec::BmpDecoder>,
+        codec::bmp_decoder::decoder,
         include_bytes!("images/randPixels.bmp"),
     ),
     (
         EncodedImageFormat::GIF,
-        test_decoder::<codec::GifDecoder>,
+        codec::gif_decoder::decoder,
         include_bytes!("images/box.gif"),
     ),
     (
         EncodedImageFormat::ICO,
-        test_decoder::<codec::IcoDecoder>,
+        codec::ico_decoder::decoder,
         include_bytes!("images/color_wheel.ico"),
     ),
     (
         EncodedImageFormat::JPEG,
-        test_decoder::<codec::JpegDecoder>,
+        codec::jpeg_decoder::decoder,
         include_bytes!("images/color_wheel.jpg"),
     ),
     (
         EncodedImageFormat::PNG,
-        test_decoder::<codec::PngDecoder>,
+        codec::png_decoder::decoder,
         include_bytes!("images/mandrill_16.png"),
     ),
     (
         EncodedImageFormat::WBMP,
-        test_decoder::<codec::WbmpDecoder>,
+        codec::wbmp_decoder::decoder,
         include_bytes!("images/mandrill.wbmp"),
     ),
     #[cfg(feature = "webp-decode")]
     (
         EncodedImageFormat::WEBP,
-        test_decoder::<codec::WebpDecoder>,
+        codec::webp_decoder::decoder,
         include_bytes!("images/color_wheel.webp"),
     ),
-    // (
-    //     EncodedImageFormat::DNG,
-    //     include_bytes!("images/sample_1mp.dng"),
-    // ),
 ];
 
-fn test_decoder<D: Decoder>(bytes: &[u8]) {
-    assert!(D::is_format(bytes));
+fn test_decoder(decoder: Decoder, bytes: &[u8]) {
+    assert!(decoder.is_format(bytes));
     let stream = &mut io::Cursor::new(bytes);
-    let codec = D::decode_stream(stream).expect("decode_stream");
+    let codec = decoder
+        .from_stream(stream)
+        .expect("decoder.from_stream returned an error");
     let d = codec.dimensions();
     assert!(d.width > 0 && d.height > 0);
 }

--- a/skia-safe/tests/send_sync.rs
+++ b/skia-safe/tests/send_sync.rs
@@ -182,7 +182,6 @@ mod gpu {
 
     // gpu/types.rs
     assert_impl_all!(BackendAPI: Send, Sync);
-    assert_impl_all!(MipMapped: Send, Sync);
     assert_impl_all!(SurfaceOrigin: Send, Sync);
     assert_not_impl_any!(FlushInfo: Send, Sync);
     assert_impl_all!(SemaphoresSubmitted: Send, Sync);

--- a/skia-safe/tests/send_sync.rs
+++ b/skia-safe/tests/send_sync.rs
@@ -17,7 +17,7 @@ fn sendable_implements_send() {
 }
 
 mod codec {
-    use skia_safe::{codec, Codec};
+    use skia_safe::{codec, codecs, Codec};
     use static_assertions::*;
 
     // Codec seems to call into SkPngChunkReader*
@@ -28,14 +28,7 @@ mod codec {
     assert_impl_all!(codec::ZeroInitialized: Send, Sync);
     assert_impl_all!(codec::ScanlineOrder: Send, Sync);
 
-    assert_impl_all!(codec::BmpDecoder: Send, Sync);
-    assert_impl_all!(codec::GifDecoder: Send, Sync);
-    assert_impl_all!(codec::IcoDecoder: Send, Sync);
-    assert_impl_all!(codec::JpegDecoder: Send, Sync);
-    assert_impl_all!(codec::PngDecoder: Send, Sync);
-    assert_impl_all!(codec::WbmpDecoder: Send, Sync);
-    #[cfg(feature = "webp_decode")]
-    assert_impl_all!(codec::WebpDecoder: Send, Sync);
+    assert_impl_all!(codecs::Decoder: Send, Sync);
 }
 
 mod core {


### PR DESCRIPTION
This PR updates rust-skia to support Skia's `chrome/m121` branch.

- [x] Update `README.md` ([rendered](https://github.com/pragmatrix/rust-skia/blob/m121/README.md))  
  > Most important here is to change the Skia branch name and the current Skia submodule tag at the top of the `README.md` file.
- [x] Diff the the following files to see if the build organization has changed significantly:
  - [x] `/BUILD.gn`
  - [x] `/gn/*` (recursively)
  - [x] `/modules/skshaper/BUILD.gn`
  - [x] `/modules/paragraph/BUILD.gn`
- [x] Skia builds ([release notes](https://github.com/google/skia/blob/chrome/m121/RELEASE_NOTES.md)).
- [x] `/skia-bindings` builds.
- [ ] `/skia-safe`: Update & add new wrappers by diffing include files.  
  > Add TODOs for everything that can not be updated right now, and attempt to stay compatible with previous versions of skia-safe without trying too hard before version 1.0. Use `deprecated` attributes if needed.
  - [ ] `codec/`
  - [x] `core/`
  - [x] `docs/`
  - [x] `effects/`
  - [x] `encode/`
  - [x] `gpu/`
    - [x] `d3d/`
    - [x] `ganesh/`
    - [x] `gl/`
    - [x] `mtl/`
    - [x] `vk/`
  - [x] `pathops/`
  - [x] `svg/`
  - [x] `utils/`
  - [x] `modules/`
    - [x] `paragraph/`
    - [x] `shaper/`
  - [x] `private/base/*`
    - [x] `SkPoint_impl.h`
- [x] Review `Send` & `Sync` implementations for new wrappers.
- [x] Review `Debug` implementation for new wrapper types and functions.
- [x] Release date of the matching Chrome version in less than 7 days?
- [x] Any pending changes in the Skia `chrome/m121` branch that aren't synchronized yet?
- [x] Rebase on or merge with master.
- [x] Do the `rust-skia:` commits in the `skia-bindings/skia` subdirectory match with `master` (`make diff-skia`).
- [x] Update versions of `skia-bindings/Cargo.toml` and `skia-safe/Cargo.toml` and also add the version to the new `deprecated` attributes.
- [x] Do the tags/hashes in `skia-bindings/Cargo.toml` under `[package.metadata]` match the submodules `depot_tools` and `skia`?
- [x] Check for API changes: `make diff-api`.
- [ ] Test builds we don't do on the CI:
  - [ ] Compiles to Catalyst targets on macOS (#548).
    ```zsh
    make macos-qa
    ```
- [x] Do one final review of all the changes.
- [x] Run `make doc` and fix all warnings.