### PR TITLE
Make skia_use_freetype explicit

### DIFF
--- a/skia-bindings/build_support/platform.rs
+++ b/skia-bindings/build_support/platform.rs
@@ -18,6 +18,10 @@ pub mod linux;
 pub mod macos;
 mod windows;
 
+pub fn uses_freetype(config: &BuildConfiguration) -> bool {
+    details(&config.target).uses_freetype(config)
+}
+
 pub fn gn_args(config: &BuildConfiguration, mut builder: GnArgsBuilder) -> Vec<(String, String)> {
     details(&config.target).gn_args(config, &mut builder);
     builder.into_gn_args()
@@ -48,6 +52,8 @@ pub fn filter_features(
 }
 
 pub trait PlatformDetails {
+    /// We need this information relatively early on to help parameterizing GN.
+    fn uses_freetype(&self, _config: &BuildConfiguration) -> bool;
     fn gn_args(&self, config: &BuildConfiguration, builder: &mut GnArgsBuilder);
     fn bindgen_args(&self, _target: &Target, _builder: &mut BindgenArgsBuilder) {}
     fn link_libraries(&self, features: &Features) -> Vec<String>;

--- a/skia-bindings/build_support/platform/alpine.rs
+++ b/skia-bindings/build_support/platform/alpine.rs
@@ -3,6 +3,10 @@ use super::{linux, prelude::*};
 pub struct Musl;
 
 impl PlatformDetails for Musl {
+    fn uses_freetype(&self, _config: &BuildConfiguration) -> bool {
+        true
+    }
+
     fn gn_args(&self, config: &BuildConfiguration, builder: &mut GnArgsBuilder) {
         linux::gn_args(config, builder);
         let target = &config.target;

--- a/skia-bindings/build_support/platform/android.rs
+++ b/skia-bindings/build_support/platform/android.rs
@@ -9,6 +9,10 @@ pub struct Android;
 const API_LEVEL: &str = "26";
 
 impl PlatformDetails for Android {
+    fn uses_freetype(&self, _config: &BuildConfiguration) -> bool {
+        true
+    }
+
     fn gn_args(&self, config: &BuildConfiguration, builder: &mut GnArgsBuilder) {
         // TODO: this may belong into BuildConfiguration
         let (arch, _) = config.target.arch_abi();

--- a/skia-bindings/build_support/platform/emscripten.rs
+++ b/skia-bindings/build_support/platform/emscripten.rs
@@ -3,6 +3,10 @@ use super::{generic, prelude::*};
 pub struct Emscripten;
 
 impl PlatformDetails for Emscripten {
+    fn uses_freetype(&self, _config: &BuildConfiguration) -> bool {
+        true
+    }
+
     fn gn_args(&self, config: &BuildConfiguration, builder: &mut GnArgsBuilder) {
         let features = &config.features;
 
@@ -11,7 +15,6 @@ impl PlatformDetails for Emscripten {
             .arg("cxx", quote("em++"))
             .arg("ar", quote("emar"))
             .arg("skia_gl_standard", quote("webgl"))
-            .arg("skia_use_freetype", yes())
             .arg("skia_use_webgl", yes_if(features.gpu()))
             .arg("target_cpu", quote("wasm"));
 

--- a/skia-bindings/build_support/platform/generic.rs
+++ b/skia-bindings/build_support/platform/generic.rs
@@ -3,6 +3,10 @@ use super::prelude::*;
 pub struct Generic;
 
 impl PlatformDetails for Generic {
+    fn uses_freetype(&self, _config: &BuildConfiguration) -> bool {
+        true
+    }
+
     fn gn_args(&self, config: &BuildConfiguration, builder: &mut GnArgsBuilder) {
         gn_args(config, builder)
     }

--- a/skia-bindings/build_support/platform/ios.rs
+++ b/skia-bindings/build_support/platform/ios.rs
@@ -15,6 +15,10 @@ const MIN_IOS_VERSION_M1: &str = "14";
 const MIN_IOS_VERSION_CATALYST: &str = "14";
 
 impl PlatformDetails for Ios {
+    fn uses_freetype(&self, _config: &BuildConfiguration) -> bool {
+        false
+    }
+
     fn gn_args(&self, config: &BuildConfiguration, builder: &mut GnArgsBuilder) {
         let (arch, abi) = config.target.arch_abi();
 

--- a/skia-bindings/build_support/platform/linux.rs
+++ b/skia-bindings/build_support/platform/linux.rs
@@ -3,6 +3,10 @@ use super::{generic, prelude::*};
 pub struct Linux;
 
 impl PlatformDetails for Linux {
+    fn uses_freetype(&self, _config: &BuildConfiguration) -> bool {
+        true
+    }
+
     fn gn_args(&self, config: &BuildConfiguration, builder: &mut GnArgsBuilder) {
         gn_args(config, builder);
 

--- a/skia-bindings/build_support/platform/macos.rs
+++ b/skia-bindings/build_support/platform/macos.rs
@@ -8,6 +8,10 @@ use super::prelude::*;
 pub struct MacOs;
 
 impl PlatformDetails for MacOs {
+    fn uses_freetype(&self, _config: &BuildConfiguration) -> bool {
+        false
+    }
+
     fn gn_args(&self, _config: &BuildConfiguration, builder: &mut GnArgsBuilder) {
         // Skia will take care to set a specific `--target` for the current macOS version. So we
         // don't push another target `--target` that may conflict.

--- a/skia-bindings/build_support/platform/windows.rs
+++ b/skia-bindings/build_support/platform/windows.rs
@@ -6,6 +6,10 @@ use crate::build_support::{cargo, clang};
 pub struct Msvc;
 
 impl PlatformDetails for Msvc {
+    fn uses_freetype(&self, _config: &BuildConfiguration) -> bool {
+        false
+    }
+
     fn gn_args(&self, config: &BuildConfiguration, builder: &mut GnArgsBuilder) {
         if let Some(win_vc) = resolve_vc() {
             builder.arg(
@@ -66,6 +70,10 @@ impl PlatformDetails for Msvc {
 pub struct Generic;
 
 impl PlatformDetails for Generic {
+    fn uses_freetype(&self, _config: &BuildConfiguration) -> bool {
+        false
+    }
+
     fn gn_args(&self, _config: &BuildConfiguration, builder: &mut GnArgsBuilder) {
         builder.target_os_and_default_cpu("win");
     }

--- a/skia-bindings/build_support/skia/config.rs
+++ b/skia-bindings/build_support/skia/config.rs
@@ -187,20 +187,24 @@ impl FinalBuildConfiguration {
                 builder.arg("skia_use_system_libwebp", yes_if(use_system_libraries));
             }
 
-            if features.embed_freetype {
-                builder.arg("skia_use_system_freetype2", no());
-            } else {
-                // third_party/freetype2/BUILD.gn hard-codes /usr/include/freetype2
-                // as include path. When cross-compiling against a sysroot, we don't
-                // want the host directory, we want the path from the sysroot, so prepend
-                // a `=` to substitute the sysroot if present.
-                // Ideally we'd overwrite the skia_system_freetype2_include_path
-                // argument, but somehow that doesn't accept a `=`. So change it to
-                // a non-existent path, append a sysroot prefixed include path, as well
-                // as the previous fallback that's used if no sysroot is specified.
-                builder.arg("skia_system_freetype2_include_path", "\"/does/not/exist\"");
-                builder.cflag("-I=/usr/include/freetype2");
-                builder.cflag("-I/usr/include/freetype2");
+            let use_freetype = platform::uses_freetype(build);
+            builder.arg("skia_use_freetype", yes_if(use_freetype));
+            if use_freetype {
+                if features.embed_freetype {
+                    builder.arg("skia_use_system_freetype2", no());
+                } else {
+                    // third_party/freetype2/BUILD.gn hard-codes /usr/include/freetype2
+                    // as include path. When cross-compiling against a sysroot, we don't
+                    // want the host directory, we want the path from the sysroot, so prepend
+                    // a `=` to substitute the sysroot if present.
+                    // Ideally we'd overwrite the skia_system_freetype2_include_path
+                    // argument, but somehow that doesn't accept a `=`. So change it to
+                    // a non-existent path, append a sysroot prefixed include path, as well
+                    // as the previous fallback that's used if no sysroot is specified.
+                    builder.arg("skia_system_freetype2_include_path", "\"/does/not/exist\"");
+                    builder.cflag("-I=/usr/include/freetype2");
+                    builder.cflag("-I/usr/include/freetype2");
+                }
             }
 
             // target specific gn args.


### PR DESCRIPTION
This allows a more detailed control about when freetype is used and prevents GN from complaining about unexpected FreeType related arguments as a side effect.