### PR TITLE
Milestone 122

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,6 +17,7 @@
         "Codepoints",
         "CORETEXT",
         "cpufeatures",
+        "DIRECTWRITE",
         "Downsample",
         "downsampling",
         "EMCC",

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![Windows QA](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml) [![Linux QA](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml) [![macOS QA](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml)
 
-Skia Submodule Status: chrome/m121 ([upstream changes][skia-upstream], [our changes][skia-ours]).
+Skia Submodule Status: chrome/m122 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m121-0.69.1...google:chrome/m121
-[skia-ours]: https://github.com/google/skia/compare/chrome/m121...rust-skia:m121-0.69.1
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m122-0.70.0...google:chrome/m122
+[skia-ours]: https://github.com/google/skia/compare/chrome/m122...rust-skia:m122-0.70.0
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m122 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m122-0.70.0...google:chrome/m122
-[skia-ours]: https://github.com/google/skia/compare/chrome/m122...rust-skia:m122-0.70.0
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m122-0.70.1...google:chrome/m122
+[skia-ours]: https://github.com/google/skia/compare/chrome/m122...rust-skia:m122-0.70.1
 
 ## About
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -30,7 +30,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m121-0.69.1"
+skia = "m122-0.70.0"
 depot_tools = "73a2624"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -30,7 +30,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m122-0.70.0"
+skia = "m122-0.70.1"
 depot_tools = "73a2624"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.70.0"
+version = "0.71.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2021"
 build = "build.rs"

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1563,7 +1563,6 @@ extern "C" SkFontMgr* C_SkFontMgr_NewSystem() {
 #elif defined(SK_FONTMGR_CORETEXT_AVAILABLE)
     fontMgr = SkFontMgr_New_CoreText(nullptr);
 #elif defined(SK_FONTMGR_DIRECTWRITE_AVAILABLE)
-    // On windows, both GDI and DIRECTWRITE FontMgr are available, Skia prefers DIRECTWRITE
     fontMgr = SkFontMgr_New_DirectWrite();
 #elif defined(SK_FONTMGR_FREETYPE_DIRECTORY_AVAILABLE)
     fontMgr = SkFontMgr_New_Custom_Directory("/usr/share/fonts/");

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -763,6 +763,14 @@ extern "C" bool C_PathUtils_FillPathWithPaint(const SkPath* src, const SkPaint* 
 // Note: bindgen layout is broken, so we are forced to allocate Canvas instances on the heap only.
 //
 
+extern "C" void C_SkCanvas_SaveLayerRec_Construct(SkCanvas::SaveLayerRec* uninitialized) {
+    new (uninitialized) SkCanvas::SaveLayerRec();
+}
+
+extern "C" void C_SkCanvas_SaveLayerRec_destruct(SkCanvas::SaveLayerRec* self) {
+    self->~SaveLayerRec();
+}
+
 extern "C" SkCanvas* C_SkCanvas_newEmpty() {
     return new SkCanvas();
 }

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1330,20 +1330,6 @@ extern "C" bool C_SkTypeface_isItalic(const SkTypeface* self) {
     return self->isItalic();
 }
 
-extern "C" SkTypeface* C_SkTypeface_MakeFromName(const char familyName[], SkFontStyle fontStyle) {
-    return SkTypeface::MakeFromName(familyName, fontStyle).release();
-}
-
-/*
-extern "C" SkTypeface* C_SkTypeface_MakeFromFile(const char path[], int index) {
-    return SkTypeface::MakeFromFile(path, index).release();
-}
-*/
-
-extern "C" SkTypeface* C_SkTypeface_MakeFromData(SkData* data, int index) {
-    return SkTypeface::MakeFromData(sp(data), index).release();
-}
-
 extern "C" SkTypeface* C_SkTypeface_makeClone(const SkTypeface* self, const SkFontArguments* arguments) {
     return self->makeClone(*arguments).release();
 }
@@ -1356,11 +1342,7 @@ extern "C" void C_SkTypeface_serialize2(const SkTypeface* self, SkWStream* strea
     self->serialize(stream, behavior);
 }
 
-extern "C" SkTypeface* C_SkTypeface_MakeDeserialize(SkStream* stream) {
-    return SkTypeface::MakeDeserialize(stream).release();
-}
-
-extern "C" SkTypeface* C_SkTypeface_MakeDeserialize2(SkStream* stream, SkFontMgr* lastResortFontMgr) {
+extern "C" SkTypeface* C_SkTypeface_MakeDeserialize(SkStream* stream, SkFontMgr* lastResortFontMgr) {
     return SkTypeface::MakeDeserialize(stream, sp(lastResortFontMgr)).release();
 }
 

--- a/skia-org/src/drivers/gl.rs
+++ b/skia-org/src/drivers/gl.rs
@@ -12,8 +12,9 @@ impl DrawingDriver for OpenGl {
     const DRIVER: Driver = Driver::OpenGl;
 
     fn new() -> Self {
+        let interface = gpu::gl::Interface::new_native().unwrap();
         Self {
-            context: gpu::DirectContext::new_gl(None, None).unwrap(),
+            context: gpu::DirectContext::new_gl(interface, None).unwrap(),
         }
     }
 

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -18,7 +18,7 @@ categories = [
 ]
 license = "MIT"
 
-version = "0.70.0"
+version = "0.71.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2021"
 
@@ -54,7 +54,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 [dependencies]
 bitflags = "2.0"
 lazy_static = "1.4"
-skia-bindings = { version = "=0.70.0", path = "../skia-bindings", default-features = false }
+skia-bindings = { version = "=0.71.0", path = "../skia-bindings", default-features = false }
 
 # D3D types & ComPtr
 windows = { version = "0.52.0", features = [

--- a/skia-safe/examples/gl-window/main.rs
+++ b/skia-safe/examples/gl-window/main.rs
@@ -156,7 +156,7 @@ fn main() {
     })
     .expect("Could not create interface");
 
-    let mut gr_context = skia_safe::gpu::DirectContext::new_gl(Some(interface), None)
+    let mut gr_context = skia_safe::gpu::DirectContext::new_gl(interface, None)
         .expect("Could not create direct context");
 
     let fb_info = {

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -1,8 +1,10 @@
+use std::mem::MaybeUninit;
 use std::{
     cell::UnsafeCell, convert::TryInto, ffi::CString, fmt, marker::PhantomData, mem, ops::Deref,
     ptr, slice,
 };
 
+use sb::SkCanvas_FilterSpan;
 use skia_bindings::{
     self as sb, SkAutoCanvasRestore, SkCanvas, SkCanvas_SaveLayerRec, SkImageFilter, SkPaint,
     SkRect, U8CPU,
@@ -40,6 +42,7 @@ pub struct SaveLayerRec<'a> {
     // we would store a reference to a pointer only.
     bounds: Option<&'a SkRect>,
     paint: Option<&'a SkPaint>,
+    filters: MaybeUninit<SkCanvas_FilterSpan>,
     backdrop: Option<&'a SkImageFilter>,
     flags: SaveLayerFlags,
     experimental_backdrop_scale: scalar,
@@ -78,6 +81,7 @@ impl<'a> Default for SaveLayerRec<'a> {
         SaveLayerRec {
             bounds: None,
             paint: None,
+            filters: MaybeUninit::uninit(),
             backdrop: None,
             flags: SaveLayerFlags::empty(),
             experimental_backdrop_scale: 1.0,

--- a/skia-safe/src/core/canvas.rs
+++ b/skia-safe/src/core/canvas.rs
@@ -120,24 +120,6 @@ impl<'a> SaveLayerRec<'a> {
         }
     }
 
-    #[deprecated(
-        since = "0.33.0",
-        note = "removed without replacement, does not set clip_mask"
-    )]
-    #[must_use]
-    pub fn clip_mask(self, _clip_mask: &'a Image) -> Self {
-        self
-    }
-
-    #[deprecated(
-        since = "0.33.0",
-        note = "removed without replacement, does not set clip_matrix"
-    )]
-    #[must_use]
-    pub fn clip_matrix(self, _clip_matrix: &'a Matrix) -> Self {
-        self
-    }
-
     /// Preserves LCD text, creates with prior layer contents
     #[must_use]
     pub fn flags(self, flags: SaveLayerFlags) -> Self {

--- a/skia-safe/src/core/data.rs
+++ b/skia-safe/src/core/data.rs
@@ -37,12 +37,8 @@ impl Deref for Data {
 impl PartialEq for Data {
     // Although there is an implementation in SkData for equality testing, we
     // prefer to stay on the Rust side for that.
-    //
-    // False positive on unconditional recursion,
-    // see <https://github.com/rust-lang/rust-clippy/issues?q=is%3Aissue+unconditional_recursion>
-    #[allow(clippy::unconditional_recursion)]
     fn eq(&self, other: &Self) -> bool {
-        self.deref().eq(other.deref())
+        self.deref() == other.deref()
     }
 }
 

--- a/skia-safe/src/core/font.rs
+++ b/skia-safe/src/core/font.rs
@@ -178,8 +178,9 @@ impl Font {
         }
     }
 
-    pub fn typeface(&self) -> Option<Typeface> {
+    pub fn typeface(&self) -> Typeface {
         Typeface::from_unshared_ptr(self.native().fTypeface.fPtr)
+            .expect("typeface is expected to be non-null")
     }
 
     pub fn size(&self) -> scalar {

--- a/skia-safe/src/core/font_arguments.rs
+++ b/skia-safe/src/core/font_arguments.rs
@@ -39,7 +39,7 @@ pub mod palette {
     #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
     #[repr(C)]
     pub struct Override {
-        pub index: i32,
+        pub index: u16,
         pub color: Color,
     }
 

--- a/skia-safe/src/core/font_mgr.rs
+++ b/skia-safe/src/core/font_mgr.rs
@@ -247,7 +247,7 @@ mod tests {
         let font_mgr = FontMgr::default();
         let families = font_mgr.count_families();
         println!("FontMgr families: {families}");
-        // test requires that the font manager returns at least one family for now.
+        // This test requires that the default system font manager returns at least one family for now.
         assert!(families > 0);
         // print all family names and styles
         for i in 0..families {

--- a/skia-safe/src/core/font_mgr.rs
+++ b/skia-safe/src/core/font_mgr.rs
@@ -106,9 +106,10 @@ impl fmt::Debug for FontMgr {
 }
 
 impl FontMgr {
-    // Deprecated by Skia
+    // Deprecated by Skia, but we continue to support it. This returns a font manager with
+    // system fonts for the current platform.
     pub fn new() -> Self {
-        FontMgr::from_ptr(unsafe { sb::C_SkFontMgr_RefDefault() }).unwrap()
+        FontMgr::from_ptr(unsafe { sb::C_SkFontMgr_NewSystem() }).unwrap()
     }
 
     pub fn empty() -> Self {

--- a/skia-safe/src/core/graphics.rs
+++ b/skia-safe/src/core/graphics.rs
@@ -28,6 +28,14 @@ pub fn set_font_cache_count_limit(count: i32) -> i32 {
     unsafe { SkGraphics::SetFontCacheCountLimit(count) }
 }
 
+pub fn typeface_cache_count_limit() -> i32 {
+    unsafe { SkGraphics::GetTypefaceCacheCountLimit() }
+}
+
+pub fn set_typeface_cache_count_limit(count: i32) -> i32 {
+    unsafe { SkGraphics::SetTypefaceCacheCountLimit(count) }
+}
+
 pub fn purge_font_cache() {
     unsafe { SkGraphics::PurgeFontCache() }
 }

--- a/skia-safe/src/core/milestone.rs
+++ b/skia-safe/src/core/milestone.rs
@@ -1,1 +1,1 @@
-pub const MILESTONE: usize = 121;
+pub const MILESTONE: usize = 122;

--- a/skia-safe/src/core/typeface.rs
+++ b/skia-safe/src/core/typeface.rs
@@ -38,22 +38,12 @@ impl fmt::Debug for Typeface {
             .field("font_style", &self.font_style())
             .field("is_fixed_pitch", &self.is_fixed_pitch())
             .field("unique_id", &self.unique_id())
-            .field("family_name", &self.family_name())
             .field("bounds", &self.bounds())
             .finish()
     }
 }
 
 impl Typeface {
-    #[deprecated(
-        since = "0.69.0",
-        note = "call FontMgr::match_family_style or FontMgr::legacy_make_typeface"
-    )]
-    pub fn new(family_name: impl AsRef<str>, font_style: FontStyle) -> Option<Self> {
-        #[allow(deprecated)]
-        Self::from_name(family_name, font_style)
-    }
-
     pub fn font_style(&self) -> FontStyle {
         FontStyle::from_native_c(self.native().fStyle)
     }
@@ -116,27 +106,6 @@ impl Typeface {
         unsafe { SkTypeface::Equal(face_a.as_ref().native(), face_b.as_ref().native()) }
     }
 
-    #[deprecated(
-        since = "0.69.0",
-        note = "call FontMgr::match_family_style or FontMgr::legacy_make_typeface"
-    )]
-    pub fn from_name(family_name: impl AsRef<str>, font_style: FontStyle) -> Option<Typeface> {
-        let family_name = ffi::CString::new(family_name.as_ref()).ok()?;
-        Typeface::from_ptr(unsafe {
-            sb::C_SkTypeface_MakeFromName(family_name.as_ptr(), *font_style.native())
-        })
-    }
-
-    #[deprecated(since = "0.69.0", note = "call FontMgr::new_from_data instead")]
-    pub fn from_data(data: impl Into<Data>, index: impl Into<Option<usize>>) -> Option<Typeface> {
-        Typeface::from_ptr(unsafe {
-            sb::C_SkTypeface_MakeFromData(
-                data.into().into_ptr(),
-                index.into().unwrap_or_default().try_into().unwrap(),
-            )
-        })
-    }
-
     pub fn clone_with_arguments(&self, arguments: &FontArguments) -> Option<Typeface> {
         Typeface::from_ptr(unsafe { sb::C_SkTypeface_makeClone(self.native(), arguments.native()) })
     }
@@ -151,15 +120,7 @@ impl Typeface {
         Data::from_ptr(unsafe { sb::C_SkTypeface_serialize(self.native(), behavior) }).unwrap()
     }
 
-    // TODO: Deserialize(Read?)
-
-    #[deprecated(since = "0.69.0", note = "use make_deserialize()")]
-    pub fn deserialize(data: &[u8]) -> Option<Typeface> {
-        let mut stream = MemoryStream::from_bytes(data);
-        Typeface::from_ptr(unsafe {
-            sb::C_SkTypeface_MakeDeserialize(stream.native_mut().as_stream_mut())
-        })
-    }
+    // TODO: Wrap Deserialize(Read?)
 
     pub fn make_deserialize(
         mut data: impl io::Read,
@@ -167,7 +128,7 @@ impl Typeface {
     ) -> Option<Typeface> {
         let mut stream = RustStream::new(&mut data);
         Typeface::from_ptr(unsafe {
-            sb::C_SkTypeface_MakeDeserialize2(
+            sb::C_SkTypeface_MakeDeserialize(
                 stream.stream_mut(),
                 last_resort_mgr.into().into_ptr_or_null(),
             )

--- a/skia-safe/src/core/typeface.rs
+++ b/skia-safe/src/core/typeface.rs
@@ -1,11 +1,11 @@
-use std::{ffi, fmt, io, ptr};
+use std::{fmt, io, ptr};
 
 use skia_bindings::{self as sb, SkRefCntBase, SkTypeface, SkTypeface_LocalizedStrings};
 
 use crate::{
     font_arguments,
     font_parameters::VariationAxis,
-    interop::{self, MemoryStream, NativeStreamBase, RustStream, RustWStream, StreamAsset},
+    interop::{self, NativeStreamBase, RustStream, RustWStream, StreamAsset},
     prelude::*,
     Data, EncodedText, FontArguments, FontMgr, FontStyle, FourByteTag, GlyphId, Rect, Unichar,
 };

--- a/skia-safe/src/docs/pdf_document.rs
+++ b/skia-safe/src/docs/pdf_document.rs
@@ -257,6 +257,10 @@ pub mod pdf {
         pub creation: Option<DateTime>,
         /// The date and time the document was most recently modified.
         pub modified: Option<DateTime>,
+        /// The natural language of the text in the PDF. If `lang` is empty, the root
+        /// StructureElementNode::lang will be used (if not empty). Text not in
+        /// this language should be marked with StructureElementNode::lang.
+        pub lang: String,
         /// The DPI (pixels-per-inch) at which features without native PDF support
         /// will be rasterized (e.g. draw image with perspective, draw text with
         /// perspective, ...)  A larger DPI would create a PDF that reflects the
@@ -292,6 +296,7 @@ pub mod pdf {
                 producer: format!("Skia/PDF m{}", MILESTONE),
                 creation: Default::default(),
                 modified: Default::default(),
+                lang: Default::default(),
                 raster_dpi: Default::default(),
                 pdf_a: Default::default(),
                 encoding_quality: Default::default(),
@@ -327,6 +332,7 @@ pub mod pdf {
             if let Some(modified) = metadata.modified {
                 internal.fModified = modified.into_native();
             }
+            internal.fLang.set_str(&metadata.lang);
             if let Some(raster_dpi) = metadata.raster_dpi {
                 internal.fRasterDPI = raster_dpi;
             }

--- a/skia-safe/src/effects/color_matrix.rs
+++ b/skia-safe/src/effects/color_matrix.rs
@@ -10,15 +10,12 @@ impl NativeDrop for SkColorMatrix {
 }
 
 impl PartialEq for ColorMatrix {
-    // False positive on unconditional recursion,
-    // see <https://github.com/rust-lang/rust-clippy/issues?q=is%3Aissue+unconditional_recursion>
-    #[allow(clippy::unconditional_recursion)]
     fn eq(&self, other: &Self) -> bool {
         let mut array_self = [0.0f32; 20];
         let mut array_other = [0.0f32; 20];
         self.get_row_major(&mut array_self);
         other.get_row_major(&mut array_other);
-        array_self.eq(&array_other)
+        array_self == array_other
     }
 }
 

--- a/skia-safe/src/gpu/direct_context.rs
+++ b/skia-safe/src/gpu/direct_context.rs
@@ -85,7 +85,7 @@ impl DirectContext {
     // Deprecated in Skia
     #[cfg(feature = "gl")]
     pub fn new_gl<'a>(
-        interface: impl Into<Option<gl::Interface>>,
+        interface: impl Into<gl::Interface>,
         options: impl Into<Option<&'a ContextOptions>>,
     ) -> Option<DirectContext> {
         crate::gpu::direct_contexts::make_gl(interface, options)

--- a/skia-safe/src/gpu/ganesh/gl/direct_context.rs
+++ b/skia-safe/src/gpu/ganesh/gl/direct_context.rs
@@ -7,12 +7,12 @@ pub mod direct_contexts {
     };
 
     pub fn make_gl<'a>(
-        interface: impl Into<Option<gl::Interface>>,
+        interface: impl Into<gl::Interface>,
         options: impl Into<Option<&'a ContextOptions>>,
     ) -> Option<DirectContext> {
         DirectContext::from_ptr(unsafe {
             sb::C_GrDirectContext_MakeGL(
-                interface.into().into_ptr_or_null(),
+                interface.into().into_ptr(),
                 options.into().native_ptr_or_null(),
             )
         })

--- a/skia-safe/src/interop/stream.rs
+++ b/skia-safe/src/interop/stream.rs
@@ -101,6 +101,7 @@ impl fmt::Debug for MemoryStream<'_> {
 
 impl MemoryStream<'_> {
     // Create a stream asset that refers the bytes provided.
+    #[allow(unused)]
     pub fn from_bytes(bytes: &[u8]) -> MemoryStream {
         let ptr = unsafe { sb::C_SkMemoryStream_MakeDirect(bytes.as_ptr() as _, bytes.len()) };
 

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -746,16 +746,21 @@ pub mod icu {
     #[test]
     #[serial_test::serial]
     fn test_text_blob_builder_run_handler() {
+        use crate::{Font, FontMgr, FontStyle};
         init();
         let str = "العربية";
         let mut text_blob_builder_run_handler =
             crate::shaper::TextBlobBuilderRunHandler::new(str, crate::Point::default());
 
-        let shaper = crate::Shaper::new(crate::FontMgr::new());
-
+        let font_mgr = FontMgr::new();
+        let default_typeface = font_mgr
+            .legacy_make_typeface(None, FontStyle::default())
+            .unwrap();
+        let default_font = Font::new(default_typeface, 10.0);
+        let shaper = crate::Shaper::new(font_mgr);
         shaper.shape(
-            "العربية",
-            &crate::Font::default(),
+            str,
+            &default_font,
             false,
             10000.0,
             &mut text_blob_builder_run_handler,


### PR DESCRIPTION
This PR updates rust-skia to support Skia's `chrome/m122` branch.

- [x] Update `README.md` ([rendered](https://github.com/pragmatrix/rust-skia/blob/m122/README.md))  
  > Most important here is to change the Skia branch name and the current Skia submodule tag at the top of the `README.md` file.
- [x] Diff the the following files to see if the build organization has changed significantly:
  - [x] `/BUILD.gn`
  - [x] `/gn/*` (recursively)
  - [x] `/modules/skshaper/BUILD.gn`
  - [x] `/modules/paragraph/BUILD.gn`
- [x] Skia builds ([release notes](https://github.com/google/skia/blob/chrome/m122/RELEASE_NOTES.md)).
- [x] `/skia-bindings` builds.
- [x] `/skia-safe`: Update & add new wrappers by diffing include files.  
  > Add TODOs for everything that can not be updated right now, and attempt to stay compatible with previous versions of skia-safe without trying too hard before version 1.0. Use `deprecated` attributes if needed.
  - [x] `codec/`
  - [x] `core/`
  - [x] `docs/`
  - [x] `effects/`
  - [x] `encode/`
  - [x] `gpu/`
    - [x] `d3d/`
    - [x] `ganesh/`
    - [x] `gl/`
    - [x] `mtl/`
    - [x] `vk/`
  - [x] `pathops/`
  - [x] `svg/`
  - [x] `utils/`
  - [x] `modules/`
    - [x] `paragraph/`
    - [x] `shaper/`
  - [x] `private/base/*`
    - [x] `SkPoint_impl.h`
- [x] Review `Send` & `Sync` implementations for new wrappers.
- [x] Review `Debug` implementation for new wrapper types and functions.
- [x] Release date of the matching Chrome version in less than 7 days?
- [x] Any pending changes in the Skia `chrome/m122` branch that aren't synchronized yet?
- [x] Rebase on or merge with master.
- [x] Do the `rust-skia:` commits in the `skia-bindings/skia` subdirectory match with `master` (`make diff-skia`).
- [x] Update versions of `skia-bindings/Cargo.toml` and `skia-safe/Cargo.toml` and also add the version to the new `deprecated` attributes.
- [x] Do the tags/hashes in `skia-bindings/Cargo.toml` under `[package.metadata]` match the submodules `depot_tools` and `skia`?
- [x] Check for API changes: `make diff-api`.
- [ ] Test builds we don't do on the CI:
  - [ ] Compiles to Catalyst targets on macOS (#548).
    ```zsh
    make macos-qa
    ```
- [x] Do one final review of all the changes.
- [x] Run `make doc` and fix all warnings.
