### PR TITLE
Milestone 129

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m129 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m129-0.77.0...google:chrome/m129
-[skia-ours]: https://github.com/google/skia/compare/chrome/m129...rust-skia:m128-0.77.0
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m129-0.77.1...google:chrome/m129
+[skia-ours]: https://github.com/google/skia/compare/chrome/m129...rust-skia:m128-0.77.1
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![Windows QA](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml) [![Linux QA](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml) [![macOS QA](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml)
 
-Skia Submodule Status: chrome/m128 ([upstream changes][skia-upstream], [our changes][skia-ours]).
+Skia Submodule Status: chrome/m129 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m128-0.76.1...google:chrome/m128
-[skia-ours]: https://github.com/google/skia/compare/chrome/m128...rust-skia:m128-0.76.1
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m129-0.77.0...google:chrome/m129
+[skia-ours]: https://github.com/google/skia/compare/chrome/m129...rust-skia:m128-0.77.0
 
 ## About
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -30,7 +30,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m128-0.76.1"
+skia = "m129-0.77.0"
 depot_tools = "73a2624"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -30,7 +30,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download skia and depot_tools archives from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m129-0.77.0"
+skia = "m129-0.77.1"
 depot_tools = "73a2624"
 
 [features]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.77.0"
+version = "0.78.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2021"
 build = "build.rs"

--- a/skia-bindings/build_support/skia_bindgen.rs
+++ b/skia-bindings/build_support/skia_bindgen.rs
@@ -698,6 +698,8 @@ const ENUM_REWRITES: &[EnumEntry] = &[
     // m118:
     ("GrPurgeResourceOptions", rewrite::k_xxx),
     ("GrSyncCpu", rewrite::k_xxx),
+    // m129:
+    ("Clamp", rewrite::k_xxx), // SkColorFilters
 ];
 
 pub(crate) mod rewrite {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1815,12 +1815,12 @@ extern "C" SkColorFilter* C_SkColorFilters_Blend(const SkColor c, SkBlendMode bl
 }
 
 
-extern "C" SkColorFilter* C_SkColorFilters_Matrix(const SkColorMatrix* colorMatrix) {
-    return SkColorFilters::Matrix(*colorMatrix).release();
+extern "C" SkColorFilter* C_SkColorFilters_Matrix(const SkColorMatrix* colorMatrix, SkColorFilters::Clamp clamp) {
+    return SkColorFilters::Matrix(*colorMatrix, clamp).release();
 }
 
-extern "C" SkColorFilter* C_SkColorFilters_MatrixRowMajor(const SkScalar array[20]) {
-    return SkColorFilters::Matrix(array).release();
+extern "C" SkColorFilter* C_SkColorFilters_MatrixRowMajor(const SkScalar array[20], SkColorFilters::Clamp clamp) {
+    return SkColorFilters::Matrix(array, clamp).release();
 }
 
 extern "C" SkColorFilter* C_SkColorFilters_HSLAMatrixOfColorMatrix(const SkColorMatrix& colorMatrix) {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -24,6 +24,7 @@
 
 // core/
 #include "include/core/SkAnnotation.h"
+#include "include/core/SkArc.h"
 #include "include/core/SkBlendMode.h"
 #include "include/core/SkBitmap.h"
 #include "include/core/SkBlurTypes.h"
@@ -288,7 +289,7 @@ extern "C" void C_SkPixmapUtils_SwapWidthHeight(SkImageInfo* uninitialized, cons
 //
 
 extern "C" void C_Core_Types(
-    SkGraphics *, SkCoverageMode *, SkColorChannelFlag *, SkSurfaces::BackendSurfaceAccess) {};
+    SkArc *, SkGraphics *, SkCoverageMode *, SkColorChannelFlag *, SkSurfaces::BackendSurfaceAccess) {};
 
 //
 // core/SkBlender.h

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -2715,16 +2715,16 @@ SkImageFilter *C_SkImageFilters_DisplacementMap(SkColorChannel xChannelSelector,
 
 SkImageFilter *C_SkImageFilters_DropShadow(SkScalar dx, SkScalar dy,
                                            SkScalar sigmaX, SkScalar sigmaY,
-                                           SkColor color, SkImageFilter *input,
+                                           SkColor4f color, SkColorSpace *colorSpace, SkImageFilter *input,
                                            const SkRect *cropRect) {
-    return SkImageFilters::DropShadow(dx, dy, sigmaX, sigmaY, color, sp(input), cropRect).release();
+    return SkImageFilters::DropShadow(dx, dy, sigmaX, sigmaY, color, sp(colorSpace), sp(input), cropRect).release();
 }
 
 SkImageFilter *C_SkImageFilters_DropShadowOnly(SkScalar dx, SkScalar dy,
                                                SkScalar sigmaX, SkScalar sigmaY,
-                                               SkColor color, SkImageFilter *input,
+                                               SkColor4f color, SkColorSpace* colorSpace, SkImageFilter *input,
                                                const SkRect *cropRect) {
-    return SkImageFilters::DropShadowOnly(dx, dy, sigmaX, sigmaY, color, sp(input), cropRect).release();
+    return SkImageFilters::DropShadowOnly(dx, dy, sigmaX, sigmaY, color, sp(colorSpace), sp(input), cropRect).release();
 }
 
 SkImageFilter* C_SkImageFilters_Empty() {

--- a/skia-org/src/skpaint_overview.rs
+++ b/skia-org/src/skpaint_overview.rs
@@ -326,7 +326,7 @@ fn draw_mask_filter(canvas: &Canvas) {
 fn draw_color_filter(c: &Canvas) {
     fn f(c: &Canvas, (x, y): (scalar, scalar), color_matrix: &[scalar; 20]) {
         let paint = &mut Paint::default();
-        paint.set_color_filter(color_filters::matrix_row_major(color_matrix));
+        paint.set_color_filter(color_filters::matrix_row_major(color_matrix, None));
 
         let image = &resources::mandrill();
 

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -18,7 +18,7 @@ categories = [
 ]
 license = "MIT"
 
-version = "0.77.0"
+version = "0.78.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2021"
 
@@ -55,7 +55,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 [dependencies]
 bitflags = "2.0"
 lazy_static = "1.4"
-skia-bindings = { version = "=0.77.0", path = "../skia-bindings", default-features = false }
+skia-bindings = { version = "=0.78.0", path = "../skia-bindings", default-features = false }
 
 # D3D types & ComPtr
 windows = { version = "0.58.0", features = [

--- a/skia-safe/src/codec/_codec.rs
+++ b/skia-safe/src/codec/_codec.rs
@@ -39,6 +39,8 @@ pub struct Options {
     pub prior_frame: Option<usize>,
 }
 
+pub const NO_FRAME: i32 = sb::SkCodec_kNoFrame;
+
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 pub struct FrameInfo {

--- a/skia-safe/src/core/bitmap.rs
+++ b/skia-safe/src/core/bitmap.rs
@@ -689,7 +689,7 @@ impl Bitmap {
     ///
     /// `src_x` and `src_y` may be negative to copy only top or left of source. Returns `false` if
     /// [`Self::width()`] or [`Self::height()`] is zero or negative. Returns `false` if `abs(src_x)`
-    /// >= [`Self::width()`], or if `abs(src_y)` >= [`Self::height()`].
+    /// `>=` [`Self::width()`], or if `abs(src_y) >=` [`Self::height()`].
     #[allow(clippy::missing_safety_doc)]
     pub unsafe fn read_pixels(
         &self,

--- a/skia-safe/src/core/blender.rs
+++ b/skia-safe/src/core/blender.rs
@@ -2,9 +2,8 @@ use crate::{prelude::*, BlendMode, NativeFlattenable};
 use skia_bindings::{self as sb, SkBlender, SkFlattenable, SkRefCntBase};
 use std::fmt;
 
-/// Blender represents a custom blend function in the Skia pipeline. When an Blender is present in a
-/// paint, the [`BlendMode`] is ignored. A blender combines a source color (the result of our paint)
-/// and destination color (from the canvas) into a final color.
+/// [`Blender`] represents a custom blend function in the Skia pipeline.  A blender combines a source
+/// color (the result of our paint) and destination color (from the canvas) into a final color.
 pub type Blender = RCHandle<SkBlender>;
 unsafe_send_sync!(Blender);
 require_base_type!(SkBlender, SkFlattenable);

--- a/skia-safe/src/core/color_filter.rs
+++ b/skia-safe/src/core/color_filter.rs
@@ -141,13 +141,18 @@ pub mod color_filters {
         ColorFilter::from_ptr(unsafe { sb::C_SkColorFilters_Blend(c.into().into_native(), mode) })
     }
 
-    pub fn matrix(color_matrix: &ColorMatrix) -> ColorFilter {
-        ColorFilter::from_ptr(unsafe { sb::C_SkColorFilters_Matrix(color_matrix.native()) })
+    pub use sb::SkColorFilters_Clamp as Clamp;
+    variant_name!(Clamp::No);
+
+    pub fn matrix(color_matrix: &ColorMatrix, clamp: impl Into<Option<Clamp>>) -> ColorFilter {
+        let clamp = clamp.into().unwrap_or(Clamp::Yes);
+        ColorFilter::from_ptr(unsafe { sb::C_SkColorFilters_Matrix(color_matrix.native(), clamp) })
             .unwrap()
     }
 
-    pub fn matrix_row_major(array: &[scalar; 20]) -> ColorFilter {
-        ColorFilter::from_ptr(unsafe { sb::C_SkColorFilters_MatrixRowMajor(array.as_ptr()) })
+    pub fn matrix_row_major(array: &[scalar; 20], clamp: impl Into<Option<Clamp>>) -> ColorFilter {
+        let clamp = clamp.into().unwrap_or(Clamp::Yes);
+        ColorFilter::from_ptr(unsafe { sb::C_SkColorFilters_MatrixRowMajor(array.as_ptr(), clamp) })
             .unwrap()
     }
 

--- a/skia-safe/src/core/color_type.rs
+++ b/skia-safe/src/core/color_type.rs
@@ -40,6 +40,8 @@ pub enum ColorType {
     RGBAF16Norm = SkColorType::kRGBA_F16Norm_SkColorType as _,
     /// pixel with half floats for red, green, blue, alpha in 64-bit word
     RGBAF16 = SkColorType::kRGBA_F16_SkColorType as _,
+    /// pixel with half floats for red, green, blue; in 64-bit word
+    RGBF16F16F16x = SkColorType::kRGB_F16F16F16x_SkColorType as _,
     /// pixel using C float for red, green, blue, alpha; in 128-bit word
     RGBAF32 = SkColorType::kRGBA_F32_SkColorType as _,
 

--- a/skia-safe/src/core/image.rs
+++ b/skia-safe/src/core/image.rs
@@ -1028,6 +1028,9 @@ impl Image {
     /// Copies [`crate::Rect`] of pixels from [`Image`] to `dst_pixels`. Copy starts at offset (`src_x`, `src_y`),
     /// and does not exceed [`Image`] (width(), height()).
     ///
+    /// Graphite has deprecated this API in favor of the equivalent asynchronous API on
+    /// `skgpu::graphite::Context` (with an optional explicit synchonization).
+    ///
     /// `dst_info` specifies width, height, [`ColorType`], [`AlphaType`], and [`ColorSpace`] of
     /// destination. `dst_row_bytes` specifies the gap from one destination row to the next.
     /// Returns `true` if pixels are copied. Returns `false` if:
@@ -1089,6 +1092,9 @@ impl Image {
 
     /// Copies a [`crate::Rect`] of pixels from [`Image`] to dst. Copy starts at (`src_x`, `src_y`), and
     /// does not exceed [`Image`] (width(), height()).
+    ///
+    /// Graphite has deprecated this API in favor of the equivalent asynchronous API on
+    /// `skgpu::graphite::Context` (with an optional explicit synchonization).
     ///
     /// dst specifies width, height, [`ColorType`], [`AlphaType`], [`ColorSpace`], pixel storage,
     /// and row bytes of destination. dst.`row_bytes()` specifics the gap from one destination

--- a/skia-safe/src/core/milestone.rs
+++ b/skia-safe/src/core/milestone.rs
@@ -1,1 +1,1 @@
-pub const MILESTONE: usize = 128;
+pub const MILESTONE: usize = 129;

--- a/skia-safe/src/core/path.rs
+++ b/skia-safe/src/core/path.rs
@@ -4,7 +4,7 @@ use skia_bindings::{self as sb, SkPath, SkPath_Iter, SkPath_RawIter};
 
 use crate::{
     interop::DynamicMemoryWStream, matrix::ApplyPerspectiveClip, path_types, prelude::*, scalar,
-    Arc, Data, Matrix, PathDirection, PathFillType, Point, RRect, Rect, Vector,
+    Data, Matrix, PathDirection, PathFillType, Point, RRect, Rect, Vector,
 };
 
 #[deprecated(since = "0.25.0", note = "use PathDirection")]
@@ -620,19 +620,6 @@ impl Path {
     pub fn is_rrect(&self) -> Option<RRect> {
         let mut rrect = RRect::default();
         unsafe { self.native().isRRect(rrect.native_mut()) }.if_true_some(rrect)
-    }
-
-    ///  Returns `true` if path is representable as an oval arc. In other words, could this
-    ///  path be drawn using [`crate::Canvas::draw_arc`].
-    ///
-    ///  arc  receives parameters of arc
-    ///
-    /// * `arc` - storage for arc; may be `None`
-    ///
-    /// Returns: `true` if [`Path`] contains only a single arc from an oval
-    pub fn is_arc(&self) -> Option<Arc> {
-        let mut arc = Arc::default();
-        unsafe { self.native().isArc(arc.native_mut()) }.if_true_some(arc)
     }
 
     /// Sets [`Path`] to its initial state.
@@ -1611,25 +1598,6 @@ impl Path {
         unsafe {
             self.native_mut()
                 .addOval1(oval.as_ref().native(), dir, start.try_into().unwrap())
-        };
-        self
-    }
-
-    /// Experimental, subject to change or removal.
-    ///
-    /// Adds an "open" oval to [`Path`]. This follows canvas2D semantics: The oval is not
-    /// a separate contour. If the path was empty, then [`Verb::Move`] is appended. Otherwise,
-    /// [`Verb::Line`] is appended. Four [`Verb::Conic`] are appended. [`Verb::Close`] is not appended.
-    pub fn add_open_oval(
-        &mut self,
-        oval: impl AsRef<Rect>,
-        dir_start: Option<(PathDirection, usize)>,
-    ) -> &mut Self {
-        let dir = dir_start.map(|ds| ds.0).unwrap_or_default();
-        let start = dir_start.map(|ds| ds.1).unwrap_or_default();
-        unsafe {
-            self.native_mut()
-                .addOpenOval(oval.as_ref().native(), dir, start.try_into().unwrap())
         };
         self
     }

--- a/skia-safe/src/core/surface.rs
+++ b/skia-safe/src/core/surface.rs
@@ -749,7 +749,9 @@ impl Surface {
     /// Copies each readable pixel intersecting both rectangles, without scaling,
     /// converting to `dst_color_type()` and `dst_alpha_type()` if required.
     ///
-    /// Pixels are readable when [`Surface`] is raster, or backed by a GPU.
+    /// Pixels are readable when [`Surface`] is raster, or backed by a Ganesh GPU backend. Graphite
+    /// has deprecated this API in favor of the equivalent asynchronous API on
+    /// `skgpu::graphite::Context` (with an optional explicit synchonization).
     ///
     /// The destination pixel storage must be allocated by the caller.
     ///
@@ -783,7 +785,9 @@ impl Surface {
     /// Copies each readable pixel intersecting both rectangles, without scaling,
     /// converting to `dst_info_color_type()` and `dst_info_alpha_type()` if required.
     ///
-    /// Pixels are readable when [`Surface`] is raster, or backed by a GPU.
+    /// Pixels are readable when [`Surface`] is raster, or backed by a Ganesh GPU backend. Graphite
+    /// has deprecated this API in favor of the equivalent asynchronous API on
+    /// `skgpu::graphite::Context` (with an optional explicit synchonization).
     ///
     /// The destination pixel storage must be allocated by the caller.
     ///
@@ -837,7 +841,9 @@ impl Surface {
     /// Copies each readable pixel intersecting both rectangles, without scaling,
     /// converting to `bitmap.color_type()` and `bitmap.alpha_type()` if required.
     ///
-    /// Pixels are readable when [`Surface`] is raster, or backed by a GPU.
+    /// Pixels are readable when [`Surface`] is raster, or backed by a Ganesh GPU backend. Graphite
+    /// has deprecated this API in favor of the equivalent asynchronous API on
+    /// `skgpu::graphite::Context` (with an optional explicit synchonization).
     ///
     /// The destination pixel storage must be allocated by the caller.
     ///

--- a/skia-safe/src/effects/image_filters.rs
+++ b/skia-safe/src/effects/image_filters.rs
@@ -3,9 +3,9 @@ use std::ptr;
 use skia_bindings::{self as sb, SkImageFilter, SkRect};
 
 use crate::{
-    prelude::*, scalar, Blender, Color, ColorChannel, ColorFilter, CubicResampler, IPoint, IRect,
-    ISize, Image, ImageFilter, Matrix, Picture, Point3, Rect, SamplingOptions, Shader, TileMode,
-    Vector,
+    prelude::*, scalar, Blender, Color, Color4f, ColorChannel, ColorFilter, ColorSpace,
+    CubicResampler, IPoint, IRect, ISize, Image, ImageFilter, Matrix, Picture, Point3, Rect,
+    SamplingOptions, Shader, TileMode, Vector,
 };
 
 /// This is just a convenience type to allow passing [`IRect`]s, [`Rect`]s, and optional references
@@ -234,12 +234,14 @@ pub fn displacement_map(
 /// * `sigma_x` - The blur radius for the shadow, along the X axis.
 /// * `sigma_y` - The blur radius for the shadow, along the Y axis.
 /// * `color` - The color of the drop shadow.
+/// * `color_space` - The color space of the drop shadow color.
 /// * `input` - The input filter, or will use the source bitmap if this is null.
 /// * `crop_rect` - Optional rectangle that crops the input and output.
 pub fn drop_shadow(
     offset: impl Into<Vector>,
     (sigma_x, sigma_y): (scalar, scalar),
-    color: impl Into<Color>,
+    color: impl Into<Color4f>,
+    color_space: impl Into<Option<ColorSpace>>,
     input: impl Into<Option<ImageFilter>>,
     crop_rect: impl Into<CropRect>,
 ) -> Option<ImageFilter> {
@@ -252,6 +254,7 @@ pub fn drop_shadow(
             sigma_x,
             sigma_y,
             color.into_native(),
+            color_space.into().into_ptr_or_null(),
             input.into().into_ptr_or_null(),
             crop_rect.into().native(),
         )
@@ -265,12 +268,14 @@ pub fn drop_shadow(
 /// * `sigma_x` - The blur radius for the shadow, along the X axis.
 /// * `sigma_y` - The blur radius for the shadow, along the Y axis.
 /// * `color` - The color of the drop shadow.
+/// * `color_space` - The color space of the drop shadow color.
 /// * `input` - The input filter, or will use the source bitmap if this is null.
 /// * `crop_rect` - Optional rectangle that crops the input and output.
 pub fn drop_shadow_only(
     offset: impl Into<Vector>,
     (sigma_x, sigma_y): (scalar, scalar),
-    color: impl Into<Color>,
+    color: impl Into<Color4f>,
+    color_space: impl Into<Option<ColorSpace>>,
     input: impl Into<Option<ImageFilter>>,
     crop_rect: impl Into<CropRect>,
 ) -> Option<ImageFilter> {
@@ -283,6 +288,7 @@ pub fn drop_shadow_only(
             sigma_x,
             sigma_y,
             color.into_native(),
+            color_space.into().into_ptr_or_null(),
             input.into().into_ptr_or_null(),
             crop_rect.into().native(),
         )

--- a/skia-safe/src/gpu/context_options.rs
+++ b/skia-safe/src/gpu/context_options.rs
@@ -132,6 +132,15 @@ pub struct ContextOptions {
     /// A value of -1 means we will pick a limit value internally.
     pub max_cached_vulkan_secondary_command_buffers: raw::c_int,
 
+    /// If Skia is creating a default VMA allocator for the Vulkan backend this value will be used
+    /// for the `preferred_large_heap_block_size`. If the value is not set, then Skia will use an
+    /// inernally defined default size.
+    ///
+    /// However, it is highly discouraged to have Skia make a default allocator (and support for
+    /// doing so will be removed soon,  b/321962001). Instead clients should create their own
+    /// allocator to pass into Skia where they can fine tune this value themeselves.
+    vulkan_vma_large_heap_block_size: [u64; 2],
+
     /// If `true`, the caps will never support mipmaps.
     pub suppress_mipmap_support: bool,
 

--- a/skia-safe/src/gpu/context_options.rs
+++ b/skia-safe/src/gpu/context_options.rs
@@ -134,7 +134,7 @@ pub struct ContextOptions {
 
     /// If Skia is creating a default VMA allocator for the Vulkan backend this value will be used
     /// for the `preferred_large_heap_block_size`. If the value is not set, then Skia will use an
-    /// inernally defined default size.
+    /// internally defined default size.
     ///
     /// However, it is highly discouraged to have Skia make a default allocator (and support for
     /// doing so will be removed soon,  b/321962001). Instead clients should create their own


### PR DESCRIPTION
This PR aligns rust-skia with Skia's `chrome/m129` branch.

- [x] Update `README.md` ([rendered](https://github.com/pragmatrix/rust-skia/blob/m129/README.md))  
  > Most important here is to change the Skia branch name and the current Skia submodule tag at the top of the `README.md` file.
- [x] Diff the the following files to see if the build organization has changed significantly:
  - [x] `/BUILD.gn`
  - [x] `/gn/*` (recursively)
  - [x] `/modules/skshaper/BUILD.gn`
  - [x] `/modules/skshaper/skshaper.gni`
  - [x] `/modules/paragraph/BUILD.gn`
  - [x] `/modules/paragraph/skparagraph.gni`
- [x] Skia builds ([release notes](https://github.com/google/skia/blob/chrome/m129/RELEASE_NOTES.md)).
- [x] `/skia-bindings` builds.
- [x] `/skia-safe`: Update & add new wrappers by diffing include files.  
  > Add TODOs for everything that can not be updated right now, and attempt to stay compatible with previous versions of skia-safe without trying too hard before version 1.0. Use `deprecated` attributes if needed.
  - [x] `codec/`
  - [x] `core/`
  - [x] `docs/`
  - [x] `effects/`
  - [x] `encode/`
  - [x] `gpu/`
    - [x] `d3d/`
    - [x] `ganesh/`
    - [x] `gl/`
    - [x] `mtl/`
    - [x] `vk/`
  - [x] `pathops/`
  - [x] `svg/`
  - [x] `utils/`
  - [x] `modules/`
    - [x] `paragraph/`
    - [x] `shaper/`
    - [x] `skresources/`
    - [x] `svg/`
  - [x] `private/base/*`
    - [x] `SkPoint_impl.h`
- [x] Review `Send` & `Sync` implementations for new wrappers.
- [x] Review `Debug` implementation for new wrapper types and functions.
- [x] Release date of the matching Chrome version in less than 7 days?
- [x] Any pending changes in the Skia `chrome/m129` branch that aren't synchronized yet?
- [x] Rebase on or merge with master.
- [x] Do the `rust-skia:` commits in the `skia-bindings/skia` subdirectory match with `master` (`make diff-skia`).
- [x] Update versions of `skia-bindings/Cargo.toml` and `skia-safe/Cargo.toml` and also add the version to the new `deprecated` attributes.
- [x] Do the tags/hashes in `skia-bindings/Cargo.toml` under `[package.metadata]` match the submodules `depot_tools` and `skia`?
- [ ] Review API changes: `make diff-api`.
- [ ] Test builds we don't do on the CI:
  - [ ] Compiles to Catalyst targets on macOS (#548).
    ```zsh
    make macos-qa
    ```
- [x] Do one final review of all the changes.
- [x] Run `make doc` and fix all warnings.

