### PR TITLE
add no-compile feature to prevent falling back to a compile

### DIFF
--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -55,6 +55,7 @@ binary-cache = ["flate2", "tar"]
 embed-icudtl = ["lazy_static"]
 embed-freetype = []
 freetype-woff2 = []
+no-compile = []
 
 [dependencies]
 mozjpeg-sys = { version = "2", features = ["with_simd"], optional = true }

--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -43,6 +43,10 @@ fn main() -> Result<(), io::Error> {
                 None,
             );
         } else {
+            if cfg!(feature = "no-compile") {
+                panic!("refusing to offline-build skia with no-compile feature");
+            }
+
             println!("STARTING OFFLINE BUILD");
 
             let final_build_configuration = build_from_source(
@@ -85,6 +89,10 @@ fn main() -> Result<(), io::Error> {
         //
 
         if build_skia {
+            if cfg!(feature = "no-compile") {
+                panic!("refusing to full-build skia with no-compile feature");
+            }
+
             println!("STARTING A FULL BUILD");
             println!("HOST: {}", cargo::host());
 

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -49,6 +49,7 @@ binary-cache = ["skia-bindings/binary-cache"]
 embed-icudtl = ["skia-bindings/embed-icudtl"]
 embed-freetype = ["skia-bindings/embed-freetype"]
 freetype-woff2 = ["skia-bindings/freetype-woff2"]
+no-compile = ["skia-bindings/no-compile"]
 # test only
 save-svg-images = []
 


### PR DESCRIPTION
I'm packaging and caching correct rust-skia binaries at an earlier stage in my build pipeline - I don't want my app builders to fall back to a full skia build. This feature flag will give me a cargo-level way to ensure my build is working, instead of implicitly rebuilding skia.