### PR TITLE
Port `metal-window` example to `objc2`. Add iOS support to example.

### DIFF
--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -98,13 +98,20 @@ ash = { version = "^0.38.0" }
 vulkano = { version = "0.35" }
 
 # metal-window
-[target.'cfg(target_os = "macos")'.dev-dependencies]
-metal-rs = { package = "metal", version = "0.32.0" }
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
+objc2 = { version = "0.6.3", default-features = false }
+objc2-core-foundation = { version = "0.3.2", default-features = false }
+objc2-metal = { version = "0.3.2", default-features = false, features = ["MTLCommandBuffer", "MTLCommandQueue", "MTLDrawable", "MTLPixelFormat"] }
+objc2-quartz-core = { version = "0.3.2", default-features = false, features = ["objc2-core-foundation", "objc2-metal", "CAMetalLayer"] }
 raw-window-handle = "0.6.0"
-objc = "0.2.7"
-cocoa = "0.26.0"
-core-graphics-types = "0.2.0"
-foreign-types-shared = "0.3.1"
+
+# metal-window (macOS)
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["objc2-quartz-core", "NSView", "NSResponder"] }
+
+# metal-window (iOS)
+[target.'cfg(target_os = "ios")'.dependencies]
+objc2-ui-kit = { version = "0.3.2", default-features = false, features = ["objc2-quartz-core", "UIView", "UIResponder"] }
 
 # d3d-window
 [target.'cfg(target_os = "windows")'.dev-dependencies]


### PR DESCRIPTION
Ports the `metal-window` example to use the `objc2` family of crates instead of `objc`, `cocoa`, `metal-rs`, `core-graphics-types`, and `foreign-types-shared` crates.

While I was at it I added support for building on iOS (I haven't actually run this example on iOS, but it is based on [code from anyrender_skia](https://github.com/DioxusLabs/anyrender/blob/main/crates/anyrender_skia/src/metal.rs) that is able to run apps on iOS).

