### PR TITLE
Fix `Rect::from_ltrb` parameter names

### DIFF
--- a/skia-safe/src/core/rect.rs
+++ b/skia-safe/src/core/rect.rs
@@ -386,8 +386,8 @@ impl Rect {
     }
 
     #[must_use]
-    pub fn from_ltrb(l: f32, t: f32, b: f32, r: f32) -> Self {
-        Self::new(l, t, b, r)
+    pub fn from_ltrb(l: f32, t: f32, r: f32, b: f32) -> Self {
+        Self::new(l, t, r, b)
     }
 
     #[must_use]


### PR DESCRIPTION
The parameter names in `Rect::from_ltrb` for right and bottom were swapped (but still correctly forwarded). When using inlay hints in a code editor, this was confusing. This PR swaps the names - nothing functional changes.