### PR TITLE
chore: Improve working with sendable

### DIFF
--- a/skia-safe/src/prelude.rs
+++ b/skia-safe/src/prelude.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 use std::{
+    fmt::Debug,
     hash::{Hash, Hasher},
     marker::PhantomData,
     mem::{self, MaybeUninit},
@@ -980,8 +981,22 @@ pub struct Sendable<H: ConditionallySend>(H);
 unsafe impl<H: ConditionallySend> Send for Sendable<H> {}
 
 impl<H: ConditionallySend> Sendable<H> {
+    #[deprecated(note = "Use Sendable::into_inner() instead")]
     pub fn unwrap(self) -> H {
         self.0
+    }
+
+    pub fn into_inner(self) -> H {
+        self.0
+    }
+}
+
+impl<H> Debug for Sendable<H>
+where
+    H: Debug + ConditionallySend,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Sendable").field(&self.0).finish()
     }
 }
 

--- a/skia-safe/tests/send_sync.rs
+++ b/skia-safe/tests/send_sync.rs
@@ -7,7 +7,7 @@ fn sendable() {
     let mode = BlendMode::ColorBurn;
     let cf = color_filters::blend(color, mode).unwrap();
     let sendable = cf.wrap_send().ok().unwrap();
-    let _unwrapped = sendable.unwrap();
+    let _unwrapped = sendable.into_inner();
 }
 
 /// Test if Sendable<> is actually sendable for RCHandle types.


### PR DESCRIPTION
Currently it is impossible to have Sendabale wrapper on the debuggagble struct + the `unwrap` method is always adds additional anxiety about panicking while by [rust naming conventions](https://rust-lang.github.io/api-guidelines/naming.html#ad-hoc-conversions-follow-as_-to_-into_-conventions-c-conv) it should be called `into_inner`