### PR TITLE
add feature shared-library

### DIFF
--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -35,6 +35,7 @@ skia = "m135-0.83.1"
 
 [features]
 default = ["binary-cache", "embed-icudtl"]
+shared-library = []
 gl = []
 egl = []
 wayland = []

--- a/skia-bindings/build_support/binaries_config.rs
+++ b/skia-bindings/build_support/binaries_config.rs
@@ -120,7 +120,14 @@ impl BinariesConfiguration {
 
         let target = cargo::target();
 
-        cargo::add_static_link_libs(&target, self.built_libraries(true));
+        for lib in self.built_libraries(true) {
+            let is_shared = cfg!(feature = "shared-library") && lib != "skia-bindings";
+            if is_shared {
+                cargo::add_link_lib(lib);
+            } else {
+                cargo::add_static_link_lib(&target, lib);
+            }
+        }
         cargo::add_link_libs(&self.link_libraries);
     }
 
@@ -147,7 +154,8 @@ impl BinariesConfiguration {
         let target = cargo::target();
 
         for lib in self.built_libraries(copy_bindings) {
-            let filename = &target.library_to_filename(lib);
+            let is_shared = cfg!(feature = "shared-library") && lib != "skia-bindings";
+            let filename = &target.library_to_filename(lib, is_shared);
             copy(filename, from_dir, to_dir)?;
         }
 

--- a/skia-bindings/build_support/cargo.rs
+++ b/skia-bindings/build_support/cargo.rs
@@ -72,17 +72,28 @@ impl Target {
         self.system == "windows"
     }
 
+    pub fn is_macos(&self) -> bool {
+        self.system == "darwin"
+    }
+
     pub fn builds_with_msvc(&self) -> bool {
         self.abi.as_deref() == Some("msvc")
     }
 
     /// Convert a library name to a filename.
-    pub fn library_to_filename(&self, name: impl AsRef<str>) -> PathBuf {
+    pub fn library_to_filename(&self, name: impl AsRef<str>, shared: bool) -> PathBuf {
         let name = name.as_ref();
-        if self.is_windows() {
-            format!("{name}.lib").into()
+        if shared {
+            match self.system.as_str() {
+                "windows" => format!("{name}.dll").into(),
+                "darwin" => format!("lib{name}.dylib").into(),
+                _ => format!("lib{name}.so").into(),
+            }
         } else {
-            format!("lib{name}.a").into()
+            match self.system.as_str() {
+                "windows" => format!("{name}.lib").into(),
+                _ => format!("lib{name}.a").into(),
+            }
         }
     }
 

--- a/skia-bindings/build_support/features.rs
+++ b/skia-bindings/build_support/features.rs
@@ -2,6 +2,9 @@ use std::collections::HashSet;
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Features {
+    /// Build as a shared library (default is static).
+    pub shared_library: bool,
+
     /// Build with OpenGL support?
     pub gl: bool,
 
@@ -55,6 +58,7 @@ impl Default for Features {
     /// Build a Features set based on the current environment cargo supplies us with.
     fn default() -> Self {
         Features {
+            shared_library: cfg!(feature = "shared-library"),
             gl: cfg!(feature = "gl"),
             egl: cfg!(feature = "egl"),
             wayland: cfg!(feature = "wayland"),
@@ -84,6 +88,9 @@ impl Features {
     pub fn ids(&self) -> HashSet<&str> {
         let mut feature_ids = Vec::new();
 
+        if self.shared_library {
+            feature_ids.push(feature_id::SHARED_LIBRARY);
+        }
         if self.gl {
             feature_ids.push(feature_id::GL);
         }
@@ -130,6 +137,7 @@ impl Features {
 
 /// Feature identifiers define the additional configuration parts of the binaries to download.
 mod feature_id {
+    pub const SHARED_LIBRARY: &str = "shared";
     pub const GL: &str = "gl";
     pub const VULKAN: &str = "vulkan";
     pub const METAL: &str = "metal";

--- a/skia-bindings/build_support/skia/config.rs
+++ b/skia-bindings/build_support/skia/config.rs
@@ -117,6 +117,7 @@ impl FinalBuildConfiguration {
         let gn_args = {
             builder
                 .arg("is_official_build", yes_if(!build.skia_debug))
+                .arg("is_component_build", yes_if(features.shared_library))
                 .arg("is_debug", yes_if(build.skia_debug))
                 .arg("skia_enable_svg", yes_if(features.svg))
                 .arg("skia_enable_gpu", yes_if(features.gpu()))

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -28,6 +28,7 @@ doctest = false
 
 [features]
 default = ["binary-cache", "embed-icudtl"]
+shared-library = ["skia-bindings/shared-library"]
 all-linux = ["gl", "egl", "vulkan", "x11", "wayland", "textlayout", "svg", "webp"]
 all-windows = ["gl", "vulkan", "d3d", "textlayout", "svg", "webp"]
 all-macos = ["gl", "vulkan", "metal", "textlayout", "svg", "webp"]


### PR DESCRIPTION
supporting a shared library build is useful for multiple reasons

- multiple executables can link against the same skia library in an app
- it's harder to cross compile for windows against a msvc static lib

note I'm still not sure about cross-compiling with a msvc skia-bindings.lib, it would be better if we managed to build that into the main skia dll