### PR TITLE
Milestone 125

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -62,6 +62,7 @@
         "Subsetter",
         "subsetting",
         "Tahoma",
+        "Unicodes",
         "unoptimized",
         "USERPROFILE",
         "uset",
@@ -72,6 +73,7 @@
     "C_Cpp.default.defines": [
         "SK_GANESH",
         "SK_USING_THIRD_PARTY_ICU",
+        "SK_SHAPER_UNICODE_AVAILABLE",
         "SK_UNICODE_ICU_IMPLEMENTATION",
         "SK_SHAPER_HARFBUZZ_AVAILABLE",
         "SK_CODEC_DECODES_WEBP"

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![Windows QA](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml) [![Linux QA](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml) [![macOS QA](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml)
 
-Skia Submodule Status: chrome/m124 ([upstream changes][skia-upstream], [our changes][skia-ours]).
+Skia Submodule Status: chrome/m125 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m124-0.72.3...google:chrome/m124
-[skia-ours]: https://github.com/google/skia/compare/chrome/m124...rust-skia:m124-0.72.3
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m125-0.73.0...google:chrome/m125
+[skia-ours]: https://github.com/google/skia/compare/chrome/m125...rust-skia:m125-0.73.0
 
 ## About
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.73.0"
+version = "0.74.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2021"
 build = "build.rs"

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -30,7 +30,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m124-0.72.3"
+skia = "m125-0.73.0"
 depot_tools = "73a2624"
 
 [features]

--- a/skia-bindings/build_support/binaries_config.rs
+++ b/skia-bindings/build_support/binaries_config.rs
@@ -17,7 +17,8 @@ pub mod lib {
     pub const SK_PARAGRAPH: &str = "skparagraph";
     pub const SVG: &str = "svg";
     pub const SK_RESOURCES: &str = "skresources";
-    pub const SK_UNICODE: &str = "skunicode";
+    pub const SK_UNICODE_CORE: &str = "skunicode_core";
+    pub const SK_UNICODE_ICU: &str = "skunicode_icu";
 }
 
 /// The configuration of the resulting binaries.
@@ -67,8 +68,8 @@ impl BinariesConfiguration {
             }
             ninja_built_libraries.push(lib::SK_PARAGRAPH.into());
             ninja_built_libraries.push(lib::SK_SHAPER.into());
-            // Since M94, icu sources are embedded in skunicode
-            ninja_built_libraries.push(lib::SK_UNICODE.into());
+            ninja_built_libraries.push(lib::SK_UNICODE_CORE.into());
+            ninja_built_libraries.push(lib::SK_UNICODE_ICU.into());
         }
         if features.svg {
             ninja_built_libraries.push(lib::SVG.into());

--- a/skia-bindings/build_support/skia_bindgen.rs
+++ b/skia-bindings/build_support/skia_bindgen.rs
@@ -830,7 +830,8 @@ pub(crate) mod definitions {
             files.extend(vec![
                 "obj/modules/skshaper/skshaper.ninja".into(),
                 "obj/modules/skparagraph/skparagraph.ninja".into(),
-                "obj/modules/skunicode/skunicode.ninja".into(),
+                "obj/modules/skunicode/skunicode_core.ninja".into(),
+                "obj/modules/skunicode/skunicode_icu.ninja".into(),
             ]);
             // shaper.cpp includes SkLoadICU.h
             if !use_system_libraries {

--- a/skia-bindings/build_support/skia_bindgen.rs
+++ b/skia-bindings/build_support/skia_bindgen.rs
@@ -365,8 +365,6 @@ const OPAQUE_TYPES: &[&str] = &[
     "SkBitmap_HeapAllocator",
     "SkColorFilter",
     "SkDeque_F2BIter",
-    "SkDrawLooper",
-    "SkDrawLooper_Context",
     "SkDrawable_GpuDrawHandler",
     "SkFlattenable",
     "SkFontMgr",

--- a/skia-bindings/build_support/skia_bindgen.rs
+++ b/skia-bindings/build_support/skia_bindgen.rs
@@ -1,8 +1,10 @@
 //! Full build support for the SkiaBindings library, and bindings.rs file.
-use crate::build_support::{binaries_config, cargo, cargo::Target, features, platform};
+use std::path::{Path, PathBuf};
+
 use bindgen::{CodegenConfig, EnumVariation, RustTarget};
 use cc::Build;
-use std::path::{Path, PathBuf};
+
+use crate::build_support::{binaries_config, cargo, cargo::Target, features, platform};
 
 pub mod env {
     use crate::build_support::cargo;
@@ -788,22 +790,32 @@ pub(crate) mod definitions {
 
         for ninja_file in ninja_files {
             let ninja_file = output_directory.join(ninja_file);
-            let contents = fs::read_to_string(ninja_file).unwrap();
-            definitions = combine(definitions, from_ninja_file_content(contents))
+            let contents = fs::read_to_string(&ninja_file).unwrap_or_else(|err| {
+                panic!(
+                    "Failed to read ninja file: `{}`: {err}",
+                    ninja_file.display()
+                )
+            });
+            definitions = combine(definitions, from_ninja_file_content(&ninja_file, contents))
         }
 
         definitions
     }
 
     /// Parse a defines = line from a ninja build file.
-    fn from_ninja_file_content(ninja_file: impl AsRef<str>) -> Definitions {
+    fn from_ninja_file_content(file_path: &Path, contents: impl AsRef<str>) -> Definitions {
         let defines = {
             let prefix = "defines = ";
-            let defines = ninja_file
+            let defines = contents
                 .as_ref()
                 .lines()
                 .find(|s| s.starts_with(prefix))
-                .expect("missing a line with the prefix 'defines =' in a .ninja file");
+                .unwrap_or_else(|| {
+                    panic!(
+                        "Missing a line starting with `defines =` in: {}",
+                        file_path.display()
+                    )
+                });
             &defines[prefix.len()..]
         };
         from_defines_str(defines)

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1092,7 +1092,7 @@ extern "C" bool C_SkBitmap_ComputeIsOpaque(const SkBitmap* self) {
     return SkBitmap::ComputeIsOpaque(*self);
 }
 
-extern "C" bool C_SkBitmap_setColorSpace(SkBitmap* self, SkColorSpace* colorSpace) {
+extern "C" void C_SkBitmap_setColorSpace(SkBitmap* self, SkColorSpace* colorSpace) {
     self->setColorSpace(sp(colorSpace));
 }
 

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1092,6 +1092,10 @@ extern "C" bool C_SkBitmap_ComputeIsOpaque(const SkBitmap* self) {
     return SkBitmap::ComputeIsOpaque(*self);
 }
 
+extern "C" bool C_SkBitmap_setColorSpace(SkBitmap* self, SkColorSpace* colorSpace) {
+    self->setColorSpace(sp(colorSpace));
+}
+
 extern "C" bool C_SkBitmap_tryAllocN32Pixels(SkBitmap* self, int width, int height, bool isOpaque) {
     return self->tryAllocN32Pixels(width, height, isOpaque);
 }
@@ -2153,6 +2157,14 @@ extern "C" SkShader* C_SkShaders_Blend(SkBlender* blender, SkShader* dst, SkShad
 
 extern "C" SkShader* C_SkShaders_CoordClamp(SkShader* shader, const SkRect* subset) {
     return SkShaders::CoordClamp(sp(shader), *subset).release();
+}
+
+extern "C" SkShader* C_SkShaders_Image(SkImage* image, SkTileMode tmx, SkTileMode tmy, const SkSamplingOptions& options, const SkMatrix* localMatrix) {
+    return SkShaders::Image(sp(image), tmx, tmy, options, localMatrix).release();
+}
+
+extern "C" SkShader* C_SkShaders_RawImage(SkImage* image, SkTileMode tmx, SkTileMode tmy, const SkSamplingOptions& options, const SkMatrix* localMatrix) {
+    return SkShaders::RawImage(sp(image), tmx, tmy, options, localMatrix).release();
 }
 
 extern "C" SkShader* C_SkShader_Deserialize(const void* data, size_t length) {

--- a/skia-bindings/src/impls.rs
+++ b/skia-bindings/src/impls.rs
@@ -111,6 +111,7 @@ impl From<crate::GrGLFormat> for crate::GrGLenum {
         unsafe { crate::C_GrGLFormatToEnum(format) }
     }
 }
+
 #[cfg(feature = "vulkan")]
 mod vulkan {
     impl PartialEq for crate::VkComponentMapping {

--- a/skia-bindings/src/impls.rs
+++ b/skia-bindings/src/impls.rs
@@ -1,5 +1,4 @@
-//! This file contains implementations for types that are
-//! re-exported in skia-safe.
+//! This file contains implementations for types that are re-exported in skia-safe.
 //!
 //! We could provide trait implementations in skia-safe, but then users of the library would have to
 //! import the implementation type _and_ the trait.
@@ -111,6 +110,16 @@ impl From<crate::GrGLFormat> for crate::GrGLenum {
     fn from(format: crate::GrGLFormat) -> Self {
         unsafe { crate::C_GrGLFormatToEnum(format) }
     }
+}
+#[cfg(feature = "vulkan")]
+mod vulkan {
+    impl PartialEq for crate::VkComponentMapping {
+        fn eq(&self, other: &Self) -> bool {
+            self.r == other.r && self.g == other.g && self.b == other.b && self.a == other.a
+        }
+    }
+
+    impl Eq for crate::VkComponentMapping {}
 }
 
 #[cfg(feature = "d3d")]

--- a/skia-bindings/src/metal.cpp
+++ b/skia-bindings/src/metal.cpp
@@ -19,12 +19,29 @@ extern "C" void C_GrMtlTypes(GrMTLTextureUsage*, GrMtlSurfaceInfo *) {};
 // gpu/ganesh/mtl/GrMtlBackendSurface.h
 //
 
+extern "C" void C_GrBackendFormats_ConstructMtl(GrBackendFormat* uninitialized, GrMTLPixelFormat format) {
+    new(uninitialized)GrBackendFormat(GrBackendFormats::MakeMtl(format));
+}
+
 extern "C" GrMTLPixelFormat C_GrBackendFormats_AsMtlFormat(const GrBackendFormat* backendFormat) {
     return GrBackendFormats::AsMtlFormat(*backendFormat);
 }
 
+extern "C" GrBackendTexture* C_GrBackendTextures_newMtl(
+    int width, int height,
+    skgpu::Mipmapped mipMapped,
+    const GrMtlTextureInfo* mtlInfo,
+    const char* label,
+    size_t labelCount) {
+    return new GrBackendTexture(GrBackendTextures::MakeMtl(width, height, mipMapped, *mtlInfo, std::string_view(label, labelCount)));
+}
+
 extern "C" bool C_GrBackendTextures_GetMtlTextureInfo(const GrBackendTexture* backendTexture, GrMtlTextureInfo* textureInfo) {
     return GrBackendTextures::GetMtlTextureInfo(*backendTexture, textureInfo);
+}
+
+extern "C" void C_GrBackendRenderTargets_ConstructMtl(GrBackendRenderTarget* uninitialized, int width, int height, const GrMtlTextureInfo* mtlInfo) {
+    new(uninitialized)GrBackendRenderTarget(GrBackendRenderTargets::MakeMtl(width, height, *mtlInfo));
 }
 
 extern "C" bool C_GrBackendRenderTargets_GetMtlTextureInfo(const GrBackendRenderTarget* target, GrMtlTextureInfo* info) {
@@ -105,26 +122,3 @@ extern "C" void C_GrMtlTextureInfo_Destruct(GrMtlTextureInfo* self) {
 extern "C" bool C_GrMtlTextureInfo_Equals(const GrMtlTextureInfo* lhs, const GrMtlTextureInfo* rhs) {
     return *lhs == *rhs;
 }
-
-//
-// gpu/GrBackendSurface.h
-//
-
-extern "C" void C_GrBackendFormat_ConstructMtl(GrBackendFormat* uninitialized, GrMTLPixelFormat format) {
-    new(uninitialized)GrBackendFormat(GrBackendFormats::MakeMtl(format));
-}
-
-
-extern "C" GrBackendTexture* C_GrBackendTexture_newMtl(
-    int width, int height,
-    skgpu::Mipmapped mipMapped,
-    const GrMtlTextureInfo* mtlInfo,
-    const char* label,
-    size_t labelCount) {
-    return new GrBackendTexture(GrBackendTextures::MakeMtl(width, height, mipMapped, *mtlInfo, std::string_view(label, labelCount)));
-}
-
-extern "C" void C_GrBackendRenderTargets_ConstructMtl(GrBackendRenderTarget* uninitialized, int width, int height, const GrMtlTextureInfo* mtlInfo) {
-    new(uninitialized)GrBackendRenderTarget(GrBackendRenderTargets::MakeMtl(width, height, *mtlInfo));
-}
-

--- a/skia-bindings/src/metal.cpp
+++ b/skia-bindings/src/metal.cpp
@@ -7,11 +7,29 @@
 #include "include/core/SkColorSpace.h"
 #include "include/core/SkSurface.h"
 #include "include/gpu/ganesh/mtl/SkSurfaceMetal.h"
-#include "include/gpu/mtl/GrMtlBackendContext.h"
+#include "include/gpu/ganesh/mtl/GrMtlBackendContext.h"
+#include "include/gpu/ganesh/mtl/GrMtlBackendSurface.h"
+#include "include/gpu/ganesh/mtl/GrMtlDirectContext.h"
 #include "include/gpu/GrBackendSurface.h"
 #include "include/gpu/GrDirectContext.h"
 
 extern "C" void C_GrMtlTypes(GrMTLTextureUsage*, GrMtlSurfaceInfo *) {};
+
+//
+// gpu/ganesh/mtl/GrMtlBackendSurface.h
+//
+
+extern "C" GrMTLPixelFormat C_GrBackendFormats_AsMtlFormat(const GrBackendFormat* backendFormat) {
+    return GrBackendFormats::AsMtlFormat(*backendFormat);
+}
+
+extern "C" bool C_GrBackendTextures_GetMtlTextureInfo(const GrBackendTexture* backendTexture, GrMtlTextureInfo* textureInfo) {
+    return GrBackendTextures::GetMtlTextureInfo(*backendTexture, textureInfo);
+}
+
+extern "C" bool C_GrBackendRenderTargets_GetMtlTextureInfo(const GrBackendRenderTarget* target, GrMtlTextureInfo* info) {
+    return GrBackendRenderTargets::GetMtlTextureInfo(*target, info);
+}
 
 //
 // gpu/ganesh/mtl/SkSurfaceMetal.h
@@ -50,9 +68,9 @@ extern "C" GrDirectContext *C_GrContext_MakeMetal(
 {
     if (options)
     {
-        return GrDirectContext::MakeMetal(*context, *options).release();
+        return GrDirectContexts::MakeMetal(*context, *options).release();
     }
-    return GrDirectContext::MakeMetal(*context).release();
+    return GrDirectContexts::MakeMetal(*context).release();
 }
 
 //
@@ -60,12 +78,11 @@ extern "C" GrDirectContext *C_GrContext_MakeMetal(
 //
 
 extern "C" void C_GrMtlBackendContext_Construct(
-    GrMtlBackendContext* uninitialized, 
-    const void* device, const void* queue, const void* binaryArchive) {
+    GrMtlBackendContext* uninitialized,
+    const void* device, const void* queue) {
     new (uninitialized) GrMtlBackendContext();
     uninitialized->fDevice.retain(device);
     uninitialized->fQueue.retain(queue);
-    uninitialized->fBinaryArchive.retain(binaryArchive);
 }
 
 extern "C" void C_GrMtlBackendContext_Destruct(GrMtlBackendContext* self) {
@@ -94,7 +111,7 @@ extern "C" bool C_GrMtlTextureInfo_Equals(const GrMtlTextureInfo* lhs, const GrM
 //
 
 extern "C" void C_GrBackendFormat_ConstructMtl(GrBackendFormat* uninitialized, GrMTLPixelFormat format) {
-    new(uninitialized)GrBackendFormat(GrBackendFormat::MakeMtl(format));
+    new(uninitialized)GrBackendFormat(GrBackendFormats::MakeMtl(format));
 }
 
 
@@ -104,9 +121,10 @@ extern "C" GrBackendTexture* C_GrBackendTexture_newMtl(
     const GrMtlTextureInfo* mtlInfo,
     const char* label,
     size_t labelCount) {
-    return new GrBackendTexture(width, height, mipMapped, *mtlInfo, std::string_view(label, labelCount));
+    return new GrBackendTexture(GrBackendTextures::MakeMtl(width, height, mipMapped, *mtlInfo, std::string_view(label, labelCount)));
 }
 
 extern "C" void C_GrBackendRenderTargets_ConstructMtl(GrBackendRenderTarget* uninitialized, int width, int height, const GrMtlTextureInfo* mtlInfo) {
-    new(uninitialized)GrBackendRenderTarget(width, height, *mtlInfo);
+    new(uninitialized)GrBackendRenderTarget(GrBackendRenderTargets::MakeMtl(width, height, *mtlInfo));
 }
+

--- a/skia-bindings/src/shaper.cpp
+++ b/skia-bindings/src/shaper.cpp
@@ -202,13 +202,16 @@ extern "C" SkShaper* C_SkShapers_Primitive_PrimitiveText() {
 }
 
 extern "C" SkShaper::BiDiRunIterator* C_SkShapers_Primitive_TrivialBidiRunIterator_new(uint8_t bidiLevel, size_t utf8Bytes) {
-    return SkShapers::Primitive::TrivialBiDiRunIterator(bidiLevel, utf8Bytes).release();
+    // m125: This function is not yet implemented.
+    // return SkShapers::Primitive::TrivialBiDiRunIterator(bidiLevel, utf8Bytes).release();
+    return new SkShaper::TrivialBiDiRunIterator(bidiLevel, utf8Bytes);
 }
 
 extern "C" SkShaper::ScriptRunIterator* C_SkShapers_Primitive_TrivialScriptRunIterator_new(uint8_t bidiLevel, size_t utf8Bytes) {
-    return SkShapers::Primitive::TrivialScriptRunIterator(bidiLevel, utf8Bytes).release();
+    // m125: This function is not yet implemented.
+    // return SkShapers::Primitive::TrivialScriptRunIterator(bidiLevel, utf8Bytes).release();
+    return new SkShaper::TrivialScriptRunIterator(bidiLevel, utf8Bytes);
 }
-
 
 // SkShapers::HB
 

--- a/skia-bindings/src/shaper.cpp
+++ b/skia-bindings/src/shaper.cpp
@@ -2,22 +2,13 @@
 
 #include "include/core/SkFontMgr.h"
 #include "modules/skshaper/include/SkShaper.h"
+#include "modules/skshaper/include/SkShaper_harfbuzz.h"
+#include "modules/skshaper/include/SkShaper_skunicode.h"
+#include "modules/skunicode/include/SkUnicode_icu.h"
 
 #if defined(_WIN32)
 #include "third_party/icu/SkLoadICU.h"
 #endif
-
-extern "C" SkShaper* C_SkShaper_MakePrimitive() {
-    return SkShaper::MakePrimitive().release();
-}
-
-extern "C" SkShaper* C_SkShaper_MakeShaperDrivenWrapper(SkFontMgr* fontMgr) {
-    return SkShaper::MakeShaperDrivenWrapper(sk_sp<SkFontMgr>(fontMgr)).release();
-}
-
-extern "C" SkShaper* C_SkShaper_MakeShapeThenWrap(SkFontMgr* fontMgr) {
-    return SkShaper::MakeShapeThenWrap(sk_sp<SkFontMgr>(fontMgr)).release();
-}
 
 extern "C" SkShaper* C_SkShaper_MakeCoreText() {
 #ifdef SK_SHAPER_CORETEXT_AVAILABLE
@@ -75,10 +66,6 @@ extern "C" SkShaper::BiDiRunIterator* C_SkShaper_MakeIcuBidiRunIterator(const ch
     return SkShaper::MakeIcuBiDiRunIterator(utf8, utf8Bytes, bidiLevel).release();
 }
 
-extern "C" SkShaper::BiDiRunIterator* C_SkShaper_TrivialBidiRunIterator_new(uint8_t bidiLevel, size_t utf8Bytes) {
-    return new SkShaper::TrivialBiDiRunIterator(bidiLevel, utf8Bytes);
-}
-
 extern "C" SkFourByteTag C_SkShaper_ScriptRunIterator_currentScript(const SkShaper::ScriptRunIterator* self) {
     return self->currentScript();
 }
@@ -89,10 +76,6 @@ extern "C" SkShaper::ScriptRunIterator* C_SkShaper_MakeScriptRunIterator(const c
 
 extern "C" SkShaper::ScriptRunIterator* C_SkShaper_MakeHbIcuScriptRunIterator(const char* utf8, size_t utf8Bytes) {
     return SkShaper::MakeHbIcuScriptRunIterator(utf8, utf8Bytes).release();
-}
-
-extern "C" SkShaper::ScriptRunIterator* C_SkShaper_TrivialScriptRunIterator_new(uint8_t bidiLevel, size_t utf8Bytes) {
-    return new SkShaper::TrivialScriptRunIterator(bidiLevel, utf8Bytes);
 }
 
 extern "C" const char* C_SkShaper_LanguageRunIterator_currentLanguage(const SkShaper::LanguageRunIterator* self) {
@@ -210,4 +193,55 @@ extern "C" SkTextBlob* C_SkTextBlobBuilderRunHandler_makeBlob(SkTextBlobBuilderR
 
 extern "C" SkPoint C_SkTextBlobBuilderRunHandler_endPoint(SkTextBlobBuilderRunHandler* self) {
     return self->endPoint();
+}
+
+// SkShapers::Primitive
+
+extern "C" SkShaper* C_SkShapers_Primitive_PrimitiveText() {
+    return SkShapers::Primitive::PrimitiveText().release();
+}
+
+extern "C" SkShaper::BiDiRunIterator* C_SkShapers_Primitive_TrivialBidiRunIterator_new(uint8_t bidiLevel, size_t utf8Bytes) {
+    return SkShapers::Primitive::TrivialBiDiRunIterator(bidiLevel, utf8Bytes).release();
+}
+
+extern "C" SkShaper::ScriptRunIterator* C_SkShapers_Primitive_TrivialScriptRunIterator_new(uint8_t bidiLevel, size_t utf8Bytes) {
+    return SkShapers::Primitive::TrivialScriptRunIterator(bidiLevel, utf8Bytes).release();
+}
+
+
+// SkShapers::HB
+
+extern "C" SkShaper* C_SkShapers_HB_ShaperDrivenWrapper(SkFontMgr* fontMgr) {
+    auto unicode = SkUnicodes::ICU::Make();
+    if (!unicode) {
+        return nullptr;
+    }
+    return SkShapers::HB::ShaperDrivenWrapper(std::move(unicode), sk_sp<SkFontMgr>(fontMgr)).release();
+}
+
+extern "C" SkShaper* C_SkShapers_HB_ShapeThenWrap(SkFontMgr* fontMgr) {
+    auto unicode = SkUnicodes::ICU::Make();
+    if (!unicode) {
+        return nullptr;
+    }
+    return SkShapers::HB::ShapeThenWrap(std::move(unicode), sk_sp<SkFontMgr>(fontMgr)).release();
+}
+
+extern "C" SkShaper* C_SkShapers_HB_ShapeDontWrapOrReorder(SkFontMgr* fontMgr) {
+    auto unicode = SkUnicodes::ICU::Make();
+    if (!unicode) {
+        return nullptr;
+    }
+    return SkShapers::HB::ShapeDontWrapOrReorder(std::move(unicode), sk_sp<SkFontMgr>(fontMgr)).release();
+}
+
+// SkShapers::unicode
+
+extern "C" SkShaper::BiDiRunIterator* C_SkShapers_unicode_BidiRunIterator(const char* utf8, size_t utf8Bytes, uint8_t bidiLevel) {
+    auto unicode = SkUnicodes::ICU::Make();
+    if (!unicode) {
+        return nullptr;
+    }
+    return SkShapers::unicode::BidiRunIterator(std::move(unicode), utf8, utf8Bytes, bidiLevel).release();
 }

--- a/skia-bindings/src/shaper.cpp
+++ b/skia-bindings/src/shaper.cpp
@@ -2,7 +2,6 @@
 
 #include "include/core/SkFontMgr.h"
 #include "modules/skshaper/include/SkShaper.h"
-#include "modules/skunicode/include/SkUnicode.h"
 
 #if defined(_WIN32)
 #include "third_party/icu/SkLoadICU.h"
@@ -18,15 +17,6 @@ extern "C" SkShaper* C_SkShaper_MakeShaperDrivenWrapper(SkFontMgr* fontMgr) {
 
 extern "C" SkShaper* C_SkShaper_MakeShapeThenWrap(SkFontMgr* fontMgr) {
     return SkShaper::MakeShapeThenWrap(sk_sp<SkFontMgr>(fontMgr)).release();
-}
-
-extern "C" SkShaper* C_SkShaper_MakeShapeDontWrapOrReorder(SkFontMgr* fontMgr) {
-    auto unicode = SkUnicode::Make();
-    if (!unicode) {
-        return nullptr;
-    }
-
-    return SkShaper::MakeShapeDontWrapOrReorder(std::move(unicode), sk_sp<SkFontMgr>(fontMgr)).release();
 }
 
 extern "C" SkShaper* C_SkShaper_MakeCoreText() {

--- a/skia-org/src/drivers/gl.rs
+++ b/skia-org/src/drivers/gl.rs
@@ -14,7 +14,7 @@ impl DrawingDriver for OpenGl {
     fn new() -> Self {
         let interface = gpu::gl::Interface::new_native().unwrap();
         Self {
-            context: gpu::DirectContext::new_gl(interface, None).unwrap(),
+            context: gpu::direct_contexts::make_gl(interface, None).unwrap(),
         }
     }
 

--- a/skia-org/src/drivers/metal.rs
+++ b/skia-org/src/drivers/metal.rs
@@ -35,7 +35,7 @@ impl DrawingDriver for Metal {
             )
         };
 
-        let context = gpu::DirectContext::new_metal(&backend, None).unwrap();
+        let context = gpu::direct_contexts::make_metal(&backend, None).unwrap();
 
         Self {
             context,

--- a/skia-org/src/drivers/metal.rs
+++ b/skia-org/src/drivers/metal.rs
@@ -1,4 +1,4 @@
-use std::{path::Path, ptr};
+use std::path::Path;
 
 use cocoa::foundation::NSAutoreleasePool;
 use foreign_types_shared::ForeignType;
@@ -32,7 +32,6 @@ impl DrawingDriver for Metal {
             mtl::BackendContext::new(
                 device.as_ptr() as mtl::Handle,
                 queue.as_ptr() as mtl::Handle,
-                ptr::null(),
             )
         };
 

--- a/skia-org/src/drivers/vulkan.rs
+++ b/skia-org/src/drivers/vulkan.rs
@@ -44,7 +44,7 @@ impl DrawingDriver for Vulkan {
                 )
             };
 
-            gpu::DirectContext::new_vulkan(&backend_context, None).unwrap()
+            gpu::direct_contexts::make_vulkan(&backend_context, None).unwrap()
         };
 
         Self {

--- a/skia-org/src/skshaper_example.rs
+++ b/skia-org/src/skshaper_example.rs
@@ -1,6 +1,6 @@
 use std::path;
 
-use skia_safe::{shaper::shapers, Canvas, Font, FontMgr, Paint, Point, Shaper};
+use skia_safe::{shapers, Canvas, Font, FontMgr, Paint, Point, Shaper};
 
 use crate::{helper::default_typeface, DrawingDriver};
 

--- a/skia-org/src/skshaper_example.rs
+++ b/skia-org/src/skshaper_example.rs
@@ -1,6 +1,6 @@
 use std::path;
 
-use skia_safe::{Canvas, Font, FontMgr, Paint, Point, Shaper};
+use skia_safe::{shaper::shapers, Canvas, Font, FontMgr, Paint, Point, Shaper};
 
 use crate::{helper::default_typeface, DrawingDriver};
 
@@ -34,7 +34,7 @@ fn draw_rtl_unshaped(canvas: &Canvas) {
 
     let font = &Font::from_typeface(default_typeface(), 64.0);
 
-    let shaper = Shaper::new_primitive();
+    let shaper = shapers::primitive::primitive_text();
     if let Some((blob, _)) =
         shaper.shape_text_blob(RTL_TEXT, font, false, 10000.0, Point::default())
     {

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -18,7 +18,7 @@ categories = [
 ]
 license = "MIT"
 
-version = "0.73.0"
+version = "0.74.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2021"
 
@@ -54,7 +54,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 [dependencies]
 bitflags = "2.0"
 lazy_static = "1.4"
-skia-bindings = { version = "=0.73.0", path = "../skia-bindings", default-features = false }
+skia-bindings = { version = "=0.74.0", path = "../skia-bindings", default-features = false }
 
 # D3D types & ComPtr
 windows = { version = "0.56.0", features = [

--- a/skia-safe/examples/gl-window/main.rs
+++ b/skia-safe/examples/gl-window/main.rs
@@ -156,7 +156,7 @@ fn main() {
     })
     .expect("Could not create interface");
 
-    let mut gr_context = skia_safe::gpu::DirectContext::new_gl(interface, None)
+    let mut gr_context = skia_safe::gpu::direct_contexts::make_gl(interface, None)
         .expect("Could not create direct context");
 
     let fb_info = {

--- a/skia-safe/examples/metal-window/main.rs
+++ b/skia-safe/examples/metal-window/main.rs
@@ -18,7 +18,7 @@ fn main() {
     use foreign_types_shared::{ForeignType, ForeignTypeRef};
     use metal_rs::{Device, MTLPixelFormat, MetalLayer};
     use objc::{rc::autoreleasepool, runtime::YES};
-    use skia_safe::gpu::{self, mtl, BackendRenderTarget, DirectContext, SurfaceOrigin};
+    use skia_safe::gpu::{self, mtl, SurfaceOrigin};
     use winit::{
         dpi::LogicalSize,
         event::{Event, WindowEvent},
@@ -76,7 +76,7 @@ fn main() {
         )
     };
 
-    let mut context = DirectContext::new_metal(&backend, None).unwrap();
+    let mut context = gpu::direct_contexts::make_metal(&backend, None).unwrap();
 
     events_loop
         .run(move |event, window_target| {
@@ -103,10 +103,14 @@ fn main() {
                                         drawable.texture().as_ptr() as mtl::Handle,
                                     );
 
-                                    let backend_render_target = BackendRenderTarget::new_metal(
-                                        (drawable_size.width as i32, drawable_size.height as i32),
-                                        &texture_info,
-                                    );
+                                    let backend_render_target =
+                                        gpu::backend_render_targets::make_mtl(
+                                            (
+                                                drawable_size.width as i32,
+                                                drawable_size.height as i32,
+                                            ),
+                                            &texture_info,
+                                        );
 
                                     gpu::surfaces::wrap_backend_render_target(
                                         &mut context,

--- a/skia-safe/examples/metal-window/main.rs
+++ b/skia-safe/examples/metal-window/main.rs
@@ -73,7 +73,6 @@ fn main() {
         mtl::BackendContext::new(
             device.as_ptr() as mtl::Handle,
             command_queue.as_ptr() as mtl::Handle,
-            std::ptr::null(),
         )
     };
 

--- a/skia-safe/src/core/bitmap.rs
+++ b/skia-safe/src/core/bitmap.rs
@@ -197,7 +197,7 @@ impl Bitmap {
     ///
     /// This changes [`ColorSpace`] in [`PixelRef`]; all bitmaps sharing [`PixelRef`]
     /// are affected.
-    pub fn set_color_space(&mut self, color_space: impl Into<Option<ColorSpace>>) -> bool {
+    pub fn set_color_space(&mut self, color_space: impl Into<Option<ColorSpace>>) {
         unsafe {
             sb::C_SkBitmap_setColorSpace(self.native_mut(), color_space.into().into_ptr_or_null())
         }

--- a/skia-safe/src/core/bitmap.rs
+++ b/skia-safe/src/core/bitmap.rs
@@ -1,9 +1,11 @@
+use std::{ffi, fmt, ptr};
+
+use skia_bindings::{self as sb, SkBitmap};
+
 use crate::{
     prelude::*, AlphaType, Color, Color4f, ColorSpace, ColorType, IPoint, IRect, ISize, Image,
     ImageInfo, Matrix, Paint, PixelRef, Pixmap, SamplingOptions, Shader, TileMode,
 };
-use skia_bindings::{self as sb, SkBitmap};
-use std::{ffi, fmt, ptr};
 
 /// [`Bitmap`] describes a two-dimensional raster pixel array. [`Bitmap`] is built on [`ImageInfo`],
 /// containing integer width and height, [`ColorType`] and [`AlphaType`] describing the pixel
@@ -186,6 +188,19 @@ impl Bitmap {
     /// This changes [`AlphaType`] in [`PixelRef`]; all bitmaps sharing [`PixelRef`] are affected.
     pub fn set_alpha_type(&mut self, alpha_type: AlphaType) -> bool {
         unsafe { self.native_mut().setAlphaType(alpha_type) }
+    }
+
+    /// Sets the [`ColorSpace`] associated with this [`Bitmap`].
+    ///
+    /// The raw pixel data is not altered by this call; no conversion is
+    /// performed.
+    ///
+    /// This changes [`ColorSpace`] in [`PixelRef`]; all bitmaps sharing [`PixelRef`]
+    /// are affected.
+    pub fn set_color_space(&mut self, color_space: impl Into<Option<ColorSpace>>) -> bool {
+        unsafe {
+            sb::C_SkBitmap_setColorSpace(self.native_mut(), color_space.into().into_ptr_or_null())
+        }
     }
 
     /// Returns pixel address, the base address corresponding to the pixel origin.

--- a/skia-safe/src/core/color_type.rs
+++ b/skia-safe/src/core/color_type.rs
@@ -29,6 +29,8 @@ pub enum ColorType {
     BGR101010x = SkColorType::kBGR_101010x_SkColorType as _,
     /// pixel with 10 bits each for blue, green, red; in 32-bit word, extended range
     BGR101010xXR = SkColorType::kBGR_101010x_XR_SkColorType as _,
+    /// pixel with 10 bits each for blue, green, red, alpha; in 64-bit word, extended range
+    BGRA10101010XR = SkColorType::kBGRA_10101010_XR_SkColorType as _,
     /// pixel with 10 used bits (most significant) followed by 6 unused
     /// bits for red, green, blue, alpha; in 64-bit word
     RGBA10x6 = SkColorType::kRGBA_10x6_SkColorType as _,

--- a/skia-safe/src/core/milestone.rs
+++ b/skia-safe/src/core/milestone.rs
@@ -1,1 +1,1 @@
-pub const MILESTONE: usize = 124;
+pub const MILESTONE: usize = 125;

--- a/skia-safe/src/core/path.rs
+++ b/skia-safe/src/core/path.rs
@@ -948,10 +948,36 @@ impl Path {
     ///
     /// example: <https://fiddle.skia.org/c/@Path_incReserve>
     pub fn inc_reserve(&mut self, extra_pt_count: usize) -> &mut Self {
+        self.inc_reserve_with_verb_and_conic(extra_pt_count, None, None);
+        self
+    }
+
+    /// Grows [`Path`] verb array and [`Point`] array to contain `extra_pt_count` additional [`Point`].
+    /// May improve performance and use less memory by
+    /// reducing the number and size of allocations when creating [`Path`].
+    ///
+    /// * `extra_pt_count` - number of additional [`Point`] to allocate
+    /// * `extra_verb_count` - number of additional verbs
+    /// * `extra_conic_count` - number of additional conics
+    ///
+    /// example: <https://fiddle.skia.org/c/@Path_incReserve>
+    pub fn inc_reserve_with_verb_and_conic(
+        &mut self,
+        extra_pt_count: usize,
+        extra_verb_count: impl Into<Option<usize>>,
+        extract_conic_count: impl Into<Option<usize>>,
+    ) -> &mut Self {
+        let extra_verb_count = extra_verb_count.into().unwrap_or_default();
+        let extra_conic_count = extract_conic_count.into().unwrap_or_default();
+
         unsafe {
-            self.native_mut()
-                .incReserve(extra_pt_count.try_into().unwrap())
+            self.native_mut().incReserve(
+                extra_pt_count.try_into().unwrap(),
+                extra_verb_count.try_into().unwrap(),
+                extra_conic_count.try_into().unwrap(),
+            )
         }
+
         self
     }
 

--- a/skia-safe/src/core/shader.rs
+++ b/skia-safe/src/core/shader.rs
@@ -129,8 +129,12 @@ impl Shader {
 }
 
 pub mod shaders {
-    use crate::{prelude::*, Blender, Color, Color4f, ColorSpace, Rect, Shader};
     use skia_bindings as sb;
+
+    use crate::{
+        prelude::*, Blender, Color, Color4f, ColorSpace, Image, Matrix, Rect, SamplingOptions,
+        Shader, TileMode,
+    };
 
     pub fn empty() -> Shader {
         Shader::from_ptr(unsafe { sb::C_SkShaders_Empty() }).unwrap()
@@ -166,6 +170,43 @@ pub mod shaders {
     pub fn coord_clamp(shader: impl Into<Shader>, rect: impl AsRef<Rect>) -> Option<Shader> {
         Shader::from_ptr(unsafe {
             sb::C_SkShaders_CoordClamp(shader.into().into_ptr(), rect.as_ref().native())
+        })
+    }
+
+    /// Create an [`Shader`] that will sample the 'image'. This is equivalent to [`Image::to_shader`].
+    pub fn image<'a>(
+        image: impl Into<Image>,
+        tm: (TileMode, TileMode),
+        options: &SamplingOptions,
+        matrix: impl Into<Option<&'a Matrix>>,
+    ) -> Option<Shader> {
+        Shader::from_ptr(unsafe {
+            sb::C_SkShaders_Image(
+                image.into().into_ptr(),
+                tm.0,
+                tm.1,
+                options.native(),
+                matrix.into().native_ptr_or_null(),
+            )
+        })
+    }
+
+    /// Create an [`Shader`] that will sample 'image' with minimal processing. This is equivalent to
+    /// [`Image::to_raw_shader`].
+    pub fn raw_image<'a>(
+        image: impl Into<Image>,
+        tm: (TileMode, TileMode),
+        options: &SamplingOptions,
+        matrix: impl Into<Option<&'a Matrix>>,
+    ) -> Option<Shader> {
+        Shader::from_ptr(unsafe {
+            sb::C_SkShaders_RawImage(
+                image.into().into_ptr(),
+                tm.0,
+                tm.1,
+                options.native(),
+                matrix.into().native_ptr_or_null(),
+            )
         })
     }
 }

--- a/skia-safe/src/gpu.rs
+++ b/skia-safe/src/gpu.rs
@@ -9,8 +9,6 @@ mod ganesh;
 #[cfg(feature = "gl")]
 pub mod gl;
 mod gpu_types;
-#[cfg(feature = "metal")]
-pub mod mtl;
 mod mutable_texture_state;
 mod recording_context;
 mod types;
@@ -33,9 +31,14 @@ pub use yuva_backend_textures::*;
 #[deprecated(since = "0.37.0", note = "Use RecordingContext or DirectContext")]
 pub type Context = DirectContext;
 
+#[cfg(feature = "metal")]
+pub mod mtl {
+    pub use super::ganesh::mtl::{types::*, BackendContext};
+}
+
 pub mod surfaces {
     #[cfg(feature = "metal")]
-    pub use super::ganesh::mtl::*;
+    pub use super::ganesh::mtl::surface_metal::*;
     pub use super::ganesh::surface_ganesh::*;
 }
 

--- a/skia-safe/src/gpu.rs
+++ b/skia-safe/src/gpu.rs
@@ -42,6 +42,8 @@ pub mod surfaces {
 pub mod backend_formats {
     #[cfg(feature = "gl")]
     pub use super::ganesh::gl::backend_formats::*;
+    #[cfg(feature = "metal")]
+    pub use super::ganesh::mtl::backend_formats::*;
     #[cfg(feature = "vulkan")]
     pub use super::ganesh::vk::backend_formats::*;
 }
@@ -49,6 +51,8 @@ pub mod backend_formats {
 pub mod backend_textures {
     #[cfg(feature = "gl")]
     pub use super::ganesh::gl::backend_textures::*;
+    #[cfg(feature = "metal")]
+    pub use super::ganesh::mtl::backend_textures::*;
     #[cfg(feature = "vulkan")]
     pub use super::ganesh::vk::backend_textures::*;
 }
@@ -56,6 +60,8 @@ pub mod backend_textures {
 pub mod backend_render_targets {
     #[cfg(feature = "gl")]
     pub use super::ganesh::gl::backend_render_targets::*;
+    #[cfg(feature = "metal")]
+    pub use super::ganesh::mtl::backend_render_targets::*;
     #[cfg(feature = "vulkan")]
     pub use super::ganesh::vk::backend_render_targets::*;
 }

--- a/skia-safe/src/gpu/backend_surface.rs
+++ b/skia-safe/src/gpu/backend_surface.rs
@@ -124,7 +124,7 @@ impl BackendFormat {
 
     #[cfg(feature = "metal")]
     pub fn as_mtl_format(&self) -> Option<mtl::PixelFormat> {
-        let pixel_format = unsafe { self.native().asMtlFormat() };
+        let pixel_format = unsafe { sb::C_GrBackendFormats_AsMtlFormat(self.native()) };
         // Mtl's PixelFormat == 0 is invalid.
         (pixel_format != 0).if_true_some(pixel_format)
     }
@@ -371,8 +371,7 @@ impl BackendTexture {
     pub fn metal_texture_info(&self) -> Option<mtl::TextureInfo> {
         unsafe {
             let mut texture_info = mtl::TextureInfo::default();
-            self.native()
-                .getMtlTextureInfo(texture_info.native_mut())
+            sb::C_GrBackendTextures_GetMtlTextureInfo(self.native(), texture_info.native_mut())
                 .if_true_some(texture_info)
         }
     }
@@ -556,7 +555,8 @@ impl BackendRenderTarget {
     #[cfg(feature = "metal")]
     pub fn metal_texture_info(&self) -> Option<mtl::TextureInfo> {
         let mut info = mtl::TextureInfo::default();
-        unsafe { self.native().getMtlTextureInfo(info.native_mut()) }.if_true_some(info)
+        unsafe { sb::C_GrBackendRenderTargets_GetMtlTextureInfo(self.native(), info.native_mut()) }
+            .if_true_some(info)
     }
 
     #[cfg(feature = "d3d")]

--- a/skia-safe/src/gpu/backend_surface.rs
+++ b/skia-safe/src/gpu/backend_surface.rs
@@ -83,7 +83,7 @@ impl BackendFormat {
     }
 
     #[cfg(feature = "metal")]
-    #[deprecated(since = "0.0.0", note = "use gpu::backend_formats::make_mtl()")]
+    #[deprecated(since = "0.74.0", note = "use gpu::backend_formats::make_mtl()")]
     pub fn new_metal(format: mtl::PixelFormat) -> Self {
         super::backend_formats::make_mtl(format)
     }
@@ -249,7 +249,7 @@ impl BackendTexture {
 
     #[cfg(feature = "metal")]
     #[allow(clippy::missing_safety_doc)]
-    #[deprecated(since = "0.0.0", note = "use gpu::backend_textures::make_mtl()")]
+    #[deprecated(since = "0.74.0", note = "use gpu::backend_textures::make_mtl()")]
     pub unsafe fn new_metal(
         (width, height): (i32, i32),
         mipmapped: super::Mipmapped,
@@ -260,7 +260,7 @@ impl BackendTexture {
 
     #[cfg(feature = "metal")]
     #[allow(clippy::missing_safety_doc)]
-    #[deprecated(since = "0.0.0", note = "use gpu::backend_textures::make_mtl()")]
+    #[deprecated(since = "0.74.0", note = "use gpu::backend_textures::make_mtl()")]
     pub unsafe fn new_metal_with_label(
         (width, height): (i32, i32),
         mipmapped: super::Mipmapped,
@@ -473,7 +473,7 @@ impl BackendRenderTarget {
     }
 
     #[cfg(feature = "metal")]
-    #[deprecated(since = "0.0.0", note = "use gpu::backend_render_targets::make_mtl()")]
+    #[deprecated(since = "0.74.0", note = "use gpu::backend_render_targets::make_mtl()")]
     pub fn new_metal((width, height): (i32, i32), mtl_info: &mtl::TextureInfo) -> Self {
         super::backend_render_targets::make_mtl((width, height), mtl_info)
     }

--- a/skia-safe/src/gpu/backend_surface.rs
+++ b/skia-safe/src/gpu/backend_surface.rs
@@ -83,9 +83,9 @@ impl BackendFormat {
     }
 
     #[cfg(feature = "metal")]
+    #[deprecated(since = "0.0.0", note = "use gpu::backend_formats::make_mtl()")]
     pub fn new_metal(format: mtl::PixelFormat) -> Self {
-        Self::construct(|bf| unsafe { sb::C_GrBackendFormat_ConstructMtl(bf, format) })
-            .assert_valid()
+        super::backend_formats::make_mtl(format)
     }
 
     #[cfg(feature = "d3d")]
@@ -124,9 +124,7 @@ impl BackendFormat {
 
     #[cfg(feature = "metal")]
     pub fn as_mtl_format(&self) -> Option<mtl::PixelFormat> {
-        let pixel_format = unsafe { sb::C_GrBackendFormats_AsMtlFormat(self.native()) };
-        // Mtl's PixelFormat == 0 is invalid.
-        (pixel_format != 0).if_true_some(pixel_format)
+        super::backend_formats::as_mtl_format(self)
     }
 
     #[cfg(feature = "d3d")]
@@ -251,32 +249,25 @@ impl BackendTexture {
 
     #[cfg(feature = "metal")]
     #[allow(clippy::missing_safety_doc)]
+    #[deprecated(since = "0.0.0", note = "use gpu::backend_textures::make_mtl()")]
     pub unsafe fn new_metal(
         (width, height): (i32, i32),
         mipmapped: super::Mipmapped,
         mtl_info: &mtl::TextureInfo,
     ) -> Self {
-        Self::new_metal_with_label((width, height), mipmapped, mtl_info, "")
+        super::backend_textures::make_mtl((width, height), mipmapped, mtl_info, "")
     }
 
     #[cfg(feature = "metal")]
     #[allow(clippy::missing_safety_doc)]
+    #[deprecated(since = "0.0.0", note = "use gpu::backend_textures::make_mtl()")]
     pub unsafe fn new_metal_with_label(
         (width, height): (i32, i32),
         mipmapped: super::Mipmapped,
         mtl_info: &mtl::TextureInfo,
         label: impl AsRef<str>,
     ) -> Self {
-        let label = label.as_ref().as_bytes();
-        Self::from_native_if_valid(sb::C_GrBackendTexture_newMtl(
-            width,
-            height,
-            mipmapped,
-            mtl_info.native(),
-            label.as_ptr() as _,
-            label.len(),
-        ))
-        .unwrap()
+        super::backend_textures::make_mtl((width, height), mipmapped, mtl_info, label)
     }
 
     #[cfg(feature = "d3d")]
@@ -369,11 +360,7 @@ impl BackendTexture {
 
     #[cfg(feature = "metal")]
     pub fn metal_texture_info(&self) -> Option<mtl::TextureInfo> {
-        unsafe {
-            let mut texture_info = mtl::TextureInfo::default();
-            sb::C_GrBackendTextures_GetMtlTextureInfo(self.native(), texture_info.native_mut())
-                .if_true_some(texture_info)
-        }
+        super::backend_textures::get_mtl_texture_info(self)
     }
 
     #[cfg(feature = "d3d")]
@@ -486,10 +473,9 @@ impl BackendRenderTarget {
     }
 
     #[cfg(feature = "metal")]
+    #[deprecated(since = "0.0.0", note = "use gpu::backend_render_targets::make_mtl()")]
     pub fn new_metal((width, height): (i32, i32), mtl_info: &mtl::TextureInfo) -> Self {
-        Self::construct(|target| unsafe {
-            sb::C_GrBackendRenderTargets_ConstructMtl(target, width, height, mtl_info.native())
-        })
+        super::backend_render_targets::make_mtl((width, height), mtl_info)
     }
 
     #[cfg(feature = "d3d")]
@@ -554,9 +540,7 @@ impl BackendRenderTarget {
 
     #[cfg(feature = "metal")]
     pub fn metal_texture_info(&self) -> Option<mtl::TextureInfo> {
-        let mut info = mtl::TextureInfo::default();
-        unsafe { sb::C_GrBackendRenderTargets_GetMtlTextureInfo(self.native(), info.native_mut()) }
-            .if_true_some(info)
+        super::backend_render_targets::get_mtl_texture_info(self)
     }
 
     #[cfg(feature = "d3d")]

--- a/skia-safe/src/gpu/direct_context.rs
+++ b/skia-safe/src/gpu/direct_context.rs
@@ -84,7 +84,7 @@ impl fmt::Debug for DirectContext {
 impl DirectContext {
     // Removed from Skia
     #[cfg(feature = "gl")]
-    #[deprecated(since = "0.0.0", note = "use gpu::direct_contexts::make_gl()")]
+    #[deprecated(since = "0.74.0", note = "use gpu::direct_contexts::make_gl()")]
     pub fn new_gl<'a>(
         interface: impl Into<gl::Interface>,
         options: impl Into<Option<&'a ContextOptions>>,
@@ -94,7 +94,7 @@ impl DirectContext {
 
     // Removed from Skia
     #[cfg(feature = "vulkan")]
-    #[deprecated(since = "0.0.0", note = "use gpu::direct_contexts::make_vulkan()")]
+    #[deprecated(since = "0.74.0", note = "use gpu::direct_contexts::make_vulkan()")]
     pub fn new_vulkan<'a>(
         backend_context: &vk::BackendContext,
         options: impl Into<Option<&'a ContextOptions>>,
@@ -103,7 +103,7 @@ impl DirectContext {
     }
 
     #[cfg(feature = "metal")]
-    #[deprecated(since = "0.0.0", note = "use gpu::direct_contexts::make_metal()")]
+    #[deprecated(since = "0.74.0", note = "use gpu::direct_contexts::make_metal()")]
     pub fn new_metal<'a>(
         backend_context: &crate::gpu::mtl::BackendContext,
         options: impl Into<Option<&'a ContextOptions>>,

--- a/skia-safe/src/gpu/direct_context.rs
+++ b/skia-safe/src/gpu/direct_context.rs
@@ -82,8 +82,9 @@ impl fmt::Debug for DirectContext {
 }
 
 impl DirectContext {
-    // Deprecated in Skia
+    // Removed from Skia
     #[cfg(feature = "gl")]
+    #[deprecated(since = "0.0.0", note = "use gpu::direct_contexts::make_gl()")]
     pub fn new_gl<'a>(
         interface: impl Into<gl::Interface>,
         options: impl Into<Option<&'a ContextOptions>>,
@@ -91,8 +92,9 @@ impl DirectContext {
         crate::gpu::direct_contexts::make_gl(interface, options)
     }
 
-    // Deprecated in Skia
+    // Removed from Skia
     #[cfg(feature = "vulkan")]
+    #[deprecated(since = "0.0.0", note = "use gpu::direct_contexts::make_vulkan()")]
     pub fn new_vulkan<'a>(
         backend_context: &vk::BackendContext,
         options: impl Into<Option<&'a ContextOptions>>,
@@ -101,6 +103,7 @@ impl DirectContext {
     }
 
     #[cfg(feature = "metal")]
+    #[deprecated(since = "0.0.0", note = "use gpu::direct_contexts::make_metal()")]
     pub fn new_metal<'a>(
         backend_context: &crate::gpu::mtl::BackendContext,
         options: impl Into<Option<&'a ContextOptions>>,

--- a/skia-safe/src/gpu/ganesh/mtl.rs
+++ b/skia-safe/src/gpu/ganesh/mtl.rs
@@ -1,11 +1,9 @@
 mod backend_context;
 mod backend_surface;
 mod direct_context;
-mod surface_metal;
+pub(crate) mod surface_metal;
 pub(crate) mod types;
 
 pub use backend_context::*;
 pub use backend_surface::*;
 pub use direct_context::*;
-pub use surface_metal::*;
-pub use types::*;

--- a/skia-safe/src/gpu/ganesh/mtl.rs
+++ b/skia-safe/src/gpu/ganesh/mtl.rs
@@ -1,9 +1,11 @@
 mod backend_context;
+mod backend_surface;
 mod direct_context;
 mod surface_metal;
 pub(crate) mod types;
 
 pub use backend_context::*;
+pub use backend_surface::*;
 pub use direct_context::*;
 pub use surface_metal::*;
 pub use types::*;

--- a/skia-safe/src/gpu/ganesh/mtl/backend_context.rs
+++ b/skia-safe/src/gpu/ganesh/mtl/backend_context.rs
@@ -29,9 +29,7 @@ impl BackendContext {
     ///
     /// This function retains all the non-`null` handles passed to it and releases them as soon the
     /// [BackendContext] is dropped.
-    pub unsafe fn new(device: Handle, queue: Handle, binary_archive: Handle) -> Self {
-        BackendContext::construct(|bc| {
-            sb::C_GrMtlBackendContext_Construct(bc, device, queue, binary_archive)
-        })
+    pub unsafe fn new(device: Handle, queue: Handle) -> Self {
+        BackendContext::construct(|bc| sb::C_GrMtlBackendContext_Construct(bc, device, queue))
     }
 }

--- a/skia-safe/src/gpu/ganesh/mtl/backend_surface.rs
+++ b/skia-safe/src/gpu/ganesh/mtl/backend_surface.rs
@@ -1,0 +1,84 @@
+pub mod backend_formats {
+    use skia_bindings as sb;
+
+    use crate::{
+        gpu::{mtl, BackendFormat},
+        prelude::*,
+    };
+
+    pub fn make_mtl(format: mtl::PixelFormat) -> BackendFormat {
+        BackendFormat::construct(|bf| unsafe { sb::C_GrBackendFormats_ConstructMtl(bf, format) })
+            .assert_valid()
+    }
+
+    pub fn as_mtl_format(backend_format: &BackendFormat) -> Option<mtl::PixelFormat> {
+        let pixel_format = unsafe { sb::C_GrBackendFormats_AsMtlFormat(backend_format.native()) };
+        // Mtl's PixelFormat == 0 is invalid.
+        (pixel_format != 0).if_true_some(pixel_format)
+    }
+}
+
+pub mod backend_textures {
+    use skia_bindings as sb;
+
+    use crate::{
+        gpu::{self, mtl, BackendTexture},
+        prelude::*,
+    };
+
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe fn make_mtl(
+        (width, height): (i32, i32),
+        mipmapped: gpu::Mipmapped,
+        mtl_info: &mtl::TextureInfo,
+        label: impl AsRef<str>,
+    ) -> BackendTexture {
+        let label = label.as_ref().as_bytes();
+        BackendTexture::from_native_if_valid(sb::C_GrBackendTextures_newMtl(
+            width,
+            height,
+            mipmapped,
+            mtl_info.native(),
+            label.as_ptr() as _,
+            label.len(),
+        ))
+        .unwrap()
+    }
+
+    pub fn get_mtl_texture_info(texture: &BackendTexture) -> Option<mtl::TextureInfo> {
+        unsafe {
+            let mut texture_info = mtl::TextureInfo::default();
+            sb::C_GrBackendTextures_GetMtlTextureInfo(texture.native(), texture_info.native_mut())
+                .if_true_some(texture_info)
+        }
+    }
+}
+
+pub mod backend_render_targets {
+    use skia_bindings as sb;
+
+    use crate::{
+        gpu::{mtl, BackendRenderTarget},
+        prelude::*,
+    };
+
+    pub fn make_mtl(
+        (width, height): (i32, i32),
+        mtl_info: &mtl::TextureInfo,
+    ) -> BackendRenderTarget {
+        BackendRenderTarget::construct(|target| unsafe {
+            sb::C_GrBackendRenderTargets_ConstructMtl(target, width, height, mtl_info.native())
+        })
+    }
+
+    pub fn get_mtl_texture_info(render_target: &BackendRenderTarget) -> Option<mtl::TextureInfo> {
+        let mut info = mtl::TextureInfo::default();
+        unsafe {
+            sb::C_GrBackendRenderTargets_GetMtlTextureInfo(
+                render_target.native(),
+                info.native_mut(),
+            )
+        }
+        .if_true_some(info)
+    }
+}

--- a/skia-safe/src/gpu/ganesh/mtl/direct_context.rs
+++ b/skia-safe/src/gpu/ganesh/mtl/direct_context.rs
@@ -3,12 +3,17 @@ pub mod direct_contexts {
     use skia_bindings as sb;
 
     use crate::{
-        gpu::{ContextOptions, DirectContext},
+        gpu::{mtl, ContextOptions, DirectContext},
         prelude::*,
     };
 
+    /// Makes a [`DirectContext`] which uses Metal as the backend. The [`mtl::BackendContext`] contains a
+    /// MTLDevice and MTLCommandQueue which should be used by the backend. These objects must
+    /// have their own ref which will be released when the [`mtl::BackendContext`] is destroyed.
+    /// Ganesh will take its own ref on the objects which will be released when the [`DirectContext`]
+    /// is destroyed.
     pub fn make_metal<'a>(
-        backend: &crate::gpu::mtl::BackendContext,
+        backend: &mtl::BackendContext,
         options: impl Into<Option<&'a ContextOptions>>,
     ) -> Option<DirectContext> {
         DirectContext::from_ptr(unsafe {

--- a/skia-safe/src/gpu/mtl.rs
+++ b/skia-safe/src/gpu/mtl.rs
@@ -1,5 +1,0 @@
-mod backend_context;
-pub use backend_context::*;
-
-mod types;
-pub use types::*;

--- a/skia-safe/src/gpu/mtl/backend_context.rs
+++ b/skia-safe/src/gpu/mtl/backend_context.rs
@@ -1,1 +1,2 @@
+// This file has been completely removed from Skia in m125.
 pub use crate::gpu::ganesh::mtl::BackendContext;

--- a/skia-safe/src/gpu/mtl/backend_context.rs
+++ b/skia-safe/src/gpu/mtl/backend_context.rs
@@ -1,2 +1,0 @@
-// This file has been completely removed from Skia in m125.
-pub use crate::gpu::ganesh::mtl::BackendContext;

--- a/skia-safe/src/gpu/mtl/types.rs
+++ b/skia-safe/src/gpu/mtl/types.rs
@@ -1,1 +1,2 @@
+// This file has been completely removed from Skia in m125.
 pub use crate::gpu::ganesh::mtl::types::*;

--- a/skia-safe/src/gpu/mtl/types.rs
+++ b/skia-safe/src/gpu/mtl/types.rs
@@ -1,2 +1,0 @@
-// This file has been completely removed from Skia in m125.
-pub use crate::gpu::ganesh::mtl::types::*;

--- a/skia-safe/src/gpu/vk.rs
+++ b/skia-safe/src/gpu/vk.rs
@@ -18,6 +18,8 @@ pub use sb::VkBool32 as Bool32;
 pub use sb::VkBuffer as Buffer;
 pub use sb::VkChromaLocation as ChromaLocation;
 pub use sb::VkCommandBuffer as CommandBuffer;
+pub use sb::VkComponentMapping as ComponentMapping;
+pub use sb::VkComponentSwizzle as ComponentSwizzle;
 pub use sb::VkDevice as Device;
 pub use sb::VkDeviceMemory as DeviceMemory;
 pub use sb::VkDeviceSize as DeviceSize;

--- a/skia-safe/src/gpu/vk/types.rs
+++ b/skia-safe/src/gpu/vk/types.rs
@@ -84,6 +84,7 @@ pub struct YcbcrConversionInfo {
     pub chroma_filter: vk::Filter,
     pub force_explicit_reconstruction: vk::Bool32,
     pub format_features: vk::FormatFeatureFlags,
+    pub components: vk::ComponentMapping,
 }
 
 native_transmutable!(
@@ -110,6 +111,12 @@ impl Default for YcbcrConversionInfo {
             chroma_filter: vk::Filter::NEAREST,
             force_explicit_reconstruction: 0,
             format_features: 0,
+            components: vk::ComponentMapping {
+                r: vk::ComponentSwizzle::VK_COMPONENT_SWIZZLE_IDENTITY,
+                g: vk::ComponentSwizzle::VK_COMPONENT_SWIZZLE_IDENTITY,
+                b: vk::ComponentSwizzle::VK_COMPONENT_SWIZZLE_IDENTITY,
+                a: vk::ComponentSwizzle::VK_COMPONENT_SWIZZLE_IDENTITY,
+            },
         }
     }
 }
@@ -139,6 +146,7 @@ impl YcbcrConversionInfo {
             chroma_filter,
             force_explicit_reconstruction,
             format_features,
+            ..YcbcrConversionInfo::default()
         }
     }
 

--- a/skia-safe/src/modules.rs
+++ b/skia-safe/src/modules.rs
@@ -15,6 +15,7 @@ pub mod textlayout {
 
 #[cfg(feature = "textlayout")]
 pub mod shapers {
+    // Re-exports `shapers::primitive`.
     pub use crate::shaper::shapers::*;
 
     pub mod ct {
@@ -23,5 +24,9 @@ pub mod shapers {
 
     pub mod hb {
         pub use crate::shaper::harfbuzz::*;
+    }
+
+    pub mod unicode {
+        pub use crate::shaper::unicode::*;
     }
 }

--- a/skia-safe/src/modules/paragraph/paragraph_builder.rs
+++ b/skia-safe/src/modules/paragraph/paragraph_builder.rs
@@ -75,7 +75,7 @@ impl ParagraphBuilder {
             .unwrap()
     }
 
-    // TODO: Wrap SetWords*, SetGraphemeBreaks*, setLineBreaks*, setUnicode.
+    // TODO: Wrap SetWords*, SetGraphemeBreaks*, setLineBreaks*, getClientICUData, setUnicode.
 
     pub fn reset(&mut self) {
         unsafe { sb::C_ParagraphBuilder_Reset(self.native_mut()) }

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -13,9 +13,10 @@ use skia_bindings::{
 
 use crate::{prelude::*, scalar, Font, FontMgr, FourByteTag, Point, TextBlob};
 
-pub mod core_text;
-pub mod harfbuzz;
-pub mod unicode;
+// The following three are re-exported in `modules.rs` via `mod shapers {}`.
+pub(crate) mod core_text;
+pub(crate) mod harfbuzz;
+pub(crate) mod unicode;
 
 pub use run_handler::RunHandler;
 
@@ -737,7 +738,7 @@ impl Shaper {
     }
 }
 
-pub mod shapers {
+pub(crate) mod shapers {
     use super::{BiDiRunIterator, ScriptRunIterator, Shaper};
 
     #[deprecated(since = "0.74.0", note = "use shapers::primitive::primitive_text()")]

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -62,15 +62,6 @@ impl Shaper {
         })
     }
 
-    pub fn new_shape_dont_wrap_or_reorder(font_mgr: impl Into<Option<FontMgr>>) -> Option<Self> {
-        #[cfg(feature = "embed-icudtl")]
-        crate::icu::init();
-
-        Self::from_ptr(unsafe {
-            sb::C_SkShaper_MakeShapeDontWrapOrReorder(font_mgr.into().into_ptr_or_null())
-        })
-    }
-
     pub fn purge_harf_buzz_cache() {
         unsafe { sb::SkShaper_PurgeHarfBuzzCache() }
     }

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -15,6 +15,7 @@ use crate::{prelude::*, scalar, Font, FontMgr, FourByteTag, Point, TextBlob};
 
 pub mod core_text;
 pub mod harfbuzz;
+pub mod unicode;
 
 pub use run_handler::RunHandler;
 
@@ -40,26 +41,29 @@ impl fmt::Debug for Shaper {
 }
 
 impl Shaper {
+    #[deprecated(since = "0.0.0", note = "use shapers::primitive::primitive_text()")]
     pub fn new_primitive() -> Self {
-        shapers::primitive()
+        crate::shapers::primitive::primitive_text()
     }
 
-    pub fn new_shaper_driven_wrapper(font_mgr: impl Into<Option<FontMgr>>) -> Option<Self> {
-        #[cfg(feature = "embed-icudtl")]
-        crate::icu::init();
-
-        Self::from_ptr(unsafe {
-            sb::C_SkShaper_MakeShaperDrivenWrapper(font_mgr.into().into_ptr_or_null())
-        })
+    pub fn new_shaper_driven_wrapper(
+        fallback_font_mgr: impl Into<Option<FontMgr>>,
+    ) -> Option<Self> {
+        crate::shapers::hb::shaper_driven_wrapper(fallback_font_mgr)
     }
 
-    pub fn new_shape_then_wrap(font_mgr: impl Into<Option<FontMgr>>) -> Option<Self> {
-        #[cfg(feature = "embed-icudtl")]
-        crate::icu::init();
+    pub fn new_shape_then_wrap(fallback_font_mgr: impl Into<Option<FontMgr>>) -> Option<Self> {
+        crate::shapers::hb::shape_then_wrap(fallback_font_mgr)
+    }
 
-        Self::from_ptr(unsafe {
-            sb::C_SkShaper_MakeShapeThenWrap(font_mgr.into().into_ptr_or_null())
-        })
+    #[deprecated(
+        since = "0.0.0",
+        note = "use shapers::hb::shape_dont_wrap_or_reorder()"
+    )]
+    pub fn new_shape_dont_wrap_or_reorder(
+        fallback_font_mgr: impl Into<Option<FontMgr>>,
+    ) -> Option<Self> {
+        crate::shapers::hb::shape_dont_wrap_or_reorder(fallback_font_mgr)
     }
 
     pub fn purge_harf_buzz_cache() {
@@ -208,11 +212,12 @@ impl Shaper {
         .map(|i| i.borrows(utf8))
     }
 
+    #[deprecated(
+        since = "0.0.0",
+        note = "use shapers::primitive::trivial_bidi_run_iterator()"
+    )]
     pub fn new_trivial_bidi_run_iterator(bidi_level: u8, utf8_bytes: usize) -> BiDiRunIterator {
-        BiDiRunIterator::from_ptr(unsafe {
-            sb::C_SkShaper_TrivialBidiRunIterator_new(bidi_level, utf8_bytes)
-        })
-        .unwrap()
+        shapers::primitive::trivial_bidi_run_iterator(bidi_level, utf8_bytes)
     }
 }
 
@@ -267,11 +272,12 @@ impl Shaper {
         .borrows(utf8)
     }
 
+    #[deprecated(
+        since = "0.0.0",
+        note = "use shapers::primitive::trivial_script_run_iterator"
+    )]
     pub fn new_trivial_script_run_iterator(bidi_level: u8, utf8_bytes: usize) -> ScriptRunIterator {
-        ScriptRunIterator::from_ptr(unsafe {
-            sb::C_SkShaper_TrivialScriptRunIterator_new(bidi_level, utf8_bytes)
-        })
-        .unwrap()
+        shapers::primitive::trivial_script_run_iterator(bidi_level, utf8_bytes)
     }
 }
 
@@ -732,20 +738,51 @@ impl Shaper {
 }
 
 pub mod shapers {
-    use skia_bindings as sb;
-
     use super::{BiDiRunIterator, ScriptRunIterator, Shaper};
 
+    #[deprecated(since = "0.0.0", note = "use shapers::primitive::primitive_text()")]
     pub fn primitive() -> Shaper {
-        Shaper::from_ptr(unsafe { sb::C_SkShaper_MakePrimitive() }).unwrap()
+        primitive::primitive_text()
     }
 
+    #[deprecated(
+        since = "0.0.0",
+        note = "use shapers::primitive::trivial_bidi_run_iterator()"
+    )]
     pub fn trivial_bidi_run_iterator(bidi_level: u8, utf8_bytes: usize) -> BiDiRunIterator {
-        Shaper::new_trivial_bidi_run_iterator(bidi_level, utf8_bytes)
+        primitive::trivial_bidi_run_iterator(bidi_level, utf8_bytes)
     }
 
+    #[deprecated(
+        since = "0.0.0",
+        note = "use shapers::primitive::trivial_script_run_iterator()"
+    )]
     pub fn trivial_script_run_iterator(bidi_level: u8, utf8_bytes: usize) -> ScriptRunIterator {
-        Shaper::new_trivial_script_run_iterator(bidi_level, utf8_bytes)
+        primitive::trivial_script_run_iterator(bidi_level, utf8_bytes)
+    }
+
+    pub mod primitive {
+        use skia_bindings as sb;
+
+        use crate::shaper::{BiDiRunIterator, ScriptRunIterator, Shaper};
+
+        pub fn primitive_text() -> Shaper {
+            Shaper::from_ptr(unsafe { sb::C_SkShapers_Primitive_PrimitiveText() }).unwrap()
+        }
+
+        pub fn trivial_bidi_run_iterator(bidi_level: u8, utf8_bytes: usize) -> BiDiRunIterator {
+            BiDiRunIterator::from_ptr(unsafe {
+                sb::C_SkShapers_Primitive_TrivialBidiRunIterator_new(bidi_level, utf8_bytes)
+            })
+            .unwrap()
+        }
+
+        pub fn trivial_script_run_iterator(bidi_level: u8, utf8_bytes: usize) -> ScriptRunIterator {
+            ScriptRunIterator::from_ptr(unsafe {
+                sb::C_SkShapers_Primitive_TrivialScriptRunIterator_new(bidi_level, utf8_bytes)
+            })
+            .unwrap()
+        }
     }
 }
 

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -41,7 +41,7 @@ impl fmt::Debug for Shaper {
 }
 
 impl Shaper {
-    #[deprecated(since = "0.0.0", note = "use shapers::primitive::primitive_text()")]
+    #[deprecated(since = "0.74.0", note = "use shapers::primitive::primitive_text()")]
     pub fn new_primitive() -> Self {
         crate::shapers::primitive::primitive_text()
     }
@@ -57,7 +57,7 @@ impl Shaper {
     }
 
     #[deprecated(
-        since = "0.0.0",
+        since = "0.74.0",
         note = "use shapers::hb::shape_dont_wrap_or_reorder()"
     )]
     pub fn new_shape_dont_wrap_or_reorder(
@@ -213,7 +213,7 @@ impl Shaper {
     }
 
     #[deprecated(
-        since = "0.0.0",
+        since = "0.74.0",
         note = "use shapers::primitive::trivial_bidi_run_iterator()"
     )]
     pub fn new_trivial_bidi_run_iterator(bidi_level: u8, utf8_bytes: usize) -> BiDiRunIterator {
@@ -273,7 +273,7 @@ impl Shaper {
     }
 
     #[deprecated(
-        since = "0.0.0",
+        since = "0.74.0",
         note = "use shapers::primitive::trivial_script_run_iterator"
     )]
     pub fn new_trivial_script_run_iterator(bidi_level: u8, utf8_bytes: usize) -> ScriptRunIterator {
@@ -740,13 +740,13 @@ impl Shaper {
 pub mod shapers {
     use super::{BiDiRunIterator, ScriptRunIterator, Shaper};
 
-    #[deprecated(since = "0.0.0", note = "use shapers::primitive::primitive_text()")]
+    #[deprecated(since = "0.74.0", note = "use shapers::primitive::primitive_text()")]
     pub fn primitive() -> Shaper {
         primitive::primitive_text()
     }
 
     #[deprecated(
-        since = "0.0.0",
+        since = "0.74.0",
         note = "use shapers::primitive::trivial_bidi_run_iterator()"
     )]
     pub fn trivial_bidi_run_iterator(bidi_level: u8, utf8_bytes: usize) -> BiDiRunIterator {
@@ -754,7 +754,7 @@ pub mod shapers {
     }
 
     #[deprecated(
-        since = "0.0.0",
+        since = "0.74.0",
         note = "use shapers::primitive::trivial_script_run_iterator()"
     )]
     pub fn trivial_script_run_iterator(bidi_level: u8, utf8_bytes: usize) -> ScriptRunIterator {

--- a/skia-safe/src/modules/shaper/harfbuzz.rs
+++ b/skia-safe/src/modules/shaper/harfbuzz.rs
@@ -1,5 +1,34 @@
+use skia_bindings as sb;
+
 use super::ScriptRunIterator;
-use crate::{Borrows, FourByteTag, Shaper};
+use crate::{prelude::*, Borrows, FontMgr, FourByteTag, Shaper};
+
+pub fn shaper_driven_wrapper(fallback_font_mgr: impl Into<Option<FontMgr>>) -> Option<Shaper> {
+    #[cfg(feature = "embed-icudtl")]
+    crate::icu::init();
+
+    Shaper::from_ptr(unsafe {
+        sb::C_SkShapers_HB_ShaperDrivenWrapper(fallback_font_mgr.into().into_ptr_or_null())
+    })
+}
+
+pub fn shape_then_wrap(fallback_font_mgr: impl Into<Option<FontMgr>>) -> Option<Shaper> {
+    #[cfg(feature = "embed-icudtl")]
+    crate::icu::init();
+
+    Shaper::from_ptr(unsafe {
+        sb::C_SkShapers_HB_ShapeThenWrap(fallback_font_mgr.into().into_ptr_or_null())
+    })
+}
+
+pub fn shape_dont_wrap_or_reorder(fallback_font_mgr: impl Into<Option<FontMgr>>) -> Option<Shaper> {
+    #[cfg(feature = "embed-icudtl")]
+    crate::icu::init();
+
+    Shaper::from_ptr(unsafe {
+        sb::C_SkShapers_HB_ShapeDontWrapOrReorder(fallback_font_mgr.into().into_ptr_or_null())
+    })
+}
 
 pub fn script_run_iterator(
     utf8: &str,

--- a/skia-safe/src/modules/shaper/unicode.rs
+++ b/skia-safe/src/modules/shaper/unicode.rs
@@ -1,0 +1,12 @@
+use skia_bindings as sb;
+
+use super::BiDiRunIterator;
+use crate::prelude::*;
+
+pub fn bidi_run_iterator(utf8: &str, bidi_level: u8) -> Option<Borrows<BiDiRunIterator>> {
+    let bytes = utf8.as_bytes();
+    BiDiRunIterator::from_ptr(unsafe {
+        sb::C_SkShapers_unicode_BidiRunIterator(bytes.as_ptr() as _, bytes.len(), bidi_level)
+    })
+    .map(|i| i.borrows(utf8))
+}

--- a/skia-safe/tests/shaper.rs
+++ b/skia-safe/tests/shaper.rs
@@ -47,13 +47,11 @@ impl RunHandler for DebugRunHandler {
 #[cfg(test)]
 mod tests {
     use crate::DebugRunHandler;
-    use skia_safe::{Font, Shaper};
+    use skia_safe::{shapers, Font, Shaper};
 
     #[test]
     #[serial_test::serial]
     fn test_rtl_text_shaping() {
-        skia_bindings::icu::init();
-
         let shaper = Shaper::new(None);
         shaper.shape(
             "العربية",
@@ -62,5 +60,11 @@ mod tests {
             10000.0,
             &mut DebugRunHandler::default(),
         );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_skunicode_parameterized_shaper() {
+        shapers::hb::shape_dont_wrap_or_reorder(None).expect("Shaper");
     }
 }

--- a/skia-safe/tests/shaper.rs
+++ b/skia-safe/tests/shaper.rs
@@ -63,12 +63,4 @@ mod tests {
             &mut DebugRunHandler::default(),
         );
     }
-
-    #[test]
-    #[serial_test::serial]
-    fn test_skunicode_parameterized_shaper() {
-        skia_bindings::icu::init();
-
-        Shaper::new_shape_dont_wrap_or_reorder(None).expect("Shaper");
-    }
 }


### PR DESCRIPTION
This PR updates rust-skia to support Skia's `chrome/m125` branch.

- [x] Update `README.md` ([rendered](https://github.com/pragmatrix/rust-skia/blob/m125/README.md))  
  > Most important here is to change the Skia branch name and the current Skia submodule tag at the top of the `README.md` file.
- [x] Diff the the following files to see if the build organization has changed significantly:
  - [x] `/BUILD.gn`
  - [x] `/gn/*` (recursively)
  - [x] `/modules/skshaper/BUILD.gn`
  - [x] `/modules/skshaper/skshaper.gni`
  - [x] `/modules/paragraph/BUILD.gn`
  - [x] `/modules/paragraph/skparagraph.gni`
- [x] Skia builds ([release notes](https://github.com/google/skia/blob/chrome/m125/RELEASE_NOTES.md)).
- [x] `/skia-bindings` builds.
- [x] `/skia-safe`: Update & add new wrappers by diffing include files.  
  > Add TODOs for everything that can not be updated right now, and attempt to stay compatible with previous versions of skia-safe without trying too hard before version 1.0. Use `deprecated` attributes if needed.
  - [x] `codec/`
  - [x] `core/`
  - [x] `docs/`
  - [x] `effects/`
  - [x] `encode/`
  - [x] `gpu/`
    - [x] `d3d/`
    - [x] `ganesh/`
    - [x] `gl/`
    - [x] `mtl/`
    - [x] `vk/`
  - [x] `pathops/`
  - [x] `svg/`
  - [x] `utils/`
  - [x] `modules/`
    - [x] `paragraph/`
    - [x] `shaper/`
  - [x] `private/base/*`
    - [x] `SkPoint_impl.h`
- [x] Review `Send` & `Sync` implementations for new wrappers.
- [x] Review `Debug` implementation for new wrapper types and functions.
- [x] Release date of the matching Chrome version in less than 7 days?
- [x] Any pending changes in the Skia `chrome/m125` branch that aren't synchronized yet?
- [x] Rebase on or merge with master.
- [x] Do the `rust-skia:` commits in the `skia-bindings/skia` subdirectory match with `master` (`make diff-skia`).
- [x] Update versions of `skia-bindings/Cargo.toml` and `skia-safe/Cargo.toml` and also add the version to the new `deprecated` attributes.
- [x] Do the tags/hashes in `skia-bindings/Cargo.toml` under `[package.metadata]` match the submodules `depot_tools` and `skia`?
- [x] Check for API changes: `make diff-api`.
- [ ] Test builds we don't do on the CI:
  - [ ] Compiles to Catalyst targets on macOS (#548).
    ```zsh
    make macos-qa
    ```
- [x] Do one final review of all the changes.
- [x] Run `make doc` and fix all warnings.

