### PR TITLE
Add 'freetype-woff2' features to support woff2

### DIFF
--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -54,6 +54,7 @@ shaper = ["textlayout"]
 binary-cache = ["flate2", "tar"]
 embed-icudtl = ["lazy_static"]
 embed-freetype = []
+freetype-woff2 = []
 
 [dependencies]
 mozjpeg-sys = { version = "2", features = ["with_simd"], optional = true }

--- a/skia-bindings/build_support/features.rs
+++ b/skia-bindings/build_support/features.rs
@@ -46,6 +46,9 @@ pub struct Features {
 
     /// Build the particles module (unsupported, no wrappers).
     pub particles: bool,
+
+    /// Build with FreeType WOFF2 support.
+    pub freetype_woff2: bool,
 }
 
 impl Default for Features {
@@ -67,6 +70,7 @@ impl Default for Features {
             animation: false,
             dng: false,
             particles: false,
+            freetype_woff2: cfg!(feature = "freetype-woff2"),
         }
     }
 }

--- a/skia-bindings/build_support/skia/config.rs
+++ b/skia-bindings/build_support/skia/config.rs
@@ -135,6 +135,7 @@ impl FinalBuildConfiguration {
                 .arg("skia_use_system_zlib", yes_if(use_system_libraries))
                 .arg("skia_use_xps", no())
                 .arg("skia_use_dng_sdk", yes_if(features.dng))
+                .arg("skia_use_freetype_woff2", yes_if(features.freetype_woff2))
                 .arg("cc", quote(&build.cc))
                 .arg("cxx", quote(&build.cxx));
 

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -46,6 +46,7 @@ use-system-jpeg-turbo = ["skia-bindings/use-system-jpeg-turbo"]
 binary-cache = ["skia-bindings/binary-cache"]
 embed-icudtl = ["skia-bindings/embed-icudtl"]
 embed-freetype = ["skia-bindings/embed-freetype"]
+freetype-woff2 = ["skia-bindings/freetype-woff2"]
 
 # implied only, do not use
 gpu = []


### PR DESCRIPTION
Turning on `skia_use_freetype_woff2`, let skia use internal third-party woff2 library.
I could get success after this to make typeface and font.

Previous discussion : https://github.com/rust-skia/rust-skia/discussions/917