### PR TITLE
Milestone 133

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![Windows QA](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml) [![Linux QA](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml) [![macOS QA](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml)
 
-Skia Submodule Status: chrome/m132 ([upstream changes][skia-upstream], [our changes][skia-ours]).
+Skia Submodule Status: chrome/m133 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m132-0.81.0...google:chrome/m132
-[skia-ours]: https://github.com/google/skia/compare/chrome/m132...rust-skia:m132-0.81.0
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m133-0.81.0...google:chrome/m133
+[skia-ours]: https://github.com/google/skia/compare/chrome/m133...rust-skia:m133-0.81.0
 
 ## About
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.81.0"
+version = "0.82.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2021"
 rust-version.workspace = true

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -31,7 +31,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download the Skia archive from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m132-0.81.0"
+skia = "m133-0.81.0"
 
 [features]
 default = ["binary-cache", "embed-icudtl"]

--- a/skia-bindings/build_support/skia_bindgen.rs
+++ b/skia-bindings/build_support/skia_bindgen.rs
@@ -734,6 +734,8 @@ const ENUM_REWRITES: &[EnumEntry] = &[
     ("GrMarkFrameBoundary", rewrite::k_xxx),
     // SkResources.h
     ("ImageDecodeStrategy", rewrite::k_xxx),
+    // SkNamedPrimaries::CicpId, SkNamedTransferFn::CicpId
+    ("CicpId", rewrite::k_xxx),
 ];
 
 pub(crate) mod rewrite {

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -979,6 +979,12 @@ extern "C" SkColorSpace* C_SkColorSpace_MakeSRGBLinear() {
     return SkColorSpace::MakeSRGBLinear().release();
 }
 
+extern "C" SkColorSpace* C_SkColorSpace_MakeCICP(
+    SkNamedPrimaries::CicpId colorPrimaries,
+    SkNamedTransferFn::CicpId transferCharacteristics) {
+    return SkColorSpace::MakeCICP(colorPrimaries, transferCharacteristics).release();
+}
+
 extern "C" SkColorSpace* C_SkColorSpace_makeLinearGamma(const SkColorSpace* self) {
     return self->makeLinearGamma().release();
 }
@@ -997,6 +1003,14 @@ extern "C" SkData* C_SkColorSpace_serialize(const SkColorSpace* self) {
 
 extern "C" SkColorSpace* C_SkColorSpace_Deserialize(const void* data, size_t length) {
     return SkColorSpace::Deserialize(data, length).release();
+}
+
+extern "C" uint32_t C_SkColorSpace_transferFnHash(const SkColorSpace* self) {
+    return self->transferFnHash();
+}
+
+extern "C" uint64_t C_SkColorSpace_hash(const SkColorSpace* self) {
+    return self->hash();
 }
 
 //

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1361,6 +1361,10 @@ extern "C" SkTextBlob* C_SkTextBlobBuilder_make(SkTextBlobBuilder* self) {
 // core/SkTypeface.h
 //
 
+extern "C" void C_SkTypeface_fontStyle(const SkTypeface* self, SkFontStyle* uninitialized) {
+    new (uninitialized) SkFontStyle(self->fontStyle());
+}
+
 extern "C" SkTypeface* C_SkTypeface_makeClone(const SkTypeface* self, const SkFontArguments* arguments) {
     return self->makeClone(*arguments).release();
 }

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1347,14 +1347,6 @@ extern "C" SkTextBlob* C_SkTextBlobBuilder_make(SkTextBlobBuilder* self) {
 // core/SkTypeface.h
 //
 
-extern "C" bool C_SkTypeface_isBold(const SkTypeface* self) {
-    return self->isBold();
-}
-
-extern "C" bool C_SkTypeface_isItalic(const SkTypeface* self) {
-    return self->isItalic();
-}
-
 extern "C" SkTypeface* C_SkTypeface_makeClone(const SkTypeface* self, const SkFontArguments* arguments) {
     return self->makeClone(*arguments).release();
 }

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -18,7 +18,7 @@ categories = [
 ]
 license = "MIT"
 
-version = "0.81.0"
+version = "0.82.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2021"
 rust-version.workspace = true
@@ -62,7 +62,7 @@ vulkan-window = ["dep:ash", "dep:vulkano", "winit/rwh_05"]
 [dependencies]
 bitflags = "2.0"
 lazy_static = "1.4"
-skia-bindings = { version = "=0.81.0", path = "../skia-bindings", default-features = false }
+skia-bindings = { version = "=0.82.0", path = "../skia-bindings", default-features = false }
 
 # vulkan-window example
 ash = { version = "^0.37.3", optional = true }

--- a/skia-safe/src/core/color_space.rs
+++ b/skia-safe/src/core/color_space.rs
@@ -1,7 +1,7 @@
 use super::Data;
 use crate::prelude::*;
 use sb::SkNVRefCnt;
-use skia_bindings::{self as sb, SkColorSpace, SkColorSpacePrimaries};
+use skia_bindings::{self as sb, skcms_TransferFunction, SkColorSpace, SkColorSpacePrimaries};
 use std::fmt;
 
 #[derive(Clone, PartialEq, Debug)]
@@ -34,9 +34,154 @@ pub struct ColorSpaceTransferFn {
     pub f: f32,
 }
 
+native_transmutable!(
+    skcms_TransferFunction,
+    ColorSpaceTransferFn,
+    color_space_transfer_fn_layout
+);
+
+/// Color primaries defined by ITU-T H.273, table 2. Names are given by the first
+/// specification referenced in the value's row.
+pub mod named_primaries {
+    use super::ColorSpacePrimaries;
+    use skia_bindings::SkNamedPrimaries_CicpId;
+
+    /// Rec. ITU-R BT.709-6, value 1.
+    pub const REC709: ColorSpacePrimaries = ColorSpacePrimaries {
+        rx: 0.64,
+        ry: 0.33,
+        gx: 0.3,
+        gy: 0.6,
+        bx: 0.15,
+        by: 0.06,
+        wx: 0.3127,
+        wy: 0.329,
+    };
+
+    /// Rec. ITU-R BT.470-6 System M (historical), value 4.
+    pub const REC470_SYSTEM_M: ColorSpacePrimaries = ColorSpacePrimaries {
+        rx: 0.67,
+        ry: 0.33,
+        gx: 0.21,
+        gy: 0.71,
+        bx: 0.14,
+        by: 0.08,
+        wx: 0.31,
+        wy: 0.316,
+    };
+
+    /// Rec. ITU-R BT.470-6 System B, G (historical), value 5.
+    pub const REC470_SYSTEM_BG: ColorSpacePrimaries = ColorSpacePrimaries {
+        rx: 0.64,
+        ry: 0.33,
+        gx: 0.29,
+        gy: 0.60,
+        bx: 0.15,
+        by: 0.06,
+        wx: 0.3127,
+        wy: 0.3290,
+    };
+
+    /// Rec. ITU-R BT.601-7 525, value 6.
+    pub const REC601: ColorSpacePrimaries = ColorSpacePrimaries {
+        rx: 0.630,
+        ry: 0.340,
+        gx: 0.310,
+        gy: 0.595,
+        bx: 0.155,
+        by: 0.070,
+        wx: 0.3127,
+        wy: 0.3290,
+    };
+
+    /// SMPTE ST 240, value 7 (functionally the same as value 6).
+    pub const SMPTE_ST_240: ColorSpacePrimaries = REC601;
+
+    /// Generic film (colour filters using Illuminant C), value 8.
+    pub const GENERIC_FILM: ColorSpacePrimaries = ColorSpacePrimaries {
+        rx: 0.681,
+        ry: 0.319,
+        gx: 0.243,
+        gy: 0.692,
+        bx: 0.145,
+        by: 0.049,
+        wx: 0.310,
+        wy: 0.316,
+    };
+
+    /// Rec. ITU-R BT.2020-2, value 9.
+    pub const REC2020: ColorSpacePrimaries = ColorSpacePrimaries {
+        rx: 0.708,
+        ry: 0.292,
+        gx: 0.170,
+        gy: 0.797,
+        bx: 0.131,
+        by: 0.046,
+        wx: 0.3127,
+        wy: 0.3290,
+    };
+
+    /// SMPTE ST 428-1, value 10.
+    pub const SMPTE_ST_428_1: ColorSpacePrimaries = ColorSpacePrimaries {
+        rx: 1.0,
+        ry: 0.0,
+        gx: 0.0,
+        gy: 1.0,
+        bx: 0.0,
+        by: 0.0,
+        wx: 1.0 / 3.0,
+        wy: 1.0 / 3.0,
+    };
+
+    /// SMPTE RP 431-2, value 11.
+    pub const SMPTE_RP_431_2: ColorSpacePrimaries = ColorSpacePrimaries {
+        rx: 0.680,
+        ry: 0.320,
+        gx: 0.265,
+        gy: 0.690,
+        bx: 0.150,
+        by: 0.060,
+        wx: 0.314,
+        wy: 0.351,
+    };
+
+    /// SMPTE EG 432-1, value 12.
+    pub const SMPTE_EG_432_1: ColorSpacePrimaries = ColorSpacePrimaries {
+        rx: 0.680,
+        ry: 0.320,
+        gx: 0.265,
+        gy: 0.690,
+        bx: 0.150,
+        by: 0.060,
+        wx: 0.3127,
+        wy: 0.3290,
+    };
+
+    /// No corresponding industry specification identified, value 22.
+    /// This is sometimes referred to as EBU 3213-E, but that document doesn't
+    /// specify these values.
+    pub const ITU_T_H273_VALUE22: ColorSpacePrimaries = ColorSpacePrimaries {
+        rx: 0.630,
+        ry: 0.340,
+        gx: 0.295,
+        gy: 0.605,
+        bx: 0.155,
+        by: 0.077,
+        wx: 0.3127,
+        wy: 0.3290,
+    };
+
+    /// Mapping between names of color primaries and the number of the corresponding
+    /// row in ITU-T H.273, table 2.  As above, the constants are named based on the
+    /// first specification referenced in the value's row.
+    pub type CicpId = SkNamedPrimaries_CicpId;
+    variant_name!(CicpId::GenericFilm);
+}
+
 // TODO: Make the binding generator provide all these constants.
 pub mod named_transfer_fn {
     use crate::ColorSpaceTransferFn;
+    use skia_bindings::SkNamedTransferFn_CicpId;
 
     pub const SRGB: ColorSpaceTransferFn = ColorSpaceTransferFn {
         g: 2.4,
@@ -58,6 +203,56 @@ pub mod named_transfer_fn {
         f: 0.0,
     };
 
+    /// Rec. ITU-R BT.709-6, value 1.
+    #[allow(clippy::excessive_precision)]
+    pub const REC709: ColorSpaceTransferFn = ColorSpaceTransferFn {
+        g: 2.222222222222,
+        a: 0.909672415686,
+        b: 0.090327584314,
+        c: 0.222222222222,
+        d: 0.081242858299,
+        e: 0.0,
+        f: 0.0,
+    };
+
+    /// Rec. ITU-R BT.470-6 System M (historical) assumed display gamma 2.2, value 4.
+    pub const REC470_SYSTEM_M: ColorSpaceTransferFn = ColorSpaceTransferFn {
+        g: 2.2,
+        a: 1.0,
+        b: 0.0,
+        c: 0.0,
+        d: 0.0,
+        e: 0.0,
+        f: 0.0,
+    };
+
+    /// Rec. ITU-R BT.470-6 System B, G (historical) assumed display gamma 2.8, value 5.
+    pub const REC470_SYSTEM_BG: ColorSpaceTransferFn = ColorSpaceTransferFn {
+        g: 2.8,
+        a: 1.0,
+        b: 0.0,
+        c: 0.0,
+        d: 0.0,
+        e: 0.0,
+        f: 0.0,
+    };
+
+    /// Rec. ITU-R BT.601-7, same as kRec709, value 6.
+    pub const REC601: ColorSpaceTransferFn = REC709;
+
+    /// SMPTE ST 240, value 7.
+    #[allow(clippy::excessive_precision)]
+    pub const SMPTE_ST_240: ColorSpaceTransferFn = ColorSpaceTransferFn {
+        g: 2.222222222222,
+        a: 0.899626676224,
+        b: 0.100373323776,
+        c: 0.25,
+        d: 0.091286342118,
+        e: 0.0,
+        f: 0.0,
+    };
+
+    /// Linear, value 8
     pub const LINEAR: ColorSpaceTransferFn = ColorSpaceTransferFn {
         g: 1.0,
         a: 1.0,
@@ -68,16 +263,19 @@ pub mod named_transfer_fn {
         f: 0.0,
     };
 
-    pub const REC2020: ColorSpaceTransferFn = ColorSpaceTransferFn {
-        g: 2.22222,
-        a: 0.909_672,
-        b: 0.090_327_6,
-        c: 0.222_222,
-        d: 0.081_242_9,
-        e: 0.0,
-        f: 0.0,
-    };
+    /// IEC 61966-2-4, value 11, same as REC709 (but is explicitly extended).
+    pub const IEC61966_2_4: ColorSpaceTransferFn = REC709;
 
+    /// IEC 61966-2-1 sRGB, value 13.
+    pub const IEC61966_2_1: ColorSpaceTransferFn = SRGB;
+
+    /// Rec. ITU-R BT.2020-2 (10-bit system), value 14.
+    pub const REC2020_10BIT: ColorSpaceTransferFn = REC709;
+
+    /// Rec. ITU-R BT.2020-2 (12-bit system), value 15.
+    pub const REC2020_12BIT: ColorSpaceTransferFn = REC709;
+
+    /// Rec. ITU-R BT.2100-2 perceptual quantization (PQ) system, value 16.
     pub const PQ: ColorSpaceTransferFn = ColorSpaceTransferFn {
         g: -2.0,
         a: -107.0 / 128.0,
@@ -88,6 +286,19 @@ pub mod named_transfer_fn {
         f: 8192.0 / 1305.0,
     };
 
+    /// SMPTE ST 428-1, value 17.
+    #[allow(clippy::excessive_precision)]
+    pub const SMPTE_ST_428_1: ColorSpaceTransferFn = ColorSpaceTransferFn {
+        g: 2.6,
+        a: 1.034080527699,
+        b: 0.0,
+        c: 0.0,
+        d: 0.0,
+        e: 0.0,
+        f: 0.0,
+    };
+
+    /// Rec. ITU-R BT.2100-2 hybrid log-gamma (HLG) system, value 18.
     #[allow(clippy::excessive_precision)]
     pub const HLG: ColorSpaceTransferFn = ColorSpaceTransferFn {
         g: -3.0,
@@ -98,7 +309,15 @@ pub mod named_transfer_fn {
         e: 0.559_910_73,
         f: 0.0,
     };
+
+    /// Mapping between transfer function names and the number of the corresponding
+    /// row in ITU-T H.273, table 3.  As above, the constants are named based on the
+    /// first specification referenced in the value's row.
+    pub type CicpId = SkNamedTransferFn_CicpId;
+    variant_name!(CicpId::Linear);
 }
+
+// TODO: SkNamedGamut
 
 pub type ColorSpace = RCHandle<SkColorSpace>;
 unsafe_send_sync!(ColorSpace);
@@ -139,6 +358,15 @@ impl ColorSpace {
         Self::from_ptr(unsafe { sb::C_SkColorSpace_MakeSRGBLinear() }).unwrap()
     }
 
+    // TODO: makeRGB
+
+    pub fn new_cicp(
+        primaries: named_primaries::CicpId,
+        transfer_characteristics: named_transfer_fn::CicpId,
+    ) -> Option<Self> {
+        Self::from_ptr(unsafe { sb::C_SkColorSpace_MakeCICP(primaries, transfer_characteristics) })
+    }
+
     pub fn to_xyzd50_hash(&self) -> XYZD50Hash {
         XYZD50Hash(self.native().fToXYZD50Hash)
     }
@@ -175,11 +403,43 @@ impl ColorSpace {
             .unwrap()
     }
 
-    // TODO: transferFn()
-    // TODO: invTransferFn()
+    pub fn transfer_fn(&self) -> ColorSpaceTransferFn {
+        let mut transfer_fn = ColorSpaceTransferFn {
+            g: 0.0,
+            a: 0.0,
+            b: 0.0,
+            c: 0.0,
+            d: 0.0,
+            e: 0.0,
+            f: 0.0,
+        };
+        unsafe { self.native().transferFn1(transfer_fn.native_mut()) };
+        transfer_fn
+    }
+
+    pub fn inv_transfer_fn(&self) -> ColorSpaceTransferFn {
+        let mut transfer_fn = ColorSpaceTransferFn {
+            g: 0.0,
+            a: 0.0,
+            b: 0.0,
+            c: 0.0,
+            d: 0.0,
+            e: 0.0,
+            f: 0.0,
+        };
+        unsafe { self.native().invTransferFn(transfer_fn.native_mut()) };
+        transfer_fn
+    }
+
     // TODO: gamutTransformTo()
-    // TODO: transferFnHash()?
-    // TODO: hash()?
+
+    pub fn transfer_fn_hash(&self) -> u32 {
+        unsafe { sb::C_SkColorSpace_transferFnHash(self.native()) }
+    }
+
+    pub fn hash(&self) -> u64 {
+        unsafe { sb::C_SkColorSpace_hash(self.native()) }
+    }
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]

--- a/skia-safe/src/core/mask_filter.rs
+++ b/skia-safe/src/core/mask_filter.rs
@@ -1,6 +1,8 @@
-use crate::{prelude::*, scalar, BlurStyle, CoverageMode, Matrix, NativeFlattenable};
-use skia_bindings::{self as sb, SkFlattenable, SkMaskFilter, SkRefCntBase};
 use std::fmt;
+
+use skia_bindings::{self as sb, SkFlattenable, SkMaskFilter, SkRefCntBase};
+
+use crate::{prelude::*, scalar, BlurStyle, NativeFlattenable};
 
 /// MaskFilter is the base class for object that perform transformations on the mask before drawing
 /// it. An example subclass is Blur.
@@ -46,20 +48,5 @@ impl MaskFilter {
         Self::from_ptr(unsafe {
             sb::C_SkMaskFilter_MakeBlur(style, sigma, respect_ctm.into().unwrap_or(true))
         })
-    }
-
-    #[deprecated(since = "0.30.0", note = "removed without replacement")]
-    pub fn compose(_outer: Self, _inner: Self) -> ! {
-        panic!("removed without replacement")
-    }
-
-    #[deprecated(since = "0.30.0", note = "removed without replacement")]
-    pub fn combine(_filter_a: Self, _filter_b: Self, _mode: CoverageMode) -> ! {
-        panic!("removed without replacement")
-    }
-
-    #[deprecated(since = "0.29.0", note = "removed without replacement")]
-    pub fn with_matrix(&self, _matrix: &Matrix) -> ! {
-        unimplemented!("removed without replacement")
     }
 }

--- a/skia-safe/src/core/mask_filter.rs
+++ b/skia-safe/src/core/mask_filter.rs
@@ -1,4 +1,4 @@
-use crate::{prelude::*, scalar, BlurStyle, CoverageMode, Matrix, NativeFlattenable, Rect};
+use crate::{prelude::*, scalar, BlurStyle, CoverageMode, Matrix, NativeFlattenable};
 use skia_bindings::{self as sb, SkFlattenable, SkMaskFilter, SkRefCntBase};
 use std::fmt;
 
@@ -45,15 +45,6 @@ impl MaskFilter {
     ) -> Option<Self> {
         Self::from_ptr(unsafe {
             sb::C_SkMaskFilter_MakeBlur(style, sigma, respect_ctm.into().unwrap_or(true))
-        })
-    }
-
-    /// Returns the approximate bounds that would result from filtering the `src` rect. The actual
-    /// result may be different, but it should be contained within the returned bounds.
-    pub fn approximate_filtered_bounds(&self, src: impl AsRef<Rect>) -> Rect {
-        Rect::from_native_c(unsafe {
-            self.native()
-                .approximateFilteredBounds(src.as_ref().native())
         })
     }
 

--- a/skia-safe/src/core/milestone.rs
+++ b/skia-safe/src/core/milestone.rs
@@ -1,1 +1,1 @@
-pub const MILESTONE: usize = 132;
+pub const MILESTONE: usize = 133;

--- a/skia-safe/src/core/typeface.rs
+++ b/skia-safe/src/core/typeface.rs
@@ -45,19 +45,19 @@ impl fmt::Debug for Typeface {
 
 impl Typeface {
     pub fn font_style(&self) -> FontStyle {
-        FontStyle::from_native_c(self.native().fStyle)
+        FontStyle::from_native_c(unsafe { self.native().fontStyle() })
     }
 
     pub fn is_bold(&self) -> bool {
-        unsafe { sb::C_SkTypeface_isBold(self.native()) }
+        unsafe { self.native().isBold() }
     }
 
     pub fn is_italic(&self) -> bool {
-        unsafe { sb::C_SkTypeface_isItalic(self.native()) }
+        unsafe { self.native().isItalic() }
     }
 
     pub fn is_fixed_pitch(&self) -> bool {
-        self.native().fIsFixedPitch
+        unsafe { self.native().isFixedPitch() }
     }
 
     pub fn variation_design_position(

--- a/skia-safe/src/core/typeface.rs
+++ b/skia-safe/src/core/typeface.rs
@@ -245,6 +245,15 @@ impl Typeface {
             .if_true_then_some(|| name.as_str().into())
     }
 
+    pub fn resource_name(&self) -> Option<String> {
+        let mut name = interop::String::default();
+        let num_resources = unsafe { self.native().getResourceName(name.native_mut()) };
+        if num_resources == 0 {
+            return None;
+        }
+        Some(name.as_str().into())
+    }
+
     pub fn to_font_data(&self) -> Option<(Vec<u8>, usize)> {
         let mut ttc_index = 0;
         StreamAsset::from_ptr(unsafe { sb::C_SkTypeface_openStream(self.native(), &mut ttc_index) })

--- a/skia-safe/src/core/typeface.rs
+++ b/skia-safe/src/core/typeface.rs
@@ -45,7 +45,7 @@ impl fmt::Debug for Typeface {
 
 impl Typeface {
     pub fn font_style(&self) -> FontStyle {
-        FontStyle::from_native_c(unsafe { self.native().fontStyle() })
+        FontStyle::construct(|fs| unsafe { sb::C_SkTypeface_fontStyle(self.native(), fs) })
     }
 
     pub fn is_bold(&self) -> bool {

--- a/skia-safe/src/encode_/png_encoder.rs
+++ b/skia-safe/src/encode_/png_encoder.rs
@@ -25,6 +25,7 @@ pub struct Options {
     pub comments: Vec<Comment>,
     // TODO: ICCProfile
     // TODO: ICCProfileDescription
+    // TODO: If SkGainmapInfo get out of private/ : fGainmap fGainmapInfo
 }
 
 impl Default for Options {

--- a/skia-safe/src/gpu/ganesh/direct_context.rs
+++ b/skia-safe/src/gpu/ganesh/direct_context.rs
@@ -10,8 +10,8 @@ use skia_bindings::{self as sb, GrDirectContext, GrDirectContext_DirectContextID
 use crate::{
     gpu::{
         BackendFormat, BackendRenderTarget, BackendTexture, ContextOptions, FlushInfo,
-        MutableTextureState, PurgeResourceOptions, RecordingContext, SemaphoresSubmitted,
-        SubmitInfo, SyncCpu,
+        GpuStatsFlags, MutableTextureState, PurgeResourceOptions, RecordingContext,
+        SemaphoresSubmitted, SubmitInfo, SyncCpu,
     },
     prelude::*,
     surfaces, Data, Image, Surface, TextureCompressionType,
@@ -228,6 +228,10 @@ impl DirectContext {
     pub fn purge_unlocked_resources(&mut self, opts: PurgeResourceOptions) -> &mut Self {
         unsafe { self.native_mut().purgeUnlockedResources1(opts) }
         self
+    }
+
+    pub fn supported_gpu_stats(&self) -> GpuStatsFlags {
+        GpuStatsFlags::from_bits_truncate(unsafe { self.native().supportedGpuStats() })
     }
 
     // TODO: wait()

--- a/skia-safe/src/gpu/ganesh/types.rs
+++ b/skia-safe/src/gpu/ganesh/types.rs
@@ -1,6 +1,7 @@
 use std::ptr;
 
 use crate::gpu;
+use crate::gpu::GpuStatsFlags;
 use skia_bindings as sb;
 
 pub use skia_bindings::GrBackendApi as BackendApi;
@@ -28,8 +29,10 @@ variant_name!(SurfaceOrigin::BottomLeft);
 pub struct FlushInfo {
     // TODO: wrap access to the following fields in a safe way:
     num_semaphores: usize,
+    gpu_stats_flags: GpuStatsFlags,
     signal_semaphores: *mut sb::GrBackendSemaphore,
     finished_proc: sb::GrGpuFinishedProc,
+    finished_with_stats_proc: sb::GrGpuFinishedWithStatsProc,
     finished_context: sb::GrGpuFinishedContext,
     submitted_proc: sb::GrGpuSubmittedProc,
     submitted_context: sb::GrGpuSubmittedContext,
@@ -39,8 +42,10 @@ impl Default for FlushInfo {
     fn default() -> Self {
         Self {
             num_semaphores: 0,
+            gpu_stats_flags: GpuStatsFlags::NONE,
             signal_semaphores: ptr::null_mut(),
             finished_proc: None,
+            finished_with_stats_proc: None,
             finished_context: ptr::null_mut(),
             submitted_proc: None,
             submitted_context: ptr::null_mut(),

--- a/skia-safe/src/gpu/types.rs
+++ b/skia-safe/src/gpu/types.rs
@@ -1,4 +1,5 @@
 use skia_bindings as sb;
+use skia_bindings::skgpu_GpuStats;
 
 pub use sb::skgpu_BackendApi as BackendApi;
 variant_name!(BackendApi::Metal);
@@ -27,3 +28,19 @@ variant_name!(Renderable::No);
 
 pub use skia_bindings::skgpu_Origin as Origin;
 variant_name!(Origin::TopLeft);
+
+bitflags! {
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub struct GpuStatsFlags : u32 {
+        const NONE = sb::skgpu_GpuStatsFlags_kNone as _;
+        const ELAPSED_TIME = sb::skgpu_GpuStatsFlags_kElapsedTime as _;
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct GpuStats {
+    pub elapsed_time: u64,
+}
+
+native_transmutable!(skgpu_GpuStats, GpuStats, gpu_stats_layout);

--- a/skia-safe/tests/send_sync.rs
+++ b/skia-safe/tests/send_sync.rs
@@ -47,6 +47,10 @@ mod core {
     assert_not_impl_any!(OwnedCanvas: Send, Sync);
     assert_impl_all!(Color: Send, Sync);
     assert_impl_all!(ColorFilter: Send, Sync);
+    assert_impl_all!(ColorSpacePrimaries: Send, Sync);
+    assert_impl_all!(named_primaries::CicpId: Send, Sync);
+    assert_impl_all!(ColorSpaceTransferFn: Send, Sync);
+    assert_impl_all!(named_transfer_fn::CicpId: Send, Sync);
     assert_impl_all!(ColorSpace: Send, Sync);
     assert_impl_all!(ColorTable: Send, Sync);
     assert_impl_all!(ContourMeasure: Send, Sync);
@@ -185,6 +189,8 @@ mod gpu {
     assert_impl_all!(Protected: Send, Sync);
     assert_impl_all!(Renderable: Send, Sync);
     assert_impl_all!(Origin: Send, Sync);
+    assert_impl_all!(GpuStatsFlags: Send, Sync);
+    assert_impl_all!(GpuStats: Send, Sync);
 
     // gpu/ganesh/types.rs
     assert_impl_all!(SurfaceOrigin: Send, Sync);


### PR DESCRIPTION
This PR aligns rust-skia with Skia's `chrome/m133` branch.

- [x] Update `README.md` ([rendered](https://github.com/pragmatrix/rust-skia/blob/m133/README.md))  
  > Most important here is to change the Skia branch name and the current Skia submodule tag at the top of the `README.md` file.
- [x] Diff the the following files to see if the build organization has changed significantly:
  - [x] `/BUILD.gn`
  - [x] `/gn/*` (recursively)
  - [x] `/modules/skshaper/BUILD.gn`
  - [x] `/modules/skshaper/skshaper.gni`
  - [x] `/modules/paragraph/BUILD.gn`
  - [x] `/modules/paragraph/skparagraph.gni`
- [x] Skia builds ([release notes](https://github.com/google/skia/blob/chrome/m33/RELEASE_NOTES.md)).
- [x] `/skia-bindings` builds.
- [x] `/skia-safe`: Update & add new wrappers by diffing include files.  
  > Add TODOs for everything that can not be updated right now, and attempt to stay compatible with previous versions of skia-safe without trying too hard before version 1.0. Use `deprecated` attributes if needed.
  - [x] `codec/`
  - [x] `core/`
  - [x] `docs/`
  - [x] `effects/`
  - [x] `encode/`
  - [x] `gpu/`
    - [x] `d3d/`
    - [x] `ganesh/`
    - [x] `gl/`
    - [x] `mtl/`
    - [x] `vk/`
  - [x] `pathops/`
  - [x] `svg/`
  - [x] `utils/`
  - [x] `modules/`
    - [x] `paragraph/`
    - [x] `shaper/`
    - [x] `skresources/`
    - [x] `svg/`
  - [x] `private/base/*`
    - [x] `SkPoint_impl.h`
- [x] Review `Send` & `Sync` implementations for new wrappers.
- [x] Review `Debug` implementation for new wrapper types and functions.
- [x] Release date of the matching Chrome version in less than 7 days?
- [x] Any pending changes in the Skia `chrome/m133` branch that aren't synchronized yet? (only fontations related) 
- [x] Rebase on or merge with master.
- [x] Do the `rust-skia:` commits in the `skia-bindings/skia` subdirectory match with `master` (`make diff-skia`).
- [x] Update versions of `skia-bindings/Cargo.toml` and `skia-safe/Cargo.toml` and also add the version to the new `deprecated` attributes.
- [x] Does the tag/hash in `skia-bindings/Cargo.toml` under `[package.metadata]` match the `skia` submodule?
- [x] Review API changes: `make diff-api`.
- [x] Do one final review of all the changes.
- [x] Run `make doc` and fix all warnings.

