### PR TITLE
fix vulkan renderer example not launching and closing incorrectly

### DIFF
--- a/skia-safe/examples/vulkan-window/main.rs
+++ b/skia-safe/examples/vulkan-window/main.rs
@@ -54,6 +54,7 @@ fn main() {
         ) {
             match event {
                 WindowEvent::CloseRequested => {
+                    self.renderer = None;
                     event_loop.exit();
                 }
                 WindowEvent::Resized(_) => {


### PR DESCRIPTION
wanted to use this example for my graphing calculator but then it didn't launch so i fixed it, as before it didn't correctly force the color type it wanted to use on creation of the window, and if it wasn't defaulted to it then it crashes, also it wasn't handling closing correctly as it needed to properly drop the vulkan renderer it seems, i also added an example onto how to switch vsync mode to immediate if it is applicable, as the vsync seemed really bad on my calculator for some reason(added alot of latency)