### PR TITLE
add ColorSpace::new_icc()

### DIFF
--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -981,6 +981,14 @@ extern "C" bool C_SkColorSpace_unique(const SkColorSpace* self) {
     return self->unique();
 }
 
+extern "C" SkColorSpace* C_SkColorSpace_MakeICC(const void* buffer, size_t size) {
+    skcms_ICCProfile profile;
+    if (skcms_Parse(buffer, size, &profile)) {
+        return SkColorSpace::Make(profile).release();
+    }
+    return nullptr;
+}
+
 extern "C" SkColorSpace* C_SkColorSpace_MakeSRGB() {
     return SkColorSpace::MakeSRGB().release();
 }

--- a/skia-safe/src/core/color_space.rs
+++ b/skia-safe/src/core/color_space.rs
@@ -385,6 +385,10 @@ impl ColorSpace {
         Self::from_ptr(unsafe { sb::C_SkColorSpace_MakeSRGBLinear() }).unwrap()
     }
 
+    pub fn new_icc(data: &[u8]) -> Option<Self> {
+        Self::from_ptr(unsafe { sb::C_SkColorSpace_MakeICC(data.as_ptr() as _, data.len()) })
+    }
+
     // TODO: makeRGB
 
     pub fn new_cicp(


### PR DESCRIPTION
this makes it possible to create a SkColorSpace from an ICC profile, which can be necessary to make a color accurate SkImage from pixel data