### PR TITLE
Windows arm64 gn fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m138 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m138-0.86.2...google:chrome/m138
-[skia-ours]: https://github.com/google/skia/compare/chrome/m138...rust-skia:m138-0.86.2
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m138-0.87.0...google:chrome/m138
+[skia-ours]: https://github.com/google/skia/compare/chrome/m138...rust-skia:m138-0.87.0
 
 ## About
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -31,7 +31,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download the Skia archive from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m138-0.86.2"
+skia = "m138-0.87.0"
 
 [features]
 default = ["binary-cache", "embed-icudtl", "pdf"]


### PR DESCRIPTION
This changes fetch-gn so that it falls back downloading a Windows AMD64 gn.exe binary if the ARM64 binary is not available.