### PR TITLE
Fix structure element tree

### DIFF
--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -3097,6 +3097,10 @@ extern "C" SkDocument* C_SkPDF_MakeDocument(SkWStream* stream, const SkPDF::Meta
     return SkPDF::MakeDocument(stream, *metadata).release();
 }
 
+extern "C" void C_SkPDF_SetNodeId(SkCanvas* dst, int nodeID) {
+    return SkPDF::SetNodeId(dst, nodeID);
+}
+
 //
 // pathops/
 //

--- a/skia-safe/src/docs/pdf_document.rs
+++ b/skia-safe/src/docs/pdf_document.rs
@@ -345,6 +345,9 @@ pub mod pdf {
             if let Some(encoding_quality) = metadata.encoding_quality {
                 internal.fEncodingQuality = encoding_quality
             }
+            if let Some(structure_element_tree) = &metadata.structure_element_tree_root {
+                internal.fStructureElementTreeRoot = structure_element_tree.0.as_ptr();
+            }
             internal.fCompressionLevel = metadata.compression_level
         }
 

--- a/skia-safe/src/docs/pdf_document.rs
+++ b/skia-safe/src/docs/pdf_document.rs
@@ -1,6 +1,8 @@
 pub mod pdf {
     use std::{ffi::CString, fmt, io, mem, ptr};
 
+    use crate::Canvas;
+
     use skia_bindings::{
         self as sb, SkPDF_AttributeList, SkPDF_DateTime, SkPDF_Metadata, SkPDF_StructureElementNode,
     };
@@ -379,6 +381,12 @@ pub mod pdf {
     impl Default for Handle<SkPDF_Metadata> {
         fn default() -> Self {
             Self::construct(|pdf_md| unsafe { sb::C_SkPDF_Metadata_Construct(pdf_md) })
+        }
+    }
+
+    pub fn set_node_id(canvas: &Canvas, node_id: i32) {
+        unsafe {
+            sb::C_SkPDF_SetNodeId(canvas.native_mut(), node_id);
         }
     }
 }

--- a/skia-safe/src/docs/pdf_document.rs
+++ b/skia-safe/src/docs/pdf_document.rs
@@ -132,7 +132,7 @@ pub mod pdf {
 
     /// A node in a PDF structure tree, giving a semantic representation
     /// of the content.  Each node ID is associated with content
-    /// by passing the [`crate::Canvas`] and node ID to [`Self::set_node_id()`] when drawing.
+    /// by passing the [`crate::Canvas`] and node ID to [`pdf::set_node_id()`] when drawing.
     /// NodeIDs should be unique within each tree.
     impl StructureElementNode {
         pub fn new(type_string: impl AsRef<str>) -> Self {


### PR DESCRIPTION
Currently there are `StructureElementNode` is defined in the Rust code but it is not passed through when initialising a PDF. `SetNodeId()` is a function which is used to connect nodes in the Structure Element Tree to elements in the Canvas. The structure element tree is used to generate accessibility tagging in a PDF.