### PR TITLE
Enable `framebufferOnly` for `CAMetalLayer`.

### DIFF
--- a/skia-safe/examples/metal-window/main.rs
+++ b/skia-safe/examples/metal-window/main.rs
@@ -51,6 +51,7 @@ fn main() {
         layer.set_device(&device);
         layer.set_pixel_format(MTLPixelFormat::BGRA8Unorm);
         layer.set_presents_with_transaction(false);
+        layer.set_framebuffer_only(false);
 
         unsafe {
             let view = match raw_window_handle {


### PR DESCRIPTION
Enabled `framebufferOnly` for `CAMetalLayer` in example `metal-window` to support blend mode.
More discussions see:
https://groups.google.com/g/skia-discuss/c/FTO0NSR_09Q
https://developer.apple.com/documentation/quartzcore/cametallayer/1478168-framebufferonly