### PR TITLE
Fix retrieving child vector from StructureElementNode

### DIFF
--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -3071,18 +3071,26 @@ extern "C" void C_SkPDF_StructElementNode_appendChild(SkPDF::StructureElementNod
     self->fChildVector.push_back(std::unique_ptr<SkPDF::StructureElementNode>(node));
 }
 
-extern "C" size_t C_SkPDF_StructureElementNode_getChildVector(const SkPDF::StructureElementNode *self, SkPDF::StructureElementNode **nodes)
+extern "C" size_t C_SkPDF_StructureElementNode_getChildVector(const SkPDF::StructureElementNode *self, SkPDF::StructureElementNode ***nodes)
 {
-    if (self->fChildVector.empty())
-    {
+    if (self == nullptr || nodes == nullptr) {
+        return 0;
+    }
+
+    if (self->fChildVector.empty()) {
         *nodes = nullptr;
         return 0;
     }
-    else
-    {
-        *nodes = &*self->fChildVector.front();
-        return self->fChildVector.size();
+
+    size_t size = self->fChildVector.size();
+    SkPDF::StructureElementNode** nodesArray = new SkPDF::StructureElementNode*[size];
+
+    for (size_t i = 0; i < size; ++i) {
+        nodesArray[i] = self->fChildVector[i].get();
     }
+
+    *nodes = nodesArray;
+    return size;
 }
 
 extern "C" void C_SkPDF_Metadata_Construct(SkPDF::Metadata* uninitialized) {

--- a/skia-safe/src/docs/pdf_document.rs
+++ b/skia-safe/src/docs/pdf_document.rs
@@ -175,7 +175,7 @@ pub mod pdf {
             let mut ptr = ptr::null_mut();
             unsafe {
                 let len = sb::C_SkPDF_StructureElementNode_getChildVector(self.native(), &mut ptr);
-                safer::from_raw_parts(ptr as _, len)
+                safer::from_raw_parts(ptr as *const StructureElementNode, len)
             }
         }
 


### PR DESCRIPTION
Currently when retrieving child vector, it retrieves the address of the first element in the vector, rather than the address of the pointer to the first element in the vector. This PR fixes the incorrect retrieval logic in the C++ code in the bindings file.

Address #1075