### PR TITLE
Incorporate ordered fontmanager fixes by @samizdatco

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m131 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m131-0.79.1...google:chrome/m131
-[skia-ours]: https://github.com/google/skia/compare/chrome/m131...rust-skia:m131-0.79.1
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m131-0.80.1...google:chrome/m131
+[skia-ours]: https://github.com/google/skia/compare/chrome/m131...rust-skia:m131-0.80.1
 
 ## About
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.80.0"
+version = "0.80.1"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2021"
 build = "build.rs"
@@ -30,7 +30,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download the Skia archive from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m131-0.79.1"
+skia = "m131-0.80.1"
 
 [features]
 default = ["binary-cache", "embed-icudtl"]

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -18,7 +18,7 @@ categories = [
 ]
 license = "MIT"
 
-version = "0.80.1"
+version = "0.80.2"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2021"
 
@@ -58,7 +58,7 @@ shaper = ["textlayout", "skia-bindings/shaper"]
 [dependencies]
 bitflags = "2.0"
 lazy_static = "1.4"
-skia-bindings = { version = "=0.80.0", path = "../skia-bindings", default-features = false }
+skia-bindings = { version = "=0.80.1", path = "../skia-bindings", default-features = false }
 
 # D3D types & ComPtr
 windows = { version = "0.58.0", features = [


### PR DESCRIPTION
.. directly into our Skia tree, tag is ~~m131-0.80.0~~, m131-0.80.1, see #1068

/cc @samizdatco 