### PR TITLE
fixing example to 'or 1' instead of 'make odd'

### DIFF
--- a/wasm-example/web/main.js
+++ b/wasm-example/web/main.js
@@ -2,8 +2,8 @@
  * Make a canvas element fit to the display window.
  */
 function resizeCanvasToDisplaySize(canvas) {
-  const width = canvas.clientWidth | 1;
-  const height = canvas.clientHeight | 1;
+  const width = canvas.clientWidth || 1;
+  const height = canvas.clientHeight || 1;
   if (canvas.width !== width || canvas.height !== height) {
     canvas.width = width;
     canvas.height = height;


### PR DESCRIPTION
Unless the canvas and thus surface needs to be odd out of some reason I don't understand, I suppose this was a typo.  (If it's made odd on purpose this alternatively needs commenting)