### PR TITLE
Attempt to fix Linux CI jobs

### DIFF
--- a/.github/workflows/linux-qa.yaml
+++ b/.github/workflows/linux-qa.yaml
@@ -23,7 +23,7 @@ jobs:
       SKIA_DEBUG: 0
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: taiki-e/checkout-action@v1
       with:
         submodules: true
 
@@ -510,7 +510,7 @@ jobs:
       SKIA_DEBUG: 0
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: taiki-e/checkout-action@v1
       with:
         submodules: true
 

--- a/.github/workflows/linux-release.yaml
+++ b/.github/workflows/linux-release.yaml
@@ -18,7 +18,7 @@ jobs:
       SKIA_DEBUG: 0
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: taiki-e/checkout-action@v1
       with:
         submodules: true
 
@@ -505,7 +505,7 @@ jobs:
       SKIA_DEBUG: 0
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: taiki-e/checkout-action@v1
       with:
         submodules: true
 
@@ -992,7 +992,7 @@ jobs:
       SKIA_DEBUG: 0
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: taiki-e/checkout-action@v1
       with:
         submodules: true
 
@@ -1479,7 +1479,7 @@ jobs:
       SKIA_DEBUG: 0
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: taiki-e/checkout-action@v1
       with:
         submodules: true
 
@@ -1966,7 +1966,7 @@ jobs:
       SKIA_DEBUG: 0
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: taiki-e/checkout-action@v1
       with:
         submodules: true
 
@@ -2453,7 +2453,7 @@ jobs:
       SKIA_DEBUG: 0
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: taiki-e/checkout-action@v1
       with:
         submodules: true
 
@@ -2940,7 +2940,7 @@ jobs:
       SKIA_DEBUG: 0
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: taiki-e/checkout-action@v1
       with:
         submodules: true
 
@@ -3427,7 +3427,7 @@ jobs:
       SKIA_DEBUG: 0
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: taiki-e/checkout-action@v1
       with:
         submodules: true
 
@@ -3914,7 +3914,7 @@ jobs:
       SKIA_DEBUG: 0
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: taiki-e/checkout-action@v1
       with:
         submodules: true
 
@@ -4401,7 +4401,7 @@ jobs:
       SKIA_DEBUG: 0
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: taiki-e/checkout-action@v1
       with:
         submodules: true
 
@@ -4888,7 +4888,7 @@ jobs:
       SKIA_DEBUG: 0
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: taiki-e/checkout-action@v1
       with:
         submodules: true
 
@@ -5375,7 +5375,7 @@ jobs:
       SKIA_DEBUG: 0
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: taiki-e/checkout-action@v1
       with:
         submodules: true
 

--- a/mk-workflows/src/templates/linux-job.yaml
+++ b/mk-workflows/src/templates/linux-job.yaml
@@ -4,7 +4,7 @@ env:
   SKIA_DEBUG: $[[skiaDebug]]
 
 steps:
-- uses: actions/checkout@v3
+- uses: taiki-e/checkout-action@v1
   with:
     submodules: true
 


### PR DESCRIPTION
This PR attempts to fix the following CI problem (Happening because of https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/):

```
/__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
```

- https://github.com/actions/checkout/issues/1809

What seems to work is to use an alternative checkout action that does not use node.js:

- https://github.com/actions/checkout/issues/1809#issuecomment-2210575518
