### PR TITLE
Centrally declare the minimum supported rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ members = [
     "comment-converter",
 ]
 
+[workspace.package]
+rust-version = "1.82"
+
 [profile.release]
 # We want to build skia-org with with lto="thin"
 # https://github.com/rust-skia/rust-skia/issues/565

--- a/comment-converter/Cargo.toml
+++ b/comment-converter/Cargo.toml
@@ -2,6 +2,7 @@
 name = "comment-converter"
 version = "0.1.0"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 anyhow = "1.0.61"

--- a/mk-workflows/Cargo.toml
+++ b/mk-workflows/Cargo.toml
@@ -3,6 +3,7 @@ name = "mk-workflows"
 version = "0.1.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2021"
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT"
 version = "0.80.1"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2021"
+rust-version.workspace = true
 build = "build.rs"
 links = "skia"
 include = [

--- a/skia-org/Cargo.toml
+++ b/skia-org/Cargo.toml
@@ -20,6 +20,7 @@ license = "MIT"
 version = "1.0.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2021"
+rust-version.workspace = true
 
 default-run = "skia-org"
 

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -21,6 +21,7 @@ license = "MIT"
 version = "0.80.2"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2021"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/skia-svg-macros/Cargo.toml
+++ b/skia-svg-macros/Cargo.toml
@@ -4,6 +4,7 @@ name = "skia-svg-macros"
 description = "Skia SVG Macros for Dom bindings"
 version = "0.1.0"
 edition = "2021"
+rust-version.workspace = true
 
 homepage = "https://github.com/rust-skia/rust-skia"
 repository = "https://github.com/rust-skia/rust-skia"


### PR DESCRIPTION
This way, cargo reports a cleaner error instead of something obscure, when building with an older version.