### PR TITLE
Milestone 128

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m128 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m128-0.76.0...google:chrome/m128
-[skia-ours]: https://github.com/google/skia/compare/chrome/m128...rust-skia:m128-0.76.0
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m128-0.76.1...google:chrome/m128
+[skia-ours]: https://github.com/google/skia/compare/chrome/m128...rust-skia:m128-0.76.1
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![Windows QA](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml) [![Linux QA](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml) [![macOS QA](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml)
 
-Skia Submodule Status: chrome/m127 ([upstream changes][skia-upstream], [our changes][skia-ours]).
+Skia Submodule Status: chrome/m128 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m127-0.75.0...google:chrome/m127
-[skia-ours]: https://github.com/google/skia/compare/chrome/m127...rust-skia:m127-0.75.0
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m128-0.76.0...google:chrome/m128
+[skia-ours]: https://github.com/google/skia/compare/chrome/m128...rust-skia:m128-0.76.0
 
 ## About
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.76.0"
+version = "0.77.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2021"
 build = "build.rs"

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -30,7 +30,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m127-0.75.0"
+skia = "m128-0.76.0"
 depot_tools = "73a2624"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -30,7 +30,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m128-0.76.0"
+skia = "m128-0.76.1"
 depot_tools = "73a2624"
 
 [features]

--- a/skia-bindings/build_support/skia_bindgen.rs
+++ b/skia-bindings/build_support/skia_bindgen.rs
@@ -301,6 +301,7 @@ const ALLOWLISTED_FUNCTIONS: &[&str] = &[
     "Simplify",
     "TightBounds",
     "AsWinding",
+    "SkYUVColorSpaceIsLimitedRange",
 ];
 
 const OPAQUE_TYPES: &[&str] = &[

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -450,6 +450,10 @@ extern "C" bool C_SkImage_isValid(const SkImage* self, GrRecordingContext* conte
     return self->isValid(context);
 }
 
+extern "C" SkImage* C_SkImage_makeScaled(const SkImage* self, const SkImageInfo* info, const SkSamplingOptions* sampling) {
+    return self->makeScaled(*info, *sampling).release();
+}
+
 extern "C" SkData* C_SkImage_refEncodedData(const SkImage* self) {
     return self->refEncodedData().release();
 }

--- a/skia-bindings/src/impls.rs
+++ b/skia-bindings/src/impls.rs
@@ -5,7 +5,10 @@
 //!
 //! See also: <https://github.com/rust-lang/rfcs/issues/1880>
 
-use crate::{SkAlphaType, SkBlendMode, SkBlendModeCoeff, SkPathFillType, SkPathVerb, SkPath_Verb};
+use crate::{
+    SkAlphaType, SkBlendMode, SkBlendModeCoeff, SkPathFillType, SkPathVerb, SkPath_Verb,
+    SkYUVColorSpace,
+};
 use std::ffi::CStr;
 
 impl SkBlendMode {
@@ -95,6 +98,12 @@ impl SkPathFillType {
 impl SkAlphaType {
     pub fn is_opaque(self) -> bool {
         self == SkAlphaType::Opaque
+    }
+}
+
+impl SkYUVColorSpace {
+    pub fn is_limited_range(self) -> bool {
+        unsafe { crate::SkYUVColorSpaceIsLimitedRange(self) }
     }
 }
 

--- a/skia-bindings/src/vulkan.cpp
+++ b/skia-bindings/src/vulkan.cpp
@@ -9,8 +9,8 @@
 #include "include/gpu/ganesh/vk/GrVkBackendSurface.h"
 #include "include/gpu/ganesh/vk/GrVkDirectContext.h"
 #include "include/gpu/vk/GrVkTypes.h"
-#include "include/gpu/vk/GrVkBackendContext.h"
-#include "include/gpu/vk/GrVkExtensions.h"
+#include "include/gpu/vk/VulkanBackendContext.h"
+#include "include/gpu/vk/VulkanExtensions.h"
 #include "include/gpu/vk/VulkanMutableTextureState.h"
 
 // Additional types not yet referenced.
@@ -20,7 +20,7 @@ extern "C" void C_GrBackendFormat_ConstructVk(GrBackendFormat* uninitialized, Vk
     new(uninitialized)GrBackendFormat(GrBackendFormats::MakeVk(format, willUseDRMFormatModifiers));
 }
 
-extern "C" void C_GrBackendFormat_ConstructVk2(GrBackendFormat* uninitialized, const GrVkYcbcrConversionInfo* ycbcrInfo,  bool willUseDRMFormatModifiers) {
+extern "C" void C_GrBackendFormat_ConstructVk2(GrBackendFormat* uninitialized, const skgpu::VulkanYcbcrConversionInfo* ycbcrInfo,  bool willUseDRMFormatModifiers) {
     new(uninitialized)GrBackendFormat(GrBackendFormats::MakeVk(*ycbcrInfo, willUseDRMFormatModifiers));
 }
 
@@ -45,7 +45,7 @@ extern "C" void C_GPU_VK_Types(VkBuffer *) {}
 typedef PFN_vkVoidFunction (*GetProcFn)(const char* name, VkInstance instance, VkDevice device);
 typedef const void* (*GetProcFnVoidPtr)(const char* name, VkInstance instance, VkDevice device);
 
-extern "C" void *C_GrVkBackendContext_new(
+extern "C" void *C_VulkanBackendContext_new(
     void *instance,
     void *physicalDevice,
     void *device,
@@ -62,9 +62,9 @@ extern "C" void *C_GrVkBackendContext_new(
     auto vkDevice = static_cast<VkDevice>(device);
     auto vkGetProc = *(reinterpret_cast<GetProcFn *>(&getProc));
 
-    auto &extensions = *new GrVkExtensions();
+    auto &extensions = *new skgpu::VulkanExtensions();
     extensions.init(vkGetProc, vkInstance, vkPhysicalDevice, instanceExtensionCount, instanceExtensions, deviceExtensionCount, deviceExtensions);
-    auto &context = *new GrVkBackendContext();
+    auto &context = *new skgpu::VulkanBackendContext();
     context.fInstance = vkInstance;
     context.fPhysicalDevice = vkPhysicalDevice;
     context.fDevice = vkDevice;
@@ -75,31 +75,31 @@ extern "C" void *C_GrVkBackendContext_new(
     return &context;
 }
 
-extern "C" void C_GrVkBackendContext_delete(void* vkBackendContext) {
-    auto bc = static_cast<GrVkBackendContext*>(vkBackendContext);
+extern "C" void C_VulkanBackendContext_delete(void* vkBackendContext) {
+    auto bc = static_cast<skgpu::VulkanBackendContext*>(vkBackendContext);
     if (bc) {
         delete bc->fVkExtensions;
     }
     delete bc;
 }
 
-extern "C" void C_GrVkBackendContext_setProtectedContext(GrVkBackendContext *self, GrProtected protectedContext) {
+extern "C" void C_VulkanBackendContext_setProtectedContext(skgpu::VulkanBackendContext *self, GrProtected protectedContext) {
     self->fProtectedContext = protectedContext;
 }
 
-extern "C" void C_GrVkBackendContext_setMaxAPIVersion(GrVkBackendContext *self, uint32_t maxAPIVersion) {
+extern "C" void C_VulkanBackendContext_setMaxAPIVersion(skgpu::VulkanBackendContext *self, uint32_t maxAPIVersion) {
     self->fMaxAPIVersion = maxAPIVersion;
 }
 
 //
-// GrVkTypes.h
+// VulkanTypes.h
 //
 
-extern "C" bool C_GrVkAlloc_Equals(const GrVkAlloc* lhs, const GrVkAlloc* rhs) {
+extern "C" bool C_VulkanAlloc_Equals(const skgpu::VulkanAlloc* lhs, const skgpu::VulkanAlloc* rhs) {
     return *lhs == *rhs;
 }
 
-extern "C" bool C_GrVkYcbcrConversionInfo_Equals(const GrVkYcbcrConversionInfo* lhs, const GrVkYcbcrConversionInfo* rhs) {
+extern "C" bool C_VulkanYcbcrConversionInfo_Equals(const skgpu::VulkanYcbcrConversionInfo* lhs, const skgpu::VulkanYcbcrConversionInfo* rhs) {
     return *lhs == *rhs;
 }
 
@@ -111,7 +111,7 @@ extern "C" bool C_GrBackendFormats_AsVkFormat(const GrBackendFormat* format, VkF
     return GrBackendFormats::AsVkFormat(*format, vkFormat);
 }
 
-extern "C" const GrVkYcbcrConversionInfo* C_GrBackendFormats_GetVkYcbcrConversionInfo(const GrBackendFormat* format) {
+extern "C" const skgpu::VulkanYcbcrConversionInfo* C_GrBackendFormats_GetVkYcbcrConversionInfo(const GrBackendFormat* format) {
     return GrBackendFormats::GetVkYcbcrConversionInfo(*format);
 }
 
@@ -132,7 +132,7 @@ extern "C" void C_GrBackendRenderTargets_SetVkImageLayout(GrBackendRenderTarget*
 }
 
 extern "C" GrDirectContext* C_GrDirectContexts_MakeVulkan(
-    const GrVkBackendContext* vkBackendContext,
+    const skgpu::VulkanBackendContext* vkBackendContext,
     const GrContextOptions* options) {
     if (options) {
         return GrDirectContexts::MakeVulkan(*vkBackendContext, *options).release();

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -18,7 +18,7 @@ categories = [
 ]
 license = "MIT"
 
-version = "0.76.0"
+version = "0.77.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2021"
 
@@ -55,7 +55,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 [dependencies]
 bitflags = "2.0"
 lazy_static = "1.4"
-skia-bindings = { version = "=0.76.0", path = "../skia-bindings", default-features = false }
+skia-bindings = { version = "=0.77.0", path = "../skia-bindings", default-features = false }
 
 # D3D types & ComPtr
 windows = { version = "0.58.0", features = [

--- a/skia-safe/src/core/image.rs
+++ b/skia-safe/src/core/image.rs
@@ -948,6 +948,23 @@ impl Image {
         unsafe { sb::C_SkImage_isValid(self.native(), context.native_mut()) }
     }
 
+    /// Create a new image by copying this image and scaling to fit the [`ImageInfo`]'s dimensions
+    /// and converting the pixels into the ImageInfo's [`crate::ColorInfo`].
+    ///
+    /// This is done retaining the domain (backend) of the image (e.g. gpu, raster).
+    ///
+    /// Returns `None` if the requested [`crate::ColorInfo`] is not supported, its dimesions are out
+    /// of range.
+    pub fn make_scaled(
+        &self,
+        info: &ImageInfo,
+        scaling: impl Into<SamplingOptions>,
+    ) -> Option<Image> {
+        Image::from_ptr(unsafe {
+            sb::C_SkImage_makeScaled(self.native(), info.native(), scaling.into().native())
+        })
+    }
+
     /// See [`Self::flush_with_info()`]
     #[cfg(feature = "gpu")]
     #[deprecated(since = "0.63.0", note = "use gpu::DirectContext::flush()")]

--- a/skia-safe/src/core/milestone.rs
+++ b/skia-safe/src/core/milestone.rs
@@ -1,1 +1,1 @@
-pub const MILESTONE: usize = 127;
+pub const MILESTONE: usize = 128;

--- a/skia-safe/src/core/rrect.rs
+++ b/skia-safe/src/core/rrect.rs
@@ -202,6 +202,10 @@ impl RRect {
         Vector::from_native_c(self.native().fRadii[corner as usize])
     }
 
+    pub fn radii_ref(&self) -> &[Vector; 4] {
+        Vector::from_native_array_ref(&self.native().fRadii)
+    }
+
     pub fn bounds(&self) -> &Rect {
         self.rect()
     }

--- a/skia-safe/src/gpu/vk/vulkan_backend_context.rs
+++ b/skia-safe/src/gpu/vk/vulkan_backend_context.rs
@@ -21,7 +21,7 @@ pub struct BackendContext<'a> {
 
 impl<'a> Drop for BackendContext<'a> {
     fn drop(&mut self) {
-        unsafe { sb::C_GrVkBackendContext_delete(self.native.as_ptr()) }
+        unsafe { sb::C_VulkanBackendContext_delete(self.native.as_ptr()) }
     }
 }
 
@@ -87,7 +87,7 @@ impl BackendContext<'_> {
             device_extensions.iter().map(|cs| cs.as_ptr()).collect();
 
         let resolver = Self::begin_resolving_proc(get_proc);
-        let native = sb::C_GrVkBackendContext_new(
+        let native = sb::C_VulkanBackendContext_new(
             instance as _,
             physical_device as _,
             device as _,
@@ -108,7 +108,7 @@ impl BackendContext<'_> {
 
     pub fn set_protected_context(&mut self, protected_context: gpu::Protected) -> &mut Self {
         unsafe {
-            sb::C_GrVkBackendContext_setProtectedContext(
+            sb::C_VulkanBackendContext_setProtectedContext(
                 self.native.as_ptr() as _,
                 protected_context,
             )
@@ -118,7 +118,7 @@ impl BackendContext<'_> {
 
     pub fn set_max_api_version(&mut self, version: impl Into<Version>) -> &mut Self {
         unsafe {
-            sb::C_GrVkBackendContext_setMaxAPIVersion(
+            sb::C_VulkanBackendContext_setMaxAPIVersion(
                 self.native.as_ptr() as _,
                 *version.into().deref(),
             )

--- a/skia-safe/src/gpu/vk/vulkan_types.rs
+++ b/skia-safe/src/gpu/vk/vulkan_types.rs
@@ -1,4 +1,6 @@
-use skia_bindings::{self as sb, skgpu_VulkanBackendMemory, GrVkAlloc, GrVkYcbcrConversionInfo};
+use skia_bindings::{
+    self as sb, skgpu_VulkanAlloc, skgpu_VulkanBackendMemory, skgpu_VulkanYcbcrConversionInfo,
+};
 
 use crate::{gpu::vk, prelude::*};
 
@@ -18,7 +20,7 @@ pub struct Alloc {
 }
 unsafe_send_sync!(Alloc);
 
-native_transmutable!(GrVkAlloc, Alloc, alloc_layout);
+native_transmutable!(skgpu_VulkanAlloc, Alloc, alloc_layout);
 
 impl Default for Alloc {
     fn default() -> Self {
@@ -35,7 +37,7 @@ impl Default for Alloc {
 
 impl PartialEq for Alloc {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { sb::C_GrVkAlloc_Equals(self.native(), other.native()) }
+        unsafe { sb::C_VulkanAlloc_Equals(self.native(), other.native()) }
     }
 }
 
@@ -84,14 +86,14 @@ pub struct YcbcrConversionInfo {
 }
 
 native_transmutable!(
-    GrVkYcbcrConversionInfo,
+    skgpu_VulkanYcbcrConversionInfo,
     YcbcrConversionInfo,
     ycbcr_conversion_info_layout
 );
 
 impl PartialEq for YcbcrConversionInfo {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { sb::C_GrVkYcbcrConversionInfo_Equals(self.native(), other.native()) }
+        unsafe { sb::C_VulkanYcbcrConversionInfo_Equals(self.native(), other.native()) }
     }
 }
 

--- a/skia-safe/src/prelude.rs
+++ b/skia-safe/src/prelude.rs
@@ -742,14 +742,19 @@ where
         r
     }
 
-    /// Provides access to the Rust value through a
-    /// transmuted reference to the native value.
+    /// Returns a reference to the Rust value by ransmuting a reference to the native value.
     fn from_native_ref(nt: &NT) -> &Self {
         unsafe { transmute_ref(nt) }
     }
 
-    /// Provides access to the Rust value through a
-    /// transmuted reference to the native mutable value.
+    /// Returns a reference to the Rust array reference by transmuting a reference to the native
+    /// array.
+    fn from_native_array_ref<const N: usize>(nt: &[NT; N]) -> &[Self; N] {
+        unsafe { transmute_ref(nt) }
+    }
+
+    /// Returns a reference to the Rust value through a transmuted reference to the native mutable
+    /// value.
     fn from_native_ref_mut(nt: &mut NT) -> &mut Self {
         unsafe { transmute_ref_mut(nt) }
     }


### PR DESCRIPTION
This PR aligns rust-skia with Skia's `chrome/m128` branch.

- [x] Update `README.md` ([rendered](https://github.com/pragmatrix/rust-skia/blob/m128/README.md))  
  > Most important here is to change the Skia branch name and the current Skia submodule tag at the top of the `README.md` file.
- [x] Diff the the following files to see if the build organization has changed significantly:
  - [x] `/BUILD.gn`
  - [x] `/gn/*` (recursively)
  - [x] `/modules/skshaper/BUILD.gn`
  - [x] `/modules/skshaper/skshaper.gni`
  - [x] `/modules/paragraph/BUILD.gn`
  - [x] `/modules/paragraph/skparagraph.gni`
- [x] Skia builds ([release notes](https://github.com/google/skia/blob/chrome/m128/RELEASE_NOTES.md)).
- [x] `/skia-bindings` builds.
- [x] `/skia-safe`: Update & add new wrappers by diffing include files.  
  > Add TODOs for everything that can not be updated right now, and attempt to stay compatible with previous versions of skia-safe without trying too hard before version 1.0. Use `deprecated` attributes if needed.
  - [x] `codec/`
  - [x] `core/`
  - [x] `docs/`
  - [x] `effects/`
  - [x] `encode/`
  - [x] `gpu/`
    - [x] `d3d/`
    - [x] `ganesh/`
    - [x] `gl/`
    - [x] `mtl/`
    - [x] `vk/`
  - [x] `pathops/`
  - [x] `svg/`
  - [x] `utils/`
  - [x] `modules/`
    - [x] `paragraph/`
    - [x] `shaper/`
  - [x] `private/base/*`
    - [x] `SkPoint_impl.h`
- [x] Review `Send` & `Sync` implementations for new wrappers.
- [x] Review `Debug` implementation for new wrapper types and functions.
- [x] Release date of the matching Chrome version in less than 7 days?
- [x] Any pending changes in the Skia `chrome/m128` branch that aren't synchronized yet?
- [x] Rebase on or merge with master.
- [x] Do the `rust-skia:` commits in the `skia-bindings/skia` subdirectory match with `master` (`make diff-skia`).
- [x] Update versions of `skia-bindings/Cargo.toml` and `skia-safe/Cargo.toml` and also add the version to the new `deprecated` attributes.
- [x] Do the tags/hashes in `skia-bindings/Cargo.toml` under `[package.metadata]` match the submodules `depot_tools` and `skia`?
- [x] Review API changes: `make diff-api`.
- [ ] Test builds we don't do on the CI:
  - [ ] Compiles to Catalyst targets on macOS (#548).
    ```zsh
    make macos-qa
    ```
- [x] Do one final review of all the changes.
- [x] Run `make doc` and fix all warnings.

