### PR TITLE
Preserve curl outputs

### DIFF
--- a/skia-bindings/build_support/binary_cache/utils.rs
+++ b/skia-bindings/build_support/binary_cache/utils.rs
@@ -24,8 +24,8 @@ pub fn download(url: impl AsRef<str>) -> io::Result<Vec<u8>> {
         // fail fast with no "error pages" output. more of a hint though, so we might still get error on stdout.
         // so make sure to check the actual status returned.
         .arg("-f")
-        // silent. no progress or error messages. only pure "response data"
-        .arg("-s")
+        // no progress meter but keep error messages.
+        .arg("--no-progress-meter")
         .arg(url)
         .output();
     match resp {
@@ -39,8 +39,11 @@ pub fn download(url: impl AsRef<str>) -> io::Result<Vec<u8>> {
                     io::ErrorKind::Other,
                     format!(
                         "curl error code: {:?}\ncurl stderr: {:?}",
-                        out.status.code(),
-                        std::str::from_utf8(&out.stderr)
+                        out.status
+                            .code()
+                            .map(|i| i.to_string())
+                            .unwrap_or(String::from("no status code")),
+                        std::str::from_utf8(&out.stderr).unwrap_or("no stderr")
                     ),
                 ))
             }


### PR DESCRIPTION
Hello,

I was trying to use `skia-safe` on my windows machine today and was unable to resolve a build error coming from the skia binaries download. I was able to track this down to the flags used to invoke `curl`.

The `-s` option swallows all output. This means that, even though the build script will report the stderr stream on failure, there is nothing in the string (so I was unable to see the `404`). 

The flag [`--no-progress-meter` was added in `curl 7.67.0`](https://curl.se/docs/manpage.html) to hide the progress stream while keeping any error stream.

The values passed into the `Err` are also still wrapped in `Option<_>`, so I added a bit to unwrap those and make the reported errors a bit cleaner.

### Example output

```console
  --- stdout
  cargo:rerun-if-env-changed=DOCS_RS
  cargo:rerun-if-env-changed=SKIA_DEBUG
  cargo:rerun-if-env-changed=SKIA_SOURCE_DIR
  cargo:rerun-if-env-changed=FORCE_SKIA_BUILD
  cargo:rerun-if-env-changed=FORCE_SKIA_BINARIES_DOWNLOAD
  TRYING TO DOWNLOAD AND INSTALL SKIA BINARIES: 0.83.0/9b7918e9ae25c7529a24-x86_64-pc-windows-msvc
  cargo:rerun-if-env-changed=SKIA_BINARIES_URL
    FROM: https://github.com/rust-skia/skia-binaries/releases/download/0.83.0/skia-binaries-9b7918e9ae25c7529a24-x86_64-pc-windows-msvc.tar.gz
  DOWNLOAD AND INSTALL FAILED: curl error code: "22"
  curl stderr: "curl: (22) The requested URL returned error: 404\r\n"
```