### PR TITLE
Fix build with Yocto and latest cc crate

### DIFF
--- a/skia-bindings/build_support/skia_bindgen.rs
+++ b/skia-bindings/build_support/skia_bindgen.rs
@@ -250,8 +250,6 @@ pub fn generate_bindings(
         // environment, for example when targeting the ios simulator.
         if override_target {
             cc_args.push(format!("--target={target_str}"));
-        } else {
-            cc_build.target(target_str);
         }
         bindgen_args.push(format!("--target={target_str}"));
     }


### PR DESCRIPTION
Recently, there were a few amount of changes (and partially reverted) changes to the way the cc crate determines the correct compiler arguments. See also https://github.com/rust-lang/cc-rs/issues/1297 and linked issues for discussion.

The general advice is that it should not be necesary to call target(), and in the case of some arm Yocto builds it's even harmful:

When building for arm-poky-linux-gnueabi (a very typical target) and calling target() with that during the skia-bindings build, cc-rs "parses" that the compiler should use soft-float and adds `-mfloat-abi=soft`, while `CC` already has `-mfloat-abi=hard`. Specifying both on the command line means that GCC will abort.

By not calling target(), we stick to cc-rs' own heuristics of determining what's needed, and that works here (avoids adding the conflicting option).