### PR TITLE
chore: Add `metal` to the features combo of Freya

### DIFF
--- a/mk-workflows/src/config.rs
+++ b/mk-workflows/src/config.rs
@@ -162,8 +162,11 @@ pub fn binaries_jobs(workflow: &Workflow) -> Vec<Job> {
 /// <https://github.com/rust-skia/rust-skia/issues/706>
 fn freya_binaries_features(workflow: &Workflow) -> Vec<Features> {
     match workflow.host_os {
-        HostOS::Windows | HostOS::MacOS => {
+        HostOS::Windows => {
             vec!["gl,textlayout,svg".into()]
+        }
+        HostOS::MacOS => {
+            vec!["gl,textlayout,svg,metal".into()]
         }
         HostOS::WindowsArm | HostOS::Wasm => {
             vec![]


### PR DESCRIPTION
Hi, would it be possible to enable metal in the macos binaries used by freya? I am gonna add support for metal soon, and just in case I will leave opengl as fallback.

😄 