### PR TITLE
Add BBoxHierarchy support to PictureRecorder

### DIFF
--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -25,6 +25,7 @@
 // core/
 #include "include/core/SkAnnotation.h"
 #include "include/core/SkArc.h"
+#include "include/core/SkBBHFactory.h"
 #include "include/core/SkBlendMode.h"
 #include "include/core/SkBitmap.h"
 #include "include/core/SkBlurTypes.h"
@@ -1732,6 +1733,12 @@ extern "C" void C_SkPictureRecorder_Construct(SkPictureRecorder *uninitialized) 
 
 extern "C" void C_SkPictureRecorder_destruct(SkPictureRecorder *self) {
     self->~SkPictureRecorder();
+}
+
+extern "C" SkCanvas* C_SkPictureRecorder_beginRecording(SkPictureRecorder *self, const SkRect* bounds, bool useBBH) {
+    std::unique_ptr<SkBBHFactory> factory;
+    if (useBBH) factory = std::make_unique<SkRTreeFactory>();
+    return self->beginRecording(*bounds, factory.get());
 }
 
 extern "C" SkPicture* C_SkPictureRecorder_finishRecordingAsPicture(SkPictureRecorder* self, const SkRect* cullRect) {

--- a/skia-safe/src/core/picture_recorder.rs
+++ b/skia-safe/src/core/picture_recorder.rs
@@ -23,18 +23,13 @@ impl PictureRecorder {
         Self::construct(|pr| unsafe { sb::C_SkPictureRecorder_Construct(pr) })
     }
 
-    // TODO: beginRecording with BBoxHierarchy
-
     pub fn begin_recording(
         &mut self,
         bounds: impl AsRef<Rect>,
-        mut bbh_factory: Option<&mut BBHFactory>,
+        use_bbh: bool,
     ) -> &Canvas {
-        let canvas_ref = unsafe {
-            &*self.native_mut().beginRecording1(
-                bounds.as_ref().native(),
-                bbh_factory.native_ptr_or_null_mut(),
-            )
+        let canvas_ref = unsafe{
+            &*sb::C_SkPictureRecorder_beginRecording(self.native_mut(), bounds.as_ref().native(), use_bbh)
         };
 
         Canvas::borrow_from_native(canvas_ref)
@@ -101,4 +96,34 @@ fn finishing_recording_two_times() {
 fn not_recording_no_canvas() {
     let mut recorder = PictureRecorder::new();
     assert!(recorder.recording_canvas().is_none());
+}
+
+#[test]
+fn record_with_bbox_hierarchy() {
+  let mut paint = crate::Paint::new(crate::Color4f::new(0.0, 0.0, 0.0, 1.0), None);
+  paint.set_style(crate::PaintStyle::Fill);
+
+  let frame_rect = Rect::new(0.0, 0.0, 100.0, 100.0);
+  let crop_rect = Rect::new(50.0, 50.0, 100.0, 100.0);
+  let drawn_rect = Rect::new(70.0, 70.0, 80.0, 80.0);
+
+  // with bbh disabled, cull rects reflect the arg passed to begin_recording
+  let mut src_rec = PictureRecorder::new();
+  src_rec.begin_recording(frame_rect, false)
+    .draw_rect(drawn_rect, &paint);
+  let picture = src_rec.finish_recording_as_picture(None).unwrap();
+  assert!(picture.cull_rect() == frame_rect);
+
+  let mut no_bbh = PictureRecorder::new();
+  no_bbh.begin_recording(crop_rect, false)
+    .draw_picture(&picture, None, None);
+  let no_bbh_pict = no_bbh.finish_recording_as_picture(None).unwrap();
+  assert!(no_bbh_pict.cull_rect() == crop_rect);
+
+  // with bbh enabled, cull rect contracts to just the content drawn
+  let mut with_bbh = PictureRecorder::new();
+  with_bbh.begin_recording(frame_rect, true)
+    .draw_picture(&picture, None, None);
+  let bbh_pict = with_bbh.finish_recording_as_picture(None).unwrap();
+  assert!(bbh_pict.cull_rect() == drawn_rect);
 }

--- a/skia-safe/src/core/picture_recorder.rs
+++ b/skia-safe/src/core/picture_recorder.rs
@@ -23,13 +23,13 @@ impl PictureRecorder {
         Self::construct(|pr| unsafe { sb::C_SkPictureRecorder_Construct(pr) })
     }
 
-    pub fn begin_recording(
-        &mut self,
-        bounds: impl AsRef<Rect>,
-        use_bbh: bool,
-    ) -> &Canvas {
-        let canvas_ref = unsafe{
-            &*sb::C_SkPictureRecorder_beginRecording(self.native_mut(), bounds.as_ref().native(), use_bbh)
+    pub fn begin_recording(&mut self, bounds: impl AsRef<Rect>, use_bbh: bool) -> &Canvas {
+        let canvas_ref = unsafe {
+            &*sb::C_SkPictureRecorder_beginRecording(
+                self.native_mut(),
+                bounds.as_ref().native(),
+                use_bbh,
+            )
         };
 
         Canvas::borrow_from_native(canvas_ref)
@@ -100,30 +100,33 @@ fn not_recording_no_canvas() {
 
 #[test]
 fn record_with_bbox_hierarchy() {
-  let mut paint = crate::Paint::new(crate::Color4f::new(0.0, 0.0, 0.0, 1.0), None);
-  paint.set_style(crate::PaintStyle::Fill);
+    let mut paint = crate::Paint::new(crate::Color4f::new(0.0, 0.0, 0.0, 1.0), None);
+    paint.set_style(crate::PaintStyle::Fill);
 
-  let frame_rect = Rect::new(0.0, 0.0, 100.0, 100.0);
-  let crop_rect = Rect::new(50.0, 50.0, 100.0, 100.0);
-  let drawn_rect = Rect::new(70.0, 70.0, 80.0, 80.0);
+    let frame_rect = Rect::new(0.0, 0.0, 100.0, 100.0);
+    let crop_rect = Rect::new(50.0, 50.0, 100.0, 100.0);
+    let drawn_rect = Rect::new(70.0, 70.0, 80.0, 80.0);
 
-  // with bbh disabled, cull rects reflect the arg passed to begin_recording
-  let mut src_rec = PictureRecorder::new();
-  src_rec.begin_recording(frame_rect, false)
-    .draw_rect(drawn_rect, &paint);
-  let picture = src_rec.finish_recording_as_picture(None).unwrap();
-  assert!(picture.cull_rect() == frame_rect);
+    // with bbh disabled, cull rects reflect the arg passed to begin_recording
+    let mut src_rec = PictureRecorder::new();
+    src_rec
+        .begin_recording(frame_rect, false)
+        .draw_rect(drawn_rect, &paint);
+    let picture = src_rec.finish_recording_as_picture(None).unwrap();
+    assert!(picture.cull_rect() == frame_rect);
 
-  let mut no_bbh = PictureRecorder::new();
-  no_bbh.begin_recording(crop_rect, false)
-    .draw_picture(&picture, None, None);
-  let no_bbh_pict = no_bbh.finish_recording_as_picture(None).unwrap();
-  assert!(no_bbh_pict.cull_rect() == crop_rect);
+    let mut no_bbh = PictureRecorder::new();
+    no_bbh
+        .begin_recording(crop_rect, false)
+        .draw_picture(&picture, None, None);
+    let no_bbh_pict = no_bbh.finish_recording_as_picture(None).unwrap();
+    assert!(no_bbh_pict.cull_rect() == crop_rect);
 
-  // with bbh enabled, cull rect contracts to just the content drawn
-  let mut with_bbh = PictureRecorder::new();
-  with_bbh.begin_recording(frame_rect, true)
-    .draw_picture(&picture, None, None);
-  let bbh_pict = with_bbh.finish_recording_as_picture(None).unwrap();
-  assert!(bbh_pict.cull_rect() == drawn_rect);
+    // with bbh enabled, cull rect contracts to just the content drawn
+    let mut with_bbh = PictureRecorder::new();
+    with_bbh
+        .begin_recording(frame_rect, true)
+        .draw_picture(&picture, None, None);
+    let bbh_pict = with_bbh.finish_recording_as_picture(None).unwrap();
+    assert!(bbh_pict.cull_rect() == drawn_rect);
 }

--- a/skia-safe/src/core/picture_recorder.rs
+++ b/skia-safe/src/core/picture_recorder.rs
@@ -1,4 +1,4 @@
-use crate::{prelude::*, BBHFactory, Canvas, Drawable, Picture, Rect};
+use crate::{prelude::*, Canvas, Drawable, Picture, Rect};
 use skia_bindings::{self as sb, SkPictureRecorder, SkRect};
 use std::{fmt, ptr};
 

--- a/skia-safe/src/core/picture_recorder.rs
+++ b/skia-safe/src/core/picture_recorder.rs
@@ -66,7 +66,7 @@ impl PictureRecorder {
 #[test]
 fn good_case() {
     let mut recorder = PictureRecorder::new();
-    let canvas = recorder.begin_recording(Rect::new(0.0, 0.0, 100.0, 100.0), None);
+    let canvas = recorder.begin_recording(Rect::new(0.0, 0.0, 100.0, 100.0), false);
     canvas.clear(crate::Color::WHITE);
     let _picture = recorder.finish_recording_as_picture(None).unwrap();
 }
@@ -74,10 +74,10 @@ fn good_case() {
 #[test]
 fn begin_recording_two_times() {
     let mut recorder = PictureRecorder::new();
-    let canvas = recorder.begin_recording(Rect::new(0.0, 0.0, 100.0, 100.0), None);
+    let canvas = recorder.begin_recording(Rect::new(0.0, 0.0, 100.0, 100.0), false);
     canvas.clear(crate::Color::WHITE);
     assert!(recorder.recording_canvas().is_some());
-    let canvas = recorder.begin_recording(Rect::new(0.0, 0.0, 100.0, 100.0), None);
+    let canvas = recorder.begin_recording(Rect::new(0.0, 0.0, 100.0, 100.0), false);
     canvas.clear(crate::Color::WHITE);
     assert!(recorder.recording_canvas().is_some());
 }
@@ -85,7 +85,7 @@ fn begin_recording_two_times() {
 #[test]
 fn finishing_recording_two_times() {
     let mut recorder = PictureRecorder::new();
-    let canvas = recorder.begin_recording(Rect::new(0.0, 0.0, 100.0, 100.0), None);
+    let canvas = recorder.begin_recording(Rect::new(0.0, 0.0, 100.0, 100.0), false);
     canvas.clear(crate::Color::WHITE);
     assert!(recorder.finish_recording_as_picture(None).is_some());
     assert!(recorder.recording_canvas().is_none());


### PR DESCRIPTION
When beginning a recording, the `PictureRecorder` struct can optionally construct a bounding box hierarchy object in which it tracks the objects that are drawn to its canvas and calculates a minimal bounding box containing all of them (rather than simply relaying the 'cull rect' arg passed by the caller). Since this adds some memory and cpu overhead to the recording process it's not enabled by default.

In C++, the way to opt into this behavior is to pass a ‘factory’ pointer to the `beginRecording` method. As far as I can tell, the abstract `SkBBHFactory` class:
  1) only has a single implementation (`SkRTreeFactory`), and 
  2) isn't used anywhere else in Skia aside from this one method argument

Likewise, the `SkBBoxHierarchy` object the factory creates is stored as a private member of the `SkPictureRecorder` and isn't accessible after being used.

Taken together, these suggested to me it might not be worth filling in the implementation that's currently [marked TODO](https://github.com/rust-skia/rust-skia/blob/master/skia-safe/src/core/bbh_factory.rs). So in this PR I've made the use of a BBH into a simple flag, changing the signature of `PictureRecorder.begin_recording()` to accept a boolean for its second argument rather than an optional `BBHFactory`.

I didn't remove `bbh_factory.rs`, but it seems like it could also be dropped since it has no other utility that I can see.