### PR TITLE
fix(gl-window-example): Implement proper drop of resources and abandon gr context in `gl-window` example

### DIFF
--- a/skia-safe/examples/gl-window/main.rs
+++ b/skia-safe/examples/gl-window/main.rs
@@ -220,6 +220,9 @@ fn main() {
 
     impl Drop for Env {
         fn drop(&mut self) {
+            // This fixes a segmentation fault on AMD GPUs, see
+            // <https://github.com/rust-skia/rust-skia/pull/1235> and
+            // <https://github.com/marc2332/freya/issues/347> for more details.
             self.gr_context.release_resources_and_abandon();
         }
     }


### PR DESCRIPTION
Fixes https://github.com/rust-skia/rust-skia/issues/861
Fixes https://github.com/marc2332/freya/issues/347

Today I got a new AMD gpu and my freya examples were crashing when I closed the windows, this fixes it

Does this make sense?