### PR TITLE
Add Windows Arm64 build for Skia Canvas

### DIFF
--- a/mk-workflows/src/config.rs
+++ b/mk-workflows/src/config.rs
@@ -166,7 +166,10 @@ fn vizia_release_jobs(workflow: &Workflow) -> Vec<Job> {
 fn skia_canvas_release_jobs(workflow: &Workflow) -> Vec<Job> {
     match workflow.host_os {
         HostOS::MacOS => {
-            vec![release_job("metal,textlayout,webp,svg")]
+            vec![
+                release_job("textlayout,webp,svg"),
+                release_job("metal,textlayout,webp,svg")
+            ]
         }
         HostOS::Windows => {
             vec![release_job(

--- a/mk-workflows/src/config.rs
+++ b/mk-workflows/src/config.rs
@@ -174,7 +174,9 @@ fn skia_canvas_release_jobs(workflow: &Workflow) -> Vec<Job> {
             )]
         }
         HostOS::WindowsArm => {
-            vec![]
+            vec![release_job(
+                "vulkan,embed-freetype,freetype-woff2,textlayout,webp,svg",
+            )]
         }
         HostOS::Linux => {
             vec![release_job(

--- a/mk-workflows/src/config.rs
+++ b/mk-workflows/src/config.rs
@@ -168,7 +168,7 @@ fn skia_canvas_release_jobs(workflow: &Workflow) -> Vec<Job> {
         HostOS::MacOS => {
             vec![
                 release_job("textlayout,webp,svg"),
-                release_job("metal,textlayout,webp,svg")
+                release_job("metal,textlayout,webp,svg"),
             ]
         }
         HostOS::Windows => {


### PR DESCRIPTION
Now that github workers support arm-based runners I'd love to add Windows-arm64 support to Skia Canvas. Would you mind adding this additional prebuild job for that (as well as another for mac that will help me with day-to-day development tasks)?

#### Sidenote

Part of the reason prebuilt libraries are so important for Windows is I've never figured out how to successfully get rust-skia to build from source correctly when it's being pulled in as a [cargo dependency](https://github.com/samizdatco/skia-canvas-binaries/blob/713fb99f05197835c2cabf9fa4e20ab697becc35/Cargo.toml#L33). Due (I think?) to cargo's default build locations, it winds up creating a path that's too long for Ninja to handle (though the blame may be shared by whatever part of the build process is choosing to relativize those paths in the first place).

Here's an example [build failure](https://github.com/samizdatco/skia-canvas-binaries/actions/runs/15718833853/job/44295234881) for reference, ending with the lines:
```
  Note: including file:     C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC/Tools/MSVC/14.43.34808/include\vcruntime_string.h
  Note: including file:   C:/Program Files (x86)/Windows Kits/10/Include/10.0.26100.0/ucrt\corecrt_wstring.h
  Note: including file: ../../../../../../../../../Users/runneradmin/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/skia-bindings-0.86.0/skia/third_party/externals/libjpeg-turbo/src\jpeglib.h
  Note: including file:  ../../../../../../../../../Users/runneradmin/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/skia-bindings-0.86.0/skia/third_party/externals/libjpeg-turbo/src\jmorecfg.h
  Note: including file:  ../../../../../../../../../Users/runneradmin/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/skia-bindings-0.86.0/skia/third_party/externals/libjpeg-turbo/src\jpegint.h
  Note: including file:  ../../../../../../../../../Users/runneradmin/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/skia-bindings-0.86.0/skia/third_party/externals/libjpeg-turbo/src\jerror.h
  Note: including file: ../../../../../../../../../Users/runneradmin/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/skia-bindings-0.86.0/skia/third_party/externals/libjpeg-turbo/src\jsimd.h
  Note: including file: ../../../../../../../../../Users/runneradmin/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/skia-bindings-0.86.0/skia/third_party/externals/libjpeg-turbo/src\jsamplecomp.h
  Note: including file: ../../../../../../../../../Users/runneradmin/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/skia-bindings-0.86.0/skia/third_party/externals/libjpeg-turbo/src\jccolext.c
  Note: including file: ../../../../../../../../../Users/runneradmin/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/skia-bindings-0.86.0/skia/third_party/externals/libjpeg-turbo/src\jccolext.c
  Note: including file: ../../../../../../../../../Users/runneradmin/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/skia-bindings-0.86.0/skia/third_party/externals/libjpeg-turbo/src\jccolext.c
  Note: including file: ../../../../../../../../../Users/runneradmin/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/skia-bindings-0.86.0/skia/third_party/externals/libjpeg-turbo/src\jccolext.c
  Note: including file: ../../../../../../../../../Users/runneradmin/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/skia-bindings-0.86.0/skia/third_party/externals/libjpeg-turbo/src\jccolext.c
  Note: including file: ../../../../../../../../../Users/runneradmin/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/skia-bindings-0.86.0/skia/third_party/externals/libjpeg-turbo/src\jccolext.c
  Note: including file: ../../../../../../../../../Users/runneradmin/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/skia-bindings-0.86.0/skia/third_party/externals/libjpeg-turbo/src\jccolext.c
  GetFullPathNameA(../../../../../../../../../Users/runneradmin/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/skia-bindings-0.86.0/skia/third_party/externals/libjpeg-turbo/src/jinclude.h): The filename or extension is too long.
  ninja: build stopped: subcommand failed.
  --- stderr
  Checking for "C:\\Program Files\\LLVM\\bin\\clang-cl.exe"
  thread 'main' panicked at C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\skia-bindings-0.86.0\build_support\skia\config.rs:352:5:
  `ninja` returned an error, please check the output for details.
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

You can take a look at the build environment [here](https://github.com/samizdatco/skia-canvas-binaries/blob/713fb99f05197835c2cabf9fa4e20ab697becc35/.github/workflows/build.yml#L206) though it's directly copied from your own setups.
