### PR TITLE
Add is_trivial_abi=false to windows build config to avoid ABI issues

### DIFF
--- a/skia-bindings/build_support/platform/windows.rs
+++ b/skia-bindings/build_support/platform/windows.rs
@@ -44,6 +44,11 @@ impl PlatformDetails for Msvc {
             }
         }
 
+        // Disable `[[clang::trivial_abi]]` because it leads to ABI mismatches if the
+        // bindings are compiled with a compiler other than clang (e.g. MSVC).
+        // (see <https://groups.google.com/g/skia-discuss/c/3rpeWuPcD9Y/m/CySLakaTAAAJ>)
+        builder.arg("is_trivial_abi", no());
+
         // Code on MSVC needs to be compiled differently (e.g. with /MT or /MD)
         // depending on the runtime being linked. (See
         // <https://doc.rust-lang.org/reference/linkage.html#static-and-dynamic-c-runtimes>)


### PR DESCRIPTION
The default build config seems to add `[[clang::trivial_abi]]` to sk_sp which changes the calling convention for arguments of these types, which leads to an ABI mismatch & crashes if the bindings are not compiled with clang.

Fixes #1028 