### PR TITLE
Review features

### DIFF
--- a/skia-bindings/build_support/features.rs
+++ b/skia-bindings/build_support/features.rs
@@ -41,15 +41,6 @@ pub struct Features {
     /// Build with FreeType embedded.
     pub embed_freetype: bool,
 
-    /// Build with animation support (yet unsupported, no wrappers).
-    pub animation: bool,
-
-    /// Support DNG file format (currently unsupported because of build errors).
-    pub dng: bool,
-
-    /// Build the particles module (unsupported, no wrappers).
-    pub particles: bool,
-
     /// Build with FreeType WOFF2 support.
     pub freetype_woff2: bool,
 }
@@ -71,9 +62,6 @@ impl Default for Features {
             webp_decode: cfg!(feature = "webp-decode"),
             pdf: cfg!(feature = "pdf"),
             embed_freetype: cfg!(feature = "embed-freetype"),
-            animation: false,
-            dng: false,
-            particles: false,
             freetype_woff2: cfg!(feature = "freetype-woff2"),
         }
     }

--- a/skia-bindings/build_support/skia/config.rs
+++ b/skia-bindings/build_support/skia/config.rs
@@ -132,7 +132,6 @@ impl FinalBuildConfiguration {
                 .arg("skia_use_libwebp_decode", yes_if(features.webp_decode))
                 .arg("skia_use_system_zlib", yes_if(use_system_libraries))
                 .arg("skia_use_xps", no())
-                .arg("skia_use_dng_sdk", yes_if(features.dng))
                 .arg(
                     "skia_use_freetype_woff2",
                     yes_if(use_freetype && features.freetype_woff2),

--- a/skia-bindings/build_support/skia/config.rs
+++ b/skia-bindings/build_support/skia/config.rs
@@ -114,6 +114,8 @@ impl FinalBuildConfiguration {
 
         let mut builder = GnArgsBuilder::new(&build.target);
 
+        let use_freetype = platform::uses_freetype(build);
+
         let gn_args = {
             builder
                 .arg("is_official_build", yes_if(!build.skia_debug))
@@ -131,7 +133,10 @@ impl FinalBuildConfiguration {
                 .arg("skia_use_system_zlib", yes_if(use_system_libraries))
                 .arg("skia_use_xps", no())
                 .arg("skia_use_dng_sdk", yes_if(features.dng))
-                .arg("skia_use_freetype_woff2", yes_if(features.freetype_woff2))
+                .arg(
+                    "skia_use_freetype_woff2",
+                    yes_if(use_freetype && features.freetype_woff2),
+                )
                 .arg("cc", quote(&build.cc))
                 .arg("cxx", quote(&build.cxx));
 
@@ -181,7 +186,6 @@ impl FinalBuildConfiguration {
                 builder.arg("skia_use_system_libwebp", yes_if(use_system_libraries));
             }
 
-            let use_freetype = platform::uses_freetype(build);
             builder.arg("skia_use_freetype", yes_if(use_freetype));
             if use_freetype {
                 if features.embed_freetype {


### PR DESCRIPTION
- [ ] Don't enable freetype-woff2 if freetype isn't enabled.
- [ ] Don't enable any feature anymore if the platform does not support it.
  - [ ] Warn about enabled features that aren't supported.
  - [ ] Generate an error if binaries are generated with an unsupported feature set. 