### PR TITLE
Add temporary replacement for buggy `SkOrderedFontMgr` class

### DIFF
--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -3278,19 +3278,19 @@ sk_sp<SkTypeface> RustOrderedFontMgr::onMatchFamilyStyleCharacter(
     return nullptr;
 }
 
-sk_sp<SkTypeface> RustOrderedFontMgr::onMakeFromData(sk_sp<SkData>, int ttcIndex) const {
+sk_sp<SkTypeface> RustOrderedFontMgr::onMakeFromData(sk_sp<SkData>, int) const {
     return nullptr;
 }
-sk_sp<SkTypeface> RustOrderedFontMgr::onMakeFromStreamIndex(std::unique_ptr<SkStreamAsset>, int ttcIndex) const {
+sk_sp<SkTypeface> RustOrderedFontMgr::onMakeFromStreamIndex(std::unique_ptr<SkStreamAsset>, int) const {
     return nullptr;
 }
 sk_sp<SkTypeface> RustOrderedFontMgr::onMakeFromStreamArgs(std::unique_ptr<SkStreamAsset>, const SkFontArguments&) const {
     return nullptr;
 }
-sk_sp<SkTypeface> RustOrderedFontMgr::onMakeFromFile(const char path[], int ttcIndex) const {
+sk_sp<SkTypeface> RustOrderedFontMgr::onMakeFromFile(const char[], int) const {
     return nullptr;
 }
-sk_sp<SkTypeface> RustOrderedFontMgr::onLegacyMakeTypeface(const char family[], SkFontStyle) const {
+sk_sp<SkTypeface> RustOrderedFontMgr::onLegacyMakeTypeface(const char[], SkFontStyle) const {
     return nullptr;
 }
 

--- a/skia-safe/src/utils/ordered_font_mgr.rs
+++ b/skia-safe/src/utils/ordered_font_mgr.rs
@@ -1,5 +1,5 @@
 use crate::{prelude::*, FontMgr};
-use skia_bindings::{self as sb, SkOrderedFontMgr, SkRefCntBase};
+use skia_bindings::{self as sb, RustOrderedFontMgr as SkOrderedFontMgr, SkRefCntBase};
 use std::{
     fmt,
     mem::transmute,
@@ -48,12 +48,12 @@ impl fmt::Debug for OrderedFontMgr {
 
 impl OrderedFontMgr {
     pub fn new() -> Self {
-        Self::from_ptr(unsafe { sb::C_SkOrderedFontMgr_new() }).unwrap()
+        Self::from_ptr(unsafe { sb::C_RustOrderedFontMgr_new() }).unwrap()
     }
 
     pub fn append(&mut self, font_mgr: impl Into<FontMgr>) {
         let font_mgr = font_mgr.into();
-        unsafe { sb::C_SkOrderedFontMgr_append(self.native_mut(), font_mgr.into_ptr()) }
+        unsafe { sb::C_RustOrderedFontMgr_append(self.native_mut(), font_mgr.into_ptr()) }
     }
 }
 


### PR DESCRIPTION
The `SkOrderedFontMgr` class has [a bug](https://github.com/rust-skia/rust-skia/issues/1055) in its `onMatchFamily` method where it mistakenly looks for a null response rather than a zero-length `SkFontStyleSet` to indicate "no matches" from a given `FontMgr`. As a result it never looks in any of the FontMgrs it contains aside from the first one (totally defeating the purpose of the class which is supposed to act as a ‘union’ of multiple FontMgrs).

 I've reported [the issue](https://issues.skia.org/issues/382016481) upstream but it would be *extremely* useful to me to have a working OrderedFontMgr in skia-safe in the meantime. The actual fix is just a two line change to a single method, but unfortunately the original class locks its list of FontMgrs behind a private reference so I wasn't able to figure out a way to replace the broken method via subclassing.

Instead I've had to inllne the full implementation as `RustOrderedFontMgr` in `bindings.cpp`. I left the existing SkOrderedFontMgr accessors in place so this temporary class can be removed if and when Skia itself is patched. At that point, the references to `RustOrderedFontMgr` in `ordered_font_mgr.rs` could also be turned back into `SkOrderedFontMgr`.

I've also added a unit test to `ordered_font_mgr.rs` that verifies fonts can be found in FontMgrs that aren't the first in the list. It relies on the `textlayout` feature to create single-font FontMgrs via `TypefaceFontProvider`, but if that's a problem it may be possible to rewrite it with fewer dependencies…