### PR TITLE
Add ParagraphStyle option to control whether font weight/slant should be faked

### DIFF
--- a/skia-safe/src/modules/paragraph/paragraph_style.rs
+++ b/skia-safe/src/modules/paragraph/paragraph_style.rs
@@ -319,6 +319,15 @@ impl ParagraphStyle {
         self.native_mut().fApplyRoundingHack = value;
         self
     }
+
+    pub fn fake_missing_font_styles(&self) -> bool {
+        self.native().fFakeMissingFontStyles
+    }
+
+    pub fn set_fake_missing_font_styles(&mut self, value: bool) -> &mut Self {
+        self.native_mut().fFakeMissingFontStyles = value;
+        self
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
When typesetting a `Paragraph` there's currently an automatic behavior where mismatches between available fonts and the requested font style will be ‘fixed’ by generating a fake bold or italic version from an existing typeface.

While this is convenient and often 'good enough', the faked typefaces are not very high quality* and there are cases where it would be preferable to just use the 'closest' available weight/style unmodified. This PR adds rust accessors that build upon the C++ changes in [this PR to Skia](https://github.com/google/skia/pull/207) which makes the weight/slant faking behavior optional.

> *For example, here is the display font Monoton (which only exists as a single normal-weight non-italic font) when the `FontStyle` has been set to bold + italic:
> <img width="1440" height="351" alt="image" src="https://github.com/user-attachments/assets/dcdc7ac1-6bc9-4636-8fef-ceec25a109df" />
