### PR TITLE
Link with advapi32 on Windows builds

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
+        "Advapi",
         "aniso",
         "antialiasing",
         "appkit",

--- a/skia-bindings/build_support/platform/windows.rs
+++ b/skia-bindings/build_support/platform/windows.rs
@@ -97,7 +97,8 @@ impl PlatformDetails for Generic {
 }
 
 fn generic_link_libraries(features: &Features) -> Vec<String> {
-    let mut libs = vec!["usp10", "ole32", "user32", "gdi32", "fontsub"];
+    // `Advapi32` is needed by `skunicode_icu.lib`.
+    let mut libs = vec!["usp10", "ole32", "user32", "gdi32", "fontsub", "Advapi32"];
     if features[feature::GL] {
         libs.push("opengl32");
     }


### PR DESCRIPTION
We are getting the following linker errors on Windows build on the CI recently:

```
skunicode_icu.lib(icu.wintz.obj) : error LNK2019: unresolved external symbol __imp_RegOpenKeyExW referenced in function uprv_detectWindowsTimeZone
          skunicode_icu.lib(icu.wintz.obj) : error LNK2019: unresolved external symbol __imp_RegQueryInfoKeyW referenced in function uprv_detectWindowsTimeZone
          skunicode_icu.lib(icu.wintz.obj) : error LNK2019: unresolved external symbol __imp_RegCloseKey referenced in function uprv_detectWindowsTimeZone
          skunicode_icu.lib(icu.wintz.obj) : error LNK2019: unresolved external symbol __imp_RegEnumKeyExW referenced in function uprv_detectWindowsTimeZone
          skunicode_icu.lib(icu.wintz.obj) : error LNK2019: unresolved external symbol __imp_RegQueryValueExW referenced in function uprv_detectWindowsTimeZone
          C:\a\rust-skia\rust-skia\target\aarch64-pc-windows-msvc\release\deps\skia_safe-237ba88454655a21.exe : fatal error LNK1120: 5 unresolved externals␍
```
This PR links with advapi32.lib which should resolve these issues.
