### PR TITLE
Expose a `custom_empty` `FontMgr`

### DIFF
--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1973,10 +1973,9 @@ extern "C" SkFontMgr* C_SkFontMgr_RefEmpty() {
 
 extern "C" SkFontMgr* C_SkFontMgr_NewCustomEmpty() {
 #if defined(SK_FONTMGR_FREETYPE_EMPTY_AVAILABLE)
-    auto mgr = SkFontMgr_New_Custom_Empty();
-    return mgr.release();
+    return SkFontMgr_New_Custom_Empty().release();
 #else
-    return C_SkFontMgr_NewSystem();
+    return nullptr;
 #endif
 }
 

--- a/skia-safe/src/core/font_mgr.rs
+++ b/skia-safe/src/core/font_mgr.rs
@@ -113,11 +113,11 @@ impl FontMgr {
         FontMgr::from_ptr(unsafe { sb::C_SkFontMgr_RefEmpty() }).unwrap()
     }
 
-    // Custom empty manager. This avoids scanning system fonts when they are not
-    // required. Note this falls back to the system manager on platforms where
-    // Skia is not compiled with freetype (e.g. Windows)
-    pub fn custom_empty() -> Self {
-        FontMgr::from_ptr(unsafe { sb::C_SkFontMgr_NewCustomEmpty() }).unwrap()
+    // Custom empty manager. This avoids scanning system fonts when they are not required.
+    //
+    // Returns `None` on platforms where Skia is not compiled with freetype (e.g. Windows)
+    pub fn custom_empty() -> Option<Self> {
+        FontMgr::from_ptr(unsafe { sb::C_SkFontMgr_NewCustomEmpty() })
     }
 
     pub fn count_families(&self) -> usize {


### PR DESCRIPTION
Currently the only way to construct a `FontMgr` is with `new` or `empty`. The standard one scans all the system fonts, whereas the empty manager is useless in cases you actually want to render text, as you can't actually load any typefaces with it.

Here we forward to `SkFontMgr_New_Custom_Empty` (when freetype is available). This allows loading your own typefaces by calling `mgr.new_from_data`, without all the scanning of system fonts required at start up with the default manager.

As an example, on my laptop not scanning system fonts on my app cuts start up time from ~750ms to ~80ms.