### PR TITLE
Fix a PathBuilder crash

### DIFF
--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -751,8 +751,8 @@ extern "C" void C_SkPath_computeTightBounds(const SkPath* self, SkRect* uninitia
 // core/SkPathBuilder.h
 //
 
-extern "C" void C_SkPathBuilder_Construct(SkPathBuilder* uninitialized) {
-    new(uninitialized) SkPathBuilder();
+extern "C" SkPathBuilder* C_SkPathBuilder_new() {
+    return new SkPathBuilder();
 }
 
 /* m87: Implementation is missing.
@@ -761,20 +761,20 @@ extern "C" void C_SkPathBuilder_Construct2(SkPathBuilder* uninitialized, SkPathF
 }
 */
 
-extern "C" void C_SkPathBuilder_Construct3(SkPathBuilder* uninitialized, const SkPath& path) {
-    new(uninitialized) SkPathBuilder(path);
+extern "C" SkPathBuilder* C_SkPathBuilder_newFromPath(const SkPath& path) {
+     return new SkPathBuilder(path);
 }
 
 extern "C" void C_SkPathBuilder_computeBounds(const SkPathBuilder* self, SkRect* uninitialized) {
     new (uninitialized) SkRect(self->computeBounds());
 }
 
-extern "C" void C_SkPathBuilder_CopyConstruct(SkPathBuilder* uninitialized, const SkPathBuilder& pathBuilder) {
-    new(uninitialized) SkPathBuilder(pathBuilder);
+extern "C" SkPathBuilder* C_SkPathBuilder_clone(const SkPathBuilder* pathBuilder) {
+    return new SkPathBuilder(*pathBuilder);
 }
 
-extern "C" void C_SkPathBuilder_destruct(SkPathBuilder* self) {
-    self->~SkPathBuilder();
+extern "C" void C_SkPathBuilder_delete(SkPathBuilder* self) {
+    delete self;
 }
 
 extern "C" void C_SkPathBuilder_snapshot(const SkPathBuilder* self, SkPath* uninitialized) {

--- a/skia-safe/src/core/path_builder.rs
+++ b/skia-safe/src/core/path_builder.rs
@@ -470,6 +470,8 @@ impl PathBuilder {
 
 #[cfg(test)]
 mod tests {
+    use crate::{paint, surfaces, Paint};
+
     use super::*;
 
     #[test]
@@ -477,5 +479,18 @@ mod tests {
         let mut builder = PathBuilder::new();
         let _path = builder.snapshot();
         let _path = builder.detach();
+    }
+
+    #[test]
+    fn issue_1195() {
+        let mut surface = surfaces::raster_n32_premul((1000, 1000)).unwrap();
+        let canvas = surface.canvas();
+        let mut paint = Paint::default();
+        paint.set_style(paint::Style::Stroke);
+        let mut path = PathBuilder::new();
+        path.move_to((250., 250.));
+        path.cubic_to((300., 300.), (700., 700.), (750., 750.));
+        let pathsh = path.snapshot();
+        canvas.draw_path(&pathsh, &paint);
     }
 }


### PR DESCRIPTION
@axkibe reported a problem with PathBuilder::shapshot, which also crashes in master. This PR adds the code in issue #1195 to the PathBuilder tests.