### PR TITLE
Improve the safety of functions that expect text in different encodings

### DIFF
--- a/skia-bindings/src/lib.rs
+++ b/skia-bindings/src/lib.rs
@@ -11,6 +11,7 @@
 include!(concat!(env!("OUT_DIR"), "/skia/bindings.rs"));
 
 mod defaults;
+#[allow(unused_imports)]
 pub use defaults::*;
 
 mod impls;

--- a/skia-safe/src/core/font.rs
+++ b/skia-safe/src/core/font.rs
@@ -215,15 +215,11 @@ impl Font {
     }
 
     pub fn str_to_glyphs(&self, str: impl AsRef<str>, glyphs: &mut [GlyphId]) -> usize {
-        self.text_to_glyphs(str.as_ref().as_bytes(), glyphs)
+        self.text_to_glyphs(str.as_ref(), glyphs)
     }
 
-    pub fn text_to_glyphs<'a>(
-        &self,
-        text: impl Into<EncodedText<'a>>,
-        glyphs: &mut [GlyphId],
-    ) -> usize {
-        let (ptr, size, encoding) = text.into().raw();
+    pub fn text_to_glyphs(&self, text: impl EncodedText, glyphs: &mut [GlyphId]) -> usize {
+        let (ptr, size, encoding) = text.as_raw();
         unsafe {
             self.native()
                 .textToGlyphs(
@@ -244,11 +240,11 @@ impl Font {
     }
 
     pub fn count_str(&self, str: impl AsRef<str>) -> usize {
-        self.count_text(str.as_ref().as_bytes())
+        self.count_text(str.as_ref())
     }
 
-    pub fn count_text<'a>(&self, text: impl Into<EncodedText<'a>>) -> usize {
-        let (ptr, size, encoding) = text.into().raw();
+    pub fn count_text(&self, text: impl EncodedText) -> usize {
+        let (ptr, size, encoding) = text.as_raw();
         unsafe {
             self.native()
                 .textToGlyphs(
@@ -265,13 +261,12 @@ impl Font {
 
     // convenience function
     pub fn str_to_glyphs_vec(&self, str: impl AsRef<str>) -> Vec<GlyphId> {
-        self.text_to_glyphs_vec(str.as_ref().as_bytes())
+        self.text_to_glyphs_vec(str.as_ref())
     }
 
     // convenience function
-    pub fn text_to_glyphs_vec<'a>(&self, text: impl Into<EncodedText<'a>>) -> Vec<GlyphId> {
-        let text = text.into();
-        let count = self.count_text(text);
+    pub fn text_to_glyphs_vec<'a>(&self, text: impl EncodedText) -> Vec<GlyphId> {
+        let count = self.count_text(&text);
         let mut glyphs: Vec<GlyphId> = vec![Default::default(); count];
         let resulting_count = self.text_to_glyphs(text, glyphs.as_mut_slice());
         assert_eq!(count, resulting_count);
@@ -279,17 +274,16 @@ impl Font {
     }
 
     pub fn measure_str(&self, str: impl AsRef<str>, paint: Option<&Paint>) -> (scalar, Rect) {
-        let bytes = str.as_ref().as_bytes();
-        self.measure_text(bytes, paint)
+        self.measure_text(str.as_ref(), paint)
     }
 
     pub fn measure_text<'a>(
         &self,
-        text: impl Into<EncodedText<'a>>,
+        text: impl EncodedText,
         paint: Option<&Paint>,
     ) -> (scalar, Rect) {
         let mut bounds = Rect::default();
-        let (ptr, size, encoding) = text.into().raw();
+        let (ptr, size, encoding) = text.as_raw();
         let width = unsafe {
             self.native().measureText(
                 ptr,

--- a/skia-safe/src/core/font.rs
+++ b/skia-safe/src/core/font.rs
@@ -265,7 +265,7 @@ impl Font {
     }
 
     // convenience function
-    pub fn text_to_glyphs_vec<'a>(&self, text: impl EncodedText) -> Vec<GlyphId> {
+    pub fn text_to_glyphs_vec(&self, text: impl EncodedText) -> Vec<GlyphId> {
         let count = self.count_text(&text);
         let mut glyphs: Vec<GlyphId> = vec![Default::default(); count];
         let resulting_count = self.text_to_glyphs(text, glyphs.as_mut_slice());
@@ -277,11 +277,7 @@ impl Font {
         self.measure_text(str.as_ref(), paint)
     }
 
-    pub fn measure_text<'a>(
-        &self,
-        text: impl EncodedText,
-        paint: Option<&Paint>,
-    ) -> (scalar, Rect) {
+    pub fn measure_text(&self, text: impl EncodedText, paint: Option<&Paint>) -> (scalar, Rect) {
         let mut bounds = Rect::default();
         let (ptr, size, encoding) = text.as_raw();
         let width = unsafe {

--- a/skia-safe/src/core/font_types.rs
+++ b/skia-safe/src/core/font_types.rs
@@ -1,4 +1,8 @@
+use std::{ffi, mem, ptr};
+
 use skia_bindings::SkTextEncoding;
+
+use crate::GlyphId;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Default)]
 #[repr(i32)]
@@ -13,5 +17,96 @@ pub enum TextEncoding {
 
 native_transmutable!(SkTextEncoding, TextEncoding, text_encoding_layout);
 
+/// Value representing a reference to text in a specific encoding.
+///
+/// Functions that expect encoded types accept implicit conversion through the `From` trait from
+/// `&String``, `&str`, `&[u8]` (UTF8), and `&[u32]` (UTF32).
+///
+/// To pass a reference to a &[GlyphId] or `&[u16]` (UTF16) slice, use
+/// `EncodedText::GlyphIds(slice)` or `EncodedText::UTF16(slice)`.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub enum EncodedText<'a> {
+    UTF8(&'a [u8]),
+    UTF16(&'a [u16]),
+    UTF32(&'a [u32]),
+    GlyphId(&'a [GlyphId]),
+}
+
+impl<'a> From<&'a String> for EncodedText<'a> {
+    fn from(value: &'a String) -> Self {
+        value.as_bytes().into()
+    }
+}
+
+impl<'a> From<&'a str> for EncodedText<'a> {
+    fn from(value: &'a str) -> Self {
+        value.as_bytes().into()
+    }
+}
+
+impl<'a> From<&'a [u8]> for EncodedText<'a> {
+    fn from(value: &'a [u8]) -> Self {
+        EncodedText::UTF8(value)
+    }
+}
+
+impl<'a> From<&'a [u32]> for EncodedText<'a> {
+    fn from(value: &'a [u32]) -> Self {
+        EncodedText::UTF32(value)
+    }
+}
+
+impl EncodedText<'_> {
+    pub fn encoding(self) -> TextEncoding {
+        match self {
+            EncodedText::UTF8(_) => TextEncoding::UTF8,
+            EncodedText::UTF16(_) => TextEncoding::UTF16,
+            EncodedText::UTF32(_) => TextEncoding::UTF32,
+            EncodedText::GlyphId(_) => TextEncoding::GlyphId,
+        }
+    }
+
+    pub(crate) fn raw(self) -> (*const ffi::c_void, usize, TextEncoding) {
+        let size = self.size();
+        let ptr = {
+            if size == 0 {
+                ptr::null()
+            } else {
+                match self {
+                    EncodedText::UTF8(slice) => slice.as_ptr() as _,
+                    EncodedText::UTF16(slice) => slice.as_ptr() as _,
+                    EncodedText::UTF32(slice) => slice.as_ptr() as _,
+                    EncodedText::GlyphId(slice) => slice.as_ptr() as _,
+                }
+            }
+        };
+
+        (ptr, size, self.encoding())
+    }
+
+    fn size(self) -> usize {
+        match self {
+            EncodedText::UTF8(slice) => mem::size_of_val(slice),
+            EncodedText::UTF16(slice) => mem::size_of_val(slice),
+            EncodedText::UTF32(slice) => mem::size_of_val(slice),
+            EncodedText::GlyphId(slice) => mem::size_of_val(slice),
+        }
+    }
+}
+
 pub use skia_bindings::SkFontHinting as FontHinting;
 variant_name!(FontHinting::Full);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Using `mem::size_of_val` on references may lead to subtle problems, for example a `&&[u8]`
+    /// results in `16usize`` (the size of a fat pointer).
+    #[test]
+    fn text_sizes_match_expectations() {
+        let skia = "SKIA";
+        let encoded_text: EncodedText = skia.into();
+        assert_eq!(encoded_text.size(), skia.len())
+    }
+}

--- a/skia-safe/src/core/font_types.rs
+++ b/skia-safe/src/core/font_types.rs
@@ -1,8 +1,8 @@
-use std::{ffi, mem, ptr};
+use std::{ffi, mem};
 
 use skia_bindings::SkTextEncoding;
 
-use crate::GlyphId;
+use crate::{prelude::*, GlyphId};
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Default)]
 #[repr(i32)]
@@ -17,80 +17,74 @@ pub enum TextEncoding {
 
 native_transmutable!(SkTextEncoding, TextEncoding, text_encoding_layout);
 
-/// Value representing a reference to text in a specific encoding.
+/// Trait representing a text in a specific encoding.
 ///
-/// Functions that expect encoded types accept implicit conversion through the `From` trait from
-/// `&String``, `&str`, `&[u8]` (UTF8), and `&[u32]` (UTF32).
+/// Functions that expect `EncodedText` may be passed `String`, `&String``, `str`, or `&str`
+/// representing UTF-8 encoded text. In addition to that, &[u16], [u16], or &[GlyphId], [GlyphId],
+/// are interpreted as `GlyphId` slices.
 ///
-/// To pass a reference to a &[GlyphId] or `&[u16]` (UTF16) slice, use
-/// `EncodedText::GlyphIds(slice)` or `EncodedText::UTF16(slice)`.
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
-pub enum EncodedText<'a> {
-    UTF8(&'a [u8]),
-    UTF16(&'a [u16]),
-    UTF32(&'a [u32]),
-    GlyphId(&'a [GlyphId]),
+/// To use UTF16 or UTF32 encodings, use [`skia_safe::as_utf16_unchecked`] or
+/// [`skia_safe::as_utf32_unchecked`].
+pub trait EncodedText {
+    fn as_raw(&self) -> (*const ffi::c_void, usize, TextEncoding);
 }
 
-impl<'a> From<&'a String> for EncodedText<'a> {
-    fn from(value: &'a String) -> Self {
-        value.as_bytes().into()
-    }
+/// Treat a `&[u16]` as UTF16 encoded text.
+pub unsafe fn as_utf16_unchecked<'a>(slice: &'a [u16]) -> impl EncodedText + Captures<&'a [u16]> {
+    UTF16Slice(slice)
 }
 
-impl<'a> From<&'a str> for EncodedText<'a> {
-    fn from(value: &'a str) -> Self {
-        value.as_bytes().into()
-    }
+/// Treat a `&[u32]` as UTF32 encoded text.
+pub unsafe fn as_utf32_unchecked<'a>(slice: &'a [u32]) -> impl EncodedText + Captures<&'a [u32]> {
+    UTF32Slice(slice)
 }
 
-impl<'a> From<&'a [u8]> for EncodedText<'a> {
-    fn from(value: &'a [u8]) -> Self {
-        EncodedText::UTF8(value)
-    }
-}
+struct UTF16Slice<'a>(&'a [u16]);
 
-impl<'a> From<&'a [u32]> for EncodedText<'a> {
-    fn from(value: &'a [u32]) -> Self {
-        EncodedText::UTF32(value)
+impl EncodedText for UTF16Slice<'_> {
+    fn as_raw(&self) -> (*const ffi::c_void, usize, TextEncoding) {
+        let slice = self.0;
+        let size = mem::size_of_val(slice);
+        (slice.as_ptr() as _, size, TextEncoding::UTF16)
     }
 }
 
-impl EncodedText<'_> {
-    pub fn encoding(self) -> TextEncoding {
-        match self {
-            EncodedText::UTF8(_) => TextEncoding::UTF8,
-            EncodedText::UTF16(_) => TextEncoding::UTF16,
-            EncodedText::UTF32(_) => TextEncoding::UTF32,
-            EncodedText::GlyphId(_) => TextEncoding::GlyphId,
-        }
+struct UTF32Slice<'a>(&'a [u32]);
+
+impl EncodedText for UTF32Slice<'_> {
+    fn as_raw(&self) -> (*const ffi::c_void, usize, TextEncoding) {
+        let slice = self.0;
+        let size = mem::size_of_val(slice);
+        (slice.as_ptr() as _, size, TextEncoding::UTF32)
     }
+}
 
-    pub(crate) fn raw(self) -> (*const ffi::c_void, usize, TextEncoding) {
-        let size = self.size();
-        let ptr = {
-            if size == 0 {
-                ptr::null()
-            } else {
-                match self {
-                    EncodedText::UTF8(slice) => slice.as_ptr() as _,
-                    EncodedText::UTF16(slice) => slice.as_ptr() as _,
-                    EncodedText::UTF32(slice) => slice.as_ptr() as _,
-                    EncodedText::GlyphId(slice) => slice.as_ptr() as _,
-                }
-            }
-        };
-
-        (ptr, size, self.encoding())
+impl EncodedText for String {
+    fn as_raw(&self) -> (*const ffi::c_void, usize, TextEncoding) {
+        self.as_str().as_raw()
     }
+}
 
-    fn size(self) -> usize {
-        match self {
-            EncodedText::UTF8(slice) => mem::size_of_val(slice),
-            EncodedText::UTF16(slice) => mem::size_of_val(slice),
-            EncodedText::UTF32(slice) => mem::size_of_val(slice),
-            EncodedText::GlyphId(slice) => mem::size_of_val(slice),
-        }
+impl EncodedText for &str {
+    fn as_raw(&self) -> (*const ffi::c_void, usize, TextEncoding) {
+        let bytes = self.as_bytes();
+        (bytes.as_ptr() as _, bytes.len(), TextEncoding::UTF8)
+    }
+}
+
+impl EncodedText for [GlyphId] {
+    fn as_raw(&self) -> (*const ffi::c_void, usize, TextEncoding) {
+        (
+            self.as_ptr() as _,
+            mem::size_of_val(self),
+            TextEncoding::GlyphId,
+        )
+    }
+}
+
+impl<T: EncodedText> EncodedText for &T {
+    fn as_raw(&self) -> (*const ffi::c_void, usize, TextEncoding) {
+        (**self).as_raw()
     }
 }
 
@@ -101,12 +95,21 @@ variant_name!(FontHinting::Full);
 mod tests {
     use super::*;
 
-    /// Using `mem::size_of_val` on references may lead to subtle problems, for example a `&&[u8]`
-    /// results in `16usize`` (the size of a fat pointer).
     #[test]
-    fn text_sizes_match_expectations() {
-        let skia = "SKIA";
-        let encoded_text: EncodedText = skia.into();
-        assert_eq!(encoded_text.size(), skia.len())
+    fn glyph_id_size() {
+        let glyphs = [0u16, 1u16];
+        assert_eq!(glyphs.as_raw().1, 4);
+    }
+
+    #[test]
+    fn utf16_size() {
+        let utf16 = unsafe { as_utf16_unchecked(&[0u16, 1u16]) };
+        assert_eq!(utf16.as_raw().1, 4);
+    }
+
+    #[test]
+    fn utf32_size() {
+        let utf16 = unsafe { as_utf32_unchecked(&[0u32, 1u32]) };
+        assert_eq!(utf16.as_raw().1, 8);
     }
 }

--- a/skia-safe/src/core/text_blob.rs
+++ b/skia-safe/src/core/text_blob.rs
@@ -68,26 +68,25 @@ impl TextBlob {
     }
 
     pub fn from_str(str: impl AsRef<str>, font: &Font) -> Option<TextBlob> {
-        Self::from_text(str.as_ref().as_bytes(), font)
+        Self::from_text(str.as_ref(), font)
     }
 
-    pub fn from_text<'a>(text: impl Into<EncodedText<'a>>, font: &Font) -> Option<TextBlob> {
-        let (ptr, size, encoding) = text.into().raw();
+    pub fn from_text(text: impl EncodedText, font: &Font) -> Option<TextBlob> {
+        let (ptr, size, encoding) = text.as_raw();
         TextBlob::from_ptr(unsafe {
             sb::C_SkTextBlob_MakeFromText(ptr, size, font.native(), encoding.into_native())
         })
     }
 
-    pub fn from_pos_text_h<'a>(
-        text: impl Into<EncodedText<'a>>,
+    pub fn from_pos_text_h(
+        text: impl EncodedText,
         x_pos: &[scalar],
         const_y: scalar,
         font: &Font,
     ) -> Option<TextBlob> {
-        let text = text.into();
         // TODO: avoid that somehow.
-        assert_eq!(x_pos.len(), font.count_text(text));
-        let (ptr, size, encoding) = text.raw();
+        assert_eq!(x_pos.len(), font.count_text(&text));
+        let (ptr, size, encoding) = text.as_raw();
         TextBlob::from_ptr(unsafe {
             sb::C_SkTextBlob_MakeFromPosTextH(
                 ptr,
@@ -101,14 +100,13 @@ impl TextBlob {
     }
 
     pub fn from_pos_text<'a>(
-        text: impl Into<EncodedText<'a>>,
+        text: impl EncodedText,
         pos: &[Point],
         font: &Font,
     ) -> Option<TextBlob> {
-        let text = text.into();
         // TODO: avoid that somehow.
+        let (ptr, size, encoding) = text.as_raw();
         assert_eq!(pos.len(), font.count_text(text));
-        let (ptr, size, encoding) = text.raw();
         TextBlob::from_ptr(unsafe {
             sb::C_SkTextBlob_MakeFromPosText(
                 ptr,
@@ -120,15 +118,14 @@ impl TextBlob {
         })
     }
 
-    pub fn from_rsxform<'a>(
-        text: impl Into<EncodedText<'a>>,
+    pub fn from_rsxform(
+        text: impl EncodedText,
         xform: &[RSXform],
         font: &Font,
     ) -> Option<TextBlob> {
-        let text = text.into();
         // TODO: avoid that somehow.
+        let (ptr, size, encoding) = text.as_raw();
         assert_eq!(xform.len(), font.count_text(text));
-        let (ptr, size, encoding) = text.raw();
         TextBlob::from_ptr(unsafe {
             sb::C_SkTextBlob_MakeFromRSXform(
                 ptr,

--- a/skia-safe/src/core/text_blob.rs
+++ b/skia-safe/src/core/text_blob.rs
@@ -99,11 +99,7 @@ impl TextBlob {
         })
     }
 
-    pub fn from_pos_text<'a>(
-        text: impl EncodedText,
-        pos: &[Point],
-        font: &Font,
-    ) -> Option<TextBlob> {
+    pub fn from_pos_text(text: impl EncodedText, pos: &[Point], font: &Font) -> Option<TextBlob> {
         // TODO: avoid that somehow.
         let (ptr, size, encoding) = text.as_raw();
         assert_eq!(pos.len(), font.count_text(text));

--- a/skia-safe/src/core/typeface.rs
+++ b/skia-safe/src/core/typeface.rs
@@ -1,12 +1,14 @@
+use std::{ffi, fmt, io, ptr};
+
+use skia_bindings::{self as sb, SkRefCntBase, SkTypeface, SkTypeface_LocalizedStrings};
+
 use crate::{
     font_arguments,
     font_parameters::VariationAxis,
     interop::{self, MemoryStream, NativeStreamBase, RustStream, RustWStream, StreamAsset},
     prelude::*,
-    Data, FontArguments, FontMgr, FontStyle, FourByteTag, GlyphId, Rect, TextEncoding, Unichar,
+    Data, EncodedText, FontArguments, FontMgr, FontStyle, FourByteTag, GlyphId, Rect, Unichar,
 };
-use skia_bindings::{self as sb, SkRefCntBase, SkTypeface, SkTypeface_LocalizedStrings};
-use std::{ffi, fmt, io, mem, ptr};
 
 pub type TypefaceId = skia_bindings::SkTypefaceID;
 #[deprecated(since = "0.49.0", note = "use TypefaceId")]
@@ -192,20 +194,19 @@ impl Typeface {
     }
 
     pub fn str_to_glyphs(&self, str: impl AsRef<str>, glyphs: &mut [GlyphId]) -> usize {
-        self.text_to_glyphs(str.as_ref().as_bytes(), TextEncoding::UTF8, glyphs)
+        self.text_to_glyphs(str.as_ref().as_bytes(), glyphs)
     }
 
-    pub fn text_to_glyphs<C>(
+    pub fn text_to_glyphs<'a>(
         &self,
-        text: &[C],
-        encoding: TextEncoding,
+        text: impl Into<EncodedText<'a>>,
         glyphs: &mut [GlyphId],
     ) -> usize {
-        let byte_length = mem::size_of_val(text);
+        let (ptr, size, encoding) = text.into().raw();
         unsafe {
             self.native().textToGlyphs(
-                text.as_ptr() as _,
-                byte_length,
+                ptr,
+                size,
                 encoding.into_native(),
                 glyphs.as_mut_ptr(),
                 glyphs.len().try_into().unwrap(),

--- a/skia-safe/src/core/typeface.rs
+++ b/skia-safe/src/core/typeface.rs
@@ -194,15 +194,11 @@ impl Typeface {
     }
 
     pub fn str_to_glyphs(&self, str: impl AsRef<str>, glyphs: &mut [GlyphId]) -> usize {
-        self.text_to_glyphs(str.as_ref().as_bytes(), glyphs)
+        self.text_to_glyphs(str.as_ref(), glyphs)
     }
 
-    pub fn text_to_glyphs<'a>(
-        &self,
-        text: impl Into<EncodedText<'a>>,
-        glyphs: &mut [GlyphId],
-    ) -> usize {
-        let (ptr, size, encoding) = text.into().raw();
+    pub fn text_to_glyphs(&self, text: impl EncodedText, glyphs: &mut [GlyphId]) -> usize {
+        let (ptr, size, encoding) = text.as_raw();
         unsafe {
             self.native().textToGlyphs(
                 ptr,

--- a/skia-safe/src/lib.rs
+++ b/skia-safe/src/lib.rs
@@ -42,6 +42,7 @@ pub use crate::core::*;
 pub use docs::*;
 pub use effects::*;
 pub use encode_::*;
+#[allow(unused_imports)]
 pub use modules::*;
 pub use pathops::*;
 

--- a/skia-safe/src/utils/text_utils.rs
+++ b/skia-safe/src/utils/text_utils.rs
@@ -16,7 +16,7 @@ pub fn draw_str(
     draw_text(canvas, text.as_ref(), p, font, paint, align)
 }
 
-pub fn draw_text<'a>(
+pub fn draw_text(
     canvas: &Canvas,
     text: impl EncodedText,
     p: impl Into<Point>,
@@ -53,7 +53,7 @@ impl Canvas {
         self.draw_text_align(text.as_ref(), p, font, paint, align)
     }
 
-    pub fn draw_text_align<'a>(
+    pub fn draw_text_align(
         &self,
         text: impl EncodedText,
         p: impl Into<Point>,
@@ -66,7 +66,7 @@ impl Canvas {
     }
 }
 
-pub fn get_path<'a>(text: impl EncodedText, p: impl Into<Point>, font: &Font) -> Path {
+pub fn get_path(text: impl EncodedText, p: impl Into<Point>, font: &Font) -> Path {
     let (ptr, size, encoding) = text.as_raw();
     let p = p.into();
     let mut path = Path::default();

--- a/skia-safe/src/utils/text_utils.rs
+++ b/skia-safe/src/utils/text_utils.rs
@@ -18,13 +18,13 @@ pub fn draw_str(
 
 pub fn draw_text<'a>(
     canvas: &Canvas,
-    text: impl Into<EncodedText<'a>>,
+    text: impl EncodedText,
     p: impl Into<Point>,
     font: &Font,
     paint: &Paint,
     align: Align,
 ) {
-    let (ptr, size, encoding) = text.into().raw();
+    let (ptr, size, encoding) = text.as_raw();
     let p = p.into();
     unsafe {
         SkTextUtils::Draw(
@@ -55,7 +55,7 @@ impl Canvas {
 
     pub fn draw_text_align<'a>(
         &self,
-        text: impl Into<EncodedText<'a>>,
+        text: impl EncodedText,
         p: impl Into<Point>,
         font: &Font,
         paint: &Paint,
@@ -66,8 +66,8 @@ impl Canvas {
     }
 }
 
-pub fn get_path<'a>(text: impl Into<EncodedText<'a>>, p: impl Into<Point>, font: &Font) -> Path {
-    let (ptr, size, encoding) = text.into().raw();
+pub fn get_path<'a>(text: impl EncodedText, p: impl Into<Point>, font: &Font) -> Path {
+    let (ptr, size, encoding) = text.as_raw();
     let p = p.into();
     let mut path = Path::default();
     unsafe {


### PR DESCRIPTION
Closes #886 