### PR TITLE
Fix image filters color and crop rect

### DIFF
--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -2715,16 +2715,16 @@ SkImageFilter *C_SkImageFilters_DisplacementMap(SkColorChannel xChannelSelector,
 
 SkImageFilter *C_SkImageFilters_DropShadow(SkScalar dx, SkScalar dy,
                                            SkScalar sigmaX, SkScalar sigmaY,
-                                           SkColor4f color, SkColorSpace *colorSpace, SkImageFilter *input,
+                                           const SkColor4f* color, SkColorSpace *colorSpace, SkImageFilter *input,
                                            const SkRect *cropRect) {
-    return SkImageFilters::DropShadow(dx, dy, sigmaX, sigmaY, color, sp(colorSpace), sp(input), cropRect).release();
+    return SkImageFilters::DropShadow(dx, dy, sigmaX, sigmaY, *color, sp(colorSpace), sp(input), cropRect).release();
 }
 
 SkImageFilter *C_SkImageFilters_DropShadowOnly(SkScalar dx, SkScalar dy,
                                                SkScalar sigmaX, SkScalar sigmaY,
-                                               SkColor4f color, SkColorSpace* colorSpace, SkImageFilter *input,
+                                               const SkColor4f* color, SkColorSpace* colorSpace, SkImageFilter *input,
                                                const SkRect *cropRect) {
-    return SkImageFilters::DropShadowOnly(dx, dy, sigmaX, sigmaY, color, sp(colorSpace), sp(input), cropRect).release();
+    return SkImageFilters::DropShadowOnly(dx, dy, sigmaX, sigmaY, *color, sp(colorSpace), sp(input), cropRect).release();
 }
 
 SkImageFilter* C_SkImageFilters_Empty() {

--- a/skia-safe/src/effects/image_filters.rs
+++ b/skia-safe/src/effects/image_filters.rs
@@ -246,14 +246,13 @@ pub fn drop_shadow(
     crop_rect: impl Into<CropRect>,
 ) -> Option<ImageFilter> {
     let delta = offset.into();
-    let color = color.into();
     ImageFilter::from_ptr(unsafe {
         sb::C_SkImageFilters_DropShadow(
             delta.x,
             delta.y,
             sigma_x,
             sigma_y,
-            color.into_native(),
+            color.into().native(),
             color_space.into().into_ptr_or_null(),
             input.into().into_ptr_or_null(),
             crop_rect.into().native(),
@@ -280,14 +279,14 @@ pub fn drop_shadow_only(
     crop_rect: impl Into<CropRect>,
 ) -> Option<ImageFilter> {
     let delta = offset.into();
-    let color = color.into();
+
     ImageFilter::from_ptr(unsafe {
         sb::C_SkImageFilters_DropShadowOnly(
             delta.x,
             delta.y,
             sigma_x,
             sigma_y,
-            color.into_native(),
+            color.into().native(),
             color_space.into().into_ptr_or_null(),
             input.into().into_ptr_or_null(),
             crop_rect.into().native(),
@@ -1161,5 +1160,17 @@ mod tests {
         #[allow(clippy::needless_borrow)]
         let cr_by_ref = cr(rect);
         assert_eq!(cr_by_ref, CropRect(Some(rect)));
+    }
+
+    #[test]
+    fn test_drop_shadow_only() {
+        let rect = Rect {
+            left: 1.0,
+            top: 2.0,
+            right: 3.0,
+            bottom: 4.0,
+        };
+
+        let _ = super::drop_shadow_only((10., 10.), (1.0, 1.0), 0x404040, None, None, rect);
     }
 }

--- a/skia-safe/src/effects/image_filters.rs
+++ b/skia-safe/src/effects/image_filters.rs
@@ -23,7 +23,7 @@ impl CropRect {
     }
 
     fn native(&self) -> *const SkRect {
-        match self.0 {
+        match &self.0 {
             None => ptr::null(),
             Some(r) => r.native(),
         }


### PR DESCRIPTION
This PR fixes two issues with the image filter bindings. 

- `SkColor4f` must be passed as a pointer to C.
- `CropRect`s were passed with an invalid stack location.


~~Closes #1036~~ (fixes only some of the problems in the ticket)