### PR TITLE
support SkRuntimeShaderBuilder, SkFilters::RuntimeShader

### DIFF
--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -2682,7 +2682,6 @@ void C_SkRuntimeShaderBuilder_setUniformFloat(SkRuntimeShaderBuilder *self,
   using float2 = std::array<float, 2>;
   using float3 = std::array<float, 3>;
   using float4 = std::array<float, 4>;
-  using float2x2 = std::array<float, 4>;
   using float3x3 = std::array<float, 9>;
   using float4x4 = std::array<float, 16>;
 

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -2644,6 +2644,93 @@ bool C_SkRuntimeEffect_allowBlender(const SkRuntimeEffect* self) {
     return self->allowBlender();
 }
 
+
+void C_SkRuntimeShaderBuilder_Construct(SkRuntimeShaderBuilder *uninitialized,
+                                        SkRuntimeEffect *effect) {
+  new (uninitialized) SkRuntimeShaderBuilder(sp(effect));
+}
+const SkRuntimeEffect *
+C_SkRuntimeShaderBuilder_effect(const SkRuntimeShaderBuilder *self) {
+  return self->effect();
+}
+sk_sp<const SkData>
+C_SkRuntimeShaderBuilder_uniforms(const SkRuntimeShaderBuilder *self) {
+  return self->uniforms();
+}
+SkSpan<const SkRuntimeEffect::ChildPtr>
+C_SkRuntimeShaderBuilder_children(const SkRuntimeShaderBuilder *self) {
+  return self->children();
+}
+SkShader *
+C_SkRuntimeShaderBuilder_makeShader(const SkRuntimeShaderBuilder *self,
+                                    const SkMatrix *localMatrix) {
+  auto shader = self->makeShader(localMatrix);
+  return shader.release();
+}
+
+void C_SkRuntimeShaderBuilder_setUniformFloat(SkRuntimeShaderBuilder *self,
+                                              const char *name, size_t count,
+                                              const float *const values,
+                                              size_t len) {
+  using float2 = std::array<float, 2>;
+  using float3 = std::array<float, 3>;
+  using float4 = std::array<float, 4>;
+  using float2x2 = std::array<float, 4>;
+  using float3x3 = std::array<float, 9>;
+  using float4x4 = std::array<float, 16>;
+
+  switch (len) {
+  case 1:
+    self->uniform(std::string_view(name, count)) = *values;
+    break;
+  case 2:
+    self->uniform(std::string_view(name, count)) =
+        *reinterpret_cast<const float2 *>(values);
+    break;
+  case 3:
+    self->uniform(std::string_view(name, count)) =
+        *reinterpret_cast<const float3 *>(values);
+    break;
+  case 4:
+    self->uniform(std::string_view(name, count)) =
+        *reinterpret_cast<const float4 *>(values);
+    break;
+  case 9:
+    self->uniform(std::string_view(name, count)) =
+        *reinterpret_cast<const float3x3 *>(values);
+    break;
+  case 16:
+    self->uniform(std::string_view(name, count)) =
+        *reinterpret_cast<const float4x4 *>(values);
+    break;
+  }
+}
+
+void C_SkRuntimeShaderBuilder_setUniformInt(SkRuntimeShaderBuilder *self,
+                                            const char *name, size_t count,
+                                            const int *const values,
+                                            size_t len) {
+  using int2 = std::array<int, 2>;
+  using int3 = std::array<int, 3>;
+  using int4 = std::array<int, 4>;
+  switch (len) {
+  case 1:
+    self->uniform(std::string_view(name, count)) = *values;
+    break;
+  case 2:
+    self->uniform(std::string_view(name, count)) =
+        *reinterpret_cast<const int2 *>(values);
+    break;
+  case 3:
+    self->uniform(std::string_view(name, count)) =
+        *reinterpret_cast<const int3 *>(values);
+    break;
+  case 4:
+    self->uniform(std::string_view(name, count)) =
+        *reinterpret_cast<const int4 *>(values);
+    break;
+  }
+}
 }
 
 //
@@ -2861,6 +2948,14 @@ C_SkImageFilters_SpotLitSpecular(const SkPoint3 &location,
                                            cropRect).release();
 }
 
+SkImageFilter *C_SkImageFilters_RuntimeShader(
+    const SkRuntimeShaderBuilder &builder, const char *childShaderName,
+    size_t childShaderNameCount, SkImageFilter *input) {
+  auto imageFilter = SkImageFilters::RuntimeShader(
+      builder, std::string_view(childShaderName, childShaderNameCount),
+      sp(input));
+  return imageFilter.release();
+}
 }
 
 //

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -2675,7 +2675,12 @@ C_SkRuntimeShaderBuilder_makeShader(const SkRuntimeShaderBuilder *self,
   return shader.release();
 }
 
-void C_SkRuntimeShaderBuilder_setUniformFloat(SkRuntimeShaderBuilder *self,
+enum class ShaderBuilderUniformResult {
+  Ok,
+  Error
+};
+
+ShaderBuilderUniformResult C_SkRuntimeShaderBuilder_setUniformFloat(SkRuntimeShaderBuilder *self,
                                               const char *name, size_t count,
                                               const float *const values,
                                               size_t len) {
@@ -2688,31 +2693,33 @@ void C_SkRuntimeShaderBuilder_setUniformFloat(SkRuntimeShaderBuilder *self,
   switch (len) {
   case 1:
     self->uniform(std::string_view(name, count)) = *values;
-    break;
+    return ShaderBuilderUniformResult::Ok;
   case 2:
     self->uniform(std::string_view(name, count)) =
         *reinterpret_cast<const float2 *>(values);
-    break;
+    return ShaderBuilderUniformResult::Ok;
   case 3:
     self->uniform(std::string_view(name, count)) =
         *reinterpret_cast<const float3 *>(values);
-    break;
+    return ShaderBuilderUniformResult::Ok;
   case 4:
     self->uniform(std::string_view(name, count)) =
         *reinterpret_cast<const float4 *>(values);
-    break;
+    return ShaderBuilderUniformResult::Ok;
   case 9:
     self->uniform(std::string_view(name, count)) =
         *reinterpret_cast<const float3x3 *>(values);
-    break;
+    return ShaderBuilderUniformResult::Ok;
   case 16:
     self->uniform(std::string_view(name, count)) =
         *reinterpret_cast<const float4x4 *>(values);
-    break;
+    return ShaderBuilderUniformResult::Ok;
   }
+
+  return ShaderBuilderUniformResult::Error;
 }
 
-void C_SkRuntimeShaderBuilder_setUniformInt(SkRuntimeShaderBuilder *self,
+ShaderBuilderUniformResult C_SkRuntimeShaderBuilder_setUniformInt(SkRuntimeShaderBuilder *self,
                                             const char *name, size_t count,
                                             const int *const values,
                                             size_t len) {
@@ -2722,20 +2729,21 @@ void C_SkRuntimeShaderBuilder_setUniformInt(SkRuntimeShaderBuilder *self,
   switch (len) {
   case 1:
     self->uniform(std::string_view(name, count)) = *values;
-    break;
+    return ShaderBuilderUniformResult::Ok;
   case 2:
     self->uniform(std::string_view(name, count)) =
         *reinterpret_cast<const int2 *>(values);
-    break;
+    return ShaderBuilderUniformResult::Ok;
   case 3:
     self->uniform(std::string_view(name, count)) =
         *reinterpret_cast<const int3 *>(values);
-    break;
+    return ShaderBuilderUniformResult::Ok;
   case 4:
     self->uniform(std::string_view(name, count)) =
         *reinterpret_cast<const int4 *>(values);
-    break;
+    return ShaderBuilderUniformResult::Ok;
   }
+  return ShaderBuilderUniformResult::Error;
 }
 }
 

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -2653,21 +2653,6 @@ void C_SkRuntimeShaderBuilder_destruct(SkRuntimeShaderBuilder *self) {
   self->~SkRuntimeShaderBuilder();
 }
 
-const SkRuntimeEffect *
-C_SkRuntimeShaderBuilder_effect(const SkRuntimeShaderBuilder *self) {
-  return self->effect();
-}
-
-sk_sp<const SkData>
-C_SkRuntimeShaderBuilder_uniforms(const SkRuntimeShaderBuilder *self) {
-  return self->uniforms();
-}
-
-SkSpan<const SkRuntimeEffect::ChildPtr>
-C_SkRuntimeShaderBuilder_children(const SkRuntimeShaderBuilder *self) {
-  return self->children();
-}
-
 SkShader *
 C_SkRuntimeShaderBuilder_makeShader(const SkRuntimeShaderBuilder *self,
                                     const SkMatrix *localMatrix) {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -2644,23 +2644,30 @@ bool C_SkRuntimeEffect_allowBlender(const SkRuntimeEffect* self) {
     return self->allowBlender();
 }
 
-
 void C_SkRuntimeShaderBuilder_Construct(SkRuntimeShaderBuilder *uninitialized,
                                         SkRuntimeEffect *effect) {
   new (uninitialized) SkRuntimeShaderBuilder(sp(effect));
 }
+
+void C_SkRuntimeShaderBuilder_destruct(SkRuntimeShaderBuilder *self) {
+  self->~SkRuntimeShaderBuilder();
+}
+
 const SkRuntimeEffect *
 C_SkRuntimeShaderBuilder_effect(const SkRuntimeShaderBuilder *self) {
   return self->effect();
 }
+
 sk_sp<const SkData>
 C_SkRuntimeShaderBuilder_uniforms(const SkRuntimeShaderBuilder *self) {
   return self->uniforms();
 }
+
 SkSpan<const SkRuntimeEffect::ChildPtr>
 C_SkRuntimeShaderBuilder_children(const SkRuntimeShaderBuilder *self) {
   return self->children();
 }
+
 SkShader *
 C_SkRuntimeShaderBuilder_makeShader(const SkRuntimeShaderBuilder *self,
                                     const SkMatrix *localMatrix) {

--- a/skia-safe/src/effects/image_filters.rs
+++ b/skia-safe/src/effects/image_filters.rs
@@ -486,9 +486,25 @@ pub fn picture<'a>(
     })
 }
 
-// TODO: RuntimeShader
+pub fn runtime_shader(
+    builder: &RuntimeShaderBuilder,
+    child_shader_name: impl AsRef<str>,
+    input: impl Into<Option<ImageFilter>>,
+) -> Option<ImageFilter> {
+    let child_shader_name = child_shader_name.as_ref();
+    unsafe {
+        ImageFilter::from_ptr(sb::C_SkImageFilters_RuntimeShader(
+            builder.native() as *const _,
+            child_shader_name.as_ptr() as *const _,
+            child_shader_name.len(),
+            input.into().into_ptr_or_null(),
+        ))
+    }
+}
 
 pub use skia_bindings::SkImageFilters_Dither as Dither;
+
+use super::runtime_effect::RuntimeShaderBuilder;
 variant_name!(Dither::Yes);
 
 /// Create a filter that fills the output with the per-pixel evaluation of the [`Shader`]. The

--- a/skia-safe/src/effects/runtime_effect.rs
+++ b/skia-safe/src/effects/runtime_effect.rs
@@ -404,9 +404,8 @@ impl ChildPtr {
     }
 }
 
-// TODO: wrap SkRuntimeEffectBuilder, SkRuntimeShaderBuilder, SkRuntimeColorFilterBuilder,
+// TODO: wrap SkRuntimeEffectBuilder, SkRuntimeColorFilterBuilder,
 // SkRuntimeBlendBuilder
-
 
 pub type RuntimeShaderBuilder = Handle<sb::SkRuntimeShaderBuilder>;
 unsafe_send_sync!(RuntimeShaderBuilder);
@@ -420,9 +419,9 @@ impl NativeDrop for sb::SkRuntimeShaderBuilder {
 }
 
 impl RuntimeShaderBuilder {
-    pub fn new(effect: &mut RuntimeEffect) -> Self {
+    pub fn new(effect: RuntimeEffect) -> Self {
         Self::construct(|builder| unsafe {
-            let effect: *mut SkRuntimeEffect = effect.native_mut_force() as _;
+            let effect: *mut SkRuntimeEffect = effect.into_ptr() as _;
             sb::C_SkRuntimeShaderBuilder_Construct(builder, effect)
         })
     }

--- a/skia-safe/src/effects/runtime_effect.rs
+++ b/skia-safe/src/effects/runtime_effect.rs
@@ -451,7 +451,7 @@ impl RuntimeShaderBuilder {
     pub fn set_uniform_int(&mut self, name: impl AsRef<str>, data: &[i32]) {
         let name = name.as_ref();
         unsafe {
-            sb::C_SkRuntimeShaderBuilder_setUniformFloat(
+            sb::C_SkRuntimeShaderBuilder_setUniformInt(
                 self.native_mut() as _,
                 name.as_bytes().as_ptr() as _,
                 name.len(),

--- a/skia-safe/src/effects/runtime_effect.rs
+++ b/skia-safe/src/effects/runtime_effect.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use sb::{SkFlattenable, SkRuntimeEffect_Child};
 use skia_bindings::{
-    self as sb, SkRefCntBase, SkRuntimeEffect, SkRuntimeEffect_Options, SkRuntimeEffect_Uniform,
+    self as sb, ShaderBuilderUniformResult, SkRefCntBase, SkRuntimeEffect, SkRuntimeEffect_Options, SkRuntimeEffect_Uniform,
 };
 use std::{fmt, marker::PhantomData, ops::DerefMut, ptr};
 
@@ -434,10 +434,22 @@ impl RuntimeShaderBuilder {
             Shader::from_ptr(shader)
         }
     }
-
-    pub fn set_uniform_float(&mut self, name: impl AsRef<str>, data: &[f32]) {
+    /// Set float uniform values by name. 
+    /// 
+    /// Supported types are `float`, `float2`, `float3`, `float4`, `float2x2`, `float3x3`, `float4x4`.
+    /// 
+    /// The data array must have the correct length for the corresponding uniform type:
+    /// - `float`: `[f32; 1]`
+    /// - `float2`: `[f32; 2]`
+    /// - `float3`: `[f32; 3]`
+    /// - `float4`: `[f32; 4]`
+    /// - `float2x2`: `[f32; 4]`
+    /// - `float3x3`: `[f32; 9]`
+    /// - `float4x4`: `[f32; 16]`
+    /// 
+    pub fn set_uniform_float(&mut self, name: impl AsRef<str>, data: &[f32]) -> Result<(), ()> {
         let name = name.as_ref();
-        unsafe {
+        let result = unsafe {
             sb::C_SkRuntimeShaderBuilder_setUniformFloat(
                 self.native_mut() as _,
                 name.as_bytes().as_ptr() as _,
@@ -446,10 +458,25 @@ impl RuntimeShaderBuilder {
                 data.len(),
             )
         };
+        match result {
+            ShaderBuilderUniformResult::Ok => Ok(()),
+            ShaderBuilderUniformResult::Error => Err(()),
+        }
     }
-    pub fn set_uniform_int(&mut self, name: impl AsRef<str>, data: &[i32]) {
+    /// Set int uniform values by name.
+    /// 
+    /// Supported types are `int`, `int2`, `int3`, `int4`.
+    /// 
+    /// The data array must have the correct length for the corresponding uniform type:
+    /// - `int`: `[i32; 1]`
+    /// - `int2`: `[i32; 2]`
+    /// - `int3`: `[i32; 3]`
+    /// - `int4`: `[i32; 4]`
+    ///
+    /// 
+    pub fn set_uniform_int(&mut self, name: impl AsRef<str>, data: &[i32]) -> Result<(), ()> {
         let name = name.as_ref();
-        unsafe {
+        let result = unsafe {
             sb::C_SkRuntimeShaderBuilder_setUniformInt(
                 self.native_mut() as _,
                 name.as_bytes().as_ptr() as _,
@@ -458,5 +485,9 @@ impl RuntimeShaderBuilder {
                 data.len(),
             )
         };
+        match result {
+            ShaderBuilderUniformResult::Ok => Ok(()),
+            ShaderBuilderUniformResult::Error => Err(()),
+        }
     }
 }

--- a/skia-safe/src/effects/runtime_effect.rs
+++ b/skia-safe/src/effects/runtime_effect.rs
@@ -413,7 +413,7 @@ unsafe_send_sync!(RuntimeShaderBuilder);
 impl NativeDrop for sb::SkRuntimeShaderBuilder {
     fn drop(&mut self) {
         unsafe {
-            sb::SkRuntimeShaderBuilder_SkRuntimeShaderBuilder_destructor(self);
+            sb::C_SkRuntimeShaderBuilder_destruct(self);
         }
     }
 }

--- a/skia-safe/src/effects/runtime_effect.rs
+++ b/skia-safe/src/effects/runtime_effect.rs
@@ -406,3 +406,58 @@ impl ChildPtr {
 
 // TODO: wrap SkRuntimeEffectBuilder, SkRuntimeShaderBuilder, SkRuntimeColorFilterBuilder,
 // SkRuntimeBlendBuilder
+
+
+pub type RuntimeShaderBuilder = Handle<sb::SkRuntimeShaderBuilder>;
+unsafe_send_sync!(RuntimeShaderBuilder);
+
+impl NativeDrop for sb::SkRuntimeShaderBuilder {
+    fn drop(&mut self) {
+        unsafe {
+            sb::SkRuntimeShaderBuilder_SkRuntimeShaderBuilder_destructor(self);
+        }
+    }
+}
+
+impl RuntimeShaderBuilder {
+    pub fn new(effect: &mut RuntimeEffect) -> Self {
+        Self::construct(|builder| unsafe {
+            let effect: *mut SkRuntimeEffect = effect.native_mut_force() as _;
+            sb::C_SkRuntimeShaderBuilder_Construct(builder, effect)
+        })
+    }
+
+    pub fn make_shader(&self, local_matrix: &Matrix) -> Option<Shader> {
+        unsafe {
+            let instance = self.native_mut_force();
+            let shader =
+                sb::C_SkRuntimeShaderBuilder_makeShader(instance, local_matrix.native() as _);
+            Shader::from_ptr(shader)
+        }
+    }
+
+    pub fn set_uniform_float(&mut self, name: impl AsRef<str>, data: &[f32]) {
+        let name = name.as_ref();
+        unsafe {
+            sb::C_SkRuntimeShaderBuilder_setUniformFloat(
+                self.native_mut() as _,
+                name.as_bytes().as_ptr() as _,
+                name.len(),
+                data.as_ptr() as _,
+                data.len(),
+            )
+        };
+    }
+    pub fn set_uniform_int(&mut self, name: impl AsRef<str>, data: &[i32]) {
+        let name = name.as_ref();
+        unsafe {
+            sb::C_SkRuntimeShaderBuilder_setUniformFloat(
+                self.native_mut() as _,
+                name.as_bytes().as_ptr() as _,
+                name.len(),
+                data.as_ptr() as _,
+                data.len(),
+            )
+        };
+    }
+}


### PR DESCRIPTION
This PR adds a new method to the image_filters: `runtime_shader` to expose the functionality of `SkImageFilters::RuntimeShader`
as well `SkRuntimeShaderBuilder` is now wrapped.
RuntimeShaderBuilder have 2 helper methods to set all the supported uniform types (float and int)

## Usage:
```rust
let sksl_code = r#"
  uniform shader content;
  uniform float4 uColor;
  
  half4 main(float2 coords) {
      half4 cColor = content.eval(coords);
      return half4(mix(cColor, uColor, 0.5));
  }
"#;

// Compile the SkSL shader
let mut runtime_effect = RuntimeEffect::make_for_shader(sksl_code, None).unwrap();

// Create a shader builder
let mut builder = RuntimeShaderBuilder::new(&mut runtime_effect);

// Set the uniform color
let color = [0.0, 1.0, 0.0, 1.0]; // Green color
builder.set_uniform_float("uColor", &color);

let filter_shader = image_filters::runtime_shader(&builder, "", None);
```