### PR TITLE
Ability to build for *-win7-windows-msvc

### DIFF
--- a/skia-bindings/build_support/platform/windows.rs
+++ b/skia-bindings/build_support/platform/windows.rs
@@ -88,6 +88,12 @@ impl PlatformDetails for Generic {
     fn link_libraries(&self, features: &Features) -> Vec<String> {
         generic_link_libraries(features)
     }
+
+    fn bindgen_args(&self, target: &Target, builder: &mut BindgenArgsBuilder) {
+        if let Some(specific_target) = specific_target(target) {
+            builder.override_target(specific_target);
+        }
+    }
 }
 
 fn generic_link_libraries(features: &Features) -> Vec<String> {
@@ -194,4 +200,17 @@ mod llvm {
             _ => None,
         }
     }
+}
+
+fn specific_target(target: &Target) -> Option<&'static str> {
+    if target.vendor == "win7" {
+        if target.architecture == "x86_64" {
+            return Some("x86_64-pc-windows-msvc");
+        }
+        if target.architecture == "i686" {
+            return Some("i686-pc-windows-msvc");
+        }
+    }
+
+    None
 }


### PR DESCRIPTION
Despite the lack of official support, Skia can be used on Windows 7. Rust dropped Windows 7 support for `*-pc-windows-msvc` targets, but added tier-3 `*-win7-windows-msvc`. Building skia-safe with `--target *-win7-windows-msvc` returns error, because C compiler doesn't understand `*-win7-windows-msvc` target. This PR override `*-win7-windows-msvc` target to `*-pc-windows-msvc` for bindgen.

Below proof-of-concept screenshot of Slint gallery example using Skia software renderer

![image_2025-06-04_15-52-03](https://github.com/user-attachments/assets/39df16a2-0ed1-47ec-8c3b-852f848a46e1)
