### PR TITLE
Milestone 148

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -11,6 +11,7 @@
                 "SK_SHAPER_UNICODE_AVAILABLE",
                 "SK_UNICODE_ICU_IMPLEMENTATION",
                 "SK_SHAPER_HARFBUZZ_AVAILABLE",
+                "SK_SHAPER_CORETEXT_AVAILABLE",
                 "SK_CODEC_DECODES_WEBP"
             ],
             "macFrameworkPath": [],

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md — rust-skia development notes
+
+## Repository structure
+
+- `skia-bindings/` — Low-level C++ bindings. Contains:
+  - `skia/` — Git submodule pointing to `rust-skia/skia` fork (tagged e.g. `m148-0.95.1`)
+  - `src/bindings.cpp` — C wrapper functions for Skia C++ APIs (parsed by bindgen)
+  - `src/shaper.cpp` — C wrappers for SkShaper / modules
+  - `Cargo.toml` — `[package.metadata] skia = "m148-X.Y.Z"` must match submodule tag
+  - `build_support/` — Build configuration (e.g. `binaries_config.rs` for platform-specific logic)
+- `skia-safe/` — Safe Rust wrappers over `skia-bindings`. Mirrors Skia's include structure:
+  - `src/core/` → `include/core/`
+  - `src/gpu/ganesh/` → `include/gpu/ganesh/`
+  - `src/modules/shaper/` → `modules/skshaper/include/`
+  - `src/modules/paragraph/` → `modules/skparagraph/include/`
+  - etc.
+- `docs/wiki/` — Local copies of GitHub wiki pages (e.g. milestone update template)
+
+## Binding generation
+
+- Bindgen parses the `.cpp` files in `skia-bindings/src/` to discover `extern "C"` functions and types.
+- Touch `skia-bindings/src/bindings.cpp` and run `cargo check -p skia-bindings` to force regeneration.
+- Generated bindings land in `target/*/build/skia-bindings-*/out/skia/bindings.rs`.
+- C++ `enum class` variants get their `k` prefix stripped automatically by bindgen.
+- C++ namespaced types like `SkShapers::CT::LineBreakMode` become `SkShapers_CT_LineBreakMode`.
+
+## Common patterns in skia-safe
+
+- **Enum wrapping:** `pub type Foo = skia_bindings::SkFoo;` + `variant_name!(Foo::SomeVariant);`
+- **Struct wrapping:** `pub type Foo = Handle<SkFoo>;` or `pub type Foo = RCHandle<SkFoo>;`
+- **native_transmutable!** for types that are bit-for-bit compatible.
+- **require_type_equality!** to verify base class assumptions at compile time (e.g. `SkPixelRef_INHERITED` == `SkRefCnt`).
+- **variant_name!** to verify a variant exists at compile time (catches bindgen name changes).
+- Platform-gated code uses `#[cfg(any(target_os = "macos", target_os = "ios"))]`.
+- Functions returning `Option<Self>` via `Self::from_ptr(unsafe { ... })` — returns `None` if the C function returns null (used for platform-optional features like CoreText).
+
+## Skia milestone update checklist
+
+Reference: `docs/wiki/Template-Skia-Milestone-Update-PR.md`
+
+Files to update:
+1. `README.md` — Branch name (`chrome/mXX`) and submodule tag in compare links
+2. `skia-bindings/skia` submodule — Point to new tag on `rust-skia/skia` fork
+3. `skia-bindings/Cargo.toml` — `version` bump, `[package.metadata] skia` tag
+4. `skia-safe/Cargo.toml` — `version` bump, `skia-bindings` dependency version
+5. `skia-safe/src/core/milestone.rs` — `MILESTONE` const
+6. `skia-safe/src/core/color_type.rs` — New `SkColorType` variants (check `include/core/SkColorType.h`)
+7. Wrapper updates in `skia-safe/src/` — Diff the Skia include headers between milestones
+8. `skia-bindings/src/*.cpp` — New C wrapper functions for changed APIs
+9. Deprecated attributes — Use new version number for any new `#[deprecated(since = "X.Y.Z")]`
+
+Key diffs to check between milestones (in `skia-bindings/skia/`):
+```
+git diff OLD_TAG..NEW_TAG -- include/core include/codec include/docs include/effects \
+  include/encode include/gpu include/pathops include/svg include/utils include/private/base \
+  modules/skparagraph/include modules/skshaper/include modules/svg/include modules/skresources/include
+```
+
+Build organization diffs:
+```
+git diff OLD_TAG..NEW_TAG -- BUILD.gn gn/ modules/skshaper/BUILD.gn modules/skshaper/skshaper.gni \
+  modules/paragraph/BUILD.gn modules/paragraph/skparagraph.gni modules/svg/BUILD.gn modules/svg/svg.gni
+```
+
+Version numbering: Each milestone bump increments the minor version (e.g. 0.95.0 → 0.96.0).
+
+Final steps: `make diff-skia`, `make diff-api`, `make doc`, scan for `todo!()` macros, review Send/Sync/Debug impls.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,6 @@
   - `src/modules/shaper/` → `modules/skshaper/include/`
   - `src/modules/paragraph/` → `modules/skparagraph/include/`
   - etc.
-- `docs/wiki/` — Local copies of GitHub wiki pages (e.g. milestone update template)
 
 ## Binding generation
 
@@ -36,18 +35,9 @@
 
 ## Skia milestone update checklist
 
-Reference: `docs/wiki/Template-Skia-Milestone-Update-PR.md`
+See the [Template: Skia Milestone Update PR](https://github.com/rust-skia/rust-skia/wiki/Template:-Skia-Milestone-Update-PR) wiki page.
 
-Files to update:
-1. `README.md` — Branch name (`chrome/mXX`) and submodule tag in compare links
-2. `skia-bindings/skia` submodule — Point to new tag on `rust-skia/skia` fork
-3. `skia-bindings/Cargo.toml` — `version` bump, `[package.metadata] skia` tag
-4. `skia-safe/Cargo.toml` — `version` bump, `skia-bindings` dependency version
-5. `skia-safe/src/core/milestone.rs` — `MILESTONE` const
-6. `skia-safe/src/core/color_type.rs` — New `SkColorType` variants (check `include/core/SkColorType.h`)
-7. Wrapper updates in `skia-safe/src/` — Diff the Skia include headers between milestones
-8. `skia-bindings/src/*.cpp` — New C wrapper functions for changed APIs
-9. Deprecated attributes — Use new version number for any new `#[deprecated(since = "X.Y.Z")]`
+Version numbering: Each milestone bump increments the minor version (e.g. 0.95.0 → 0.96.0).
 
 Key diffs to check between milestones (in `skia-bindings/skia/`):
 ```
@@ -61,7 +51,3 @@ Build organization diffs:
 git diff OLD_TAG..NEW_TAG -- BUILD.gn gn/ modules/skshaper/BUILD.gn modules/skshaper/skshaper.gni \
   modules/paragraph/BUILD.gn modules/paragraph/skparagraph.gni modules/svg/BUILD.gn modules/svg/svg.gni
 ```
-
-Version numbering: Each milestone bump increments the minor version (e.g. 0.95.0 → 0.96.0).
-
-Final steps: `make diff-skia`, `make diff-api`, `make doc`, scan for `todo!()` macros, review Send/Sync/Debug impls.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m148 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m148-0.95.0...google:chrome/m148
-[skia-ours]: https://github.com/google/skia/compare/chrome/m148...rust-skia:m148-0.95.0
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m148-0.95.1...google:chrome/m148
+[skia-ours]: https://github.com/google/skia/compare/chrome/m148...rust-skia:m148-0.95.1
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![Windows QA](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml) [![Linux QA](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml) [![macOS QA](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml)
 
-Skia Submodule Status: chrome/m147 ([upstream changes][skia-upstream], [our changes][skia-ours]).
+Skia Submodule Status: chrome/m148 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m147-0.94.4...google:chrome/m147
-[skia-ours]: https://github.com/google/skia/compare/chrome/m147...rust-skia:m147-0.94.4
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m148-0.95.0...google:chrome/m148
+[skia-ours]: https://github.com/google/skia/compare/chrome/m148...rust-skia:m148-0.95.0
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m148 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m148-0.95.1...google:chrome/m148
-[skia-ours]: https://github.com/google/skia/compare/chrome/m148...rust-skia:m148-0.95.1
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m148-0.95.2...google:chrome/m148
+[skia-ours]: https://github.com/google/skia/compare/chrome/m148...rust-skia:m148-0.95.2
 
 ## About
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -31,7 +31,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download the Skia archive from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m147-0.94.4"
+skia = "m148-0.95.0"
 
 [features]
 default = ["binary-cache", "embed-icudtl", "pdf"]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -31,7 +31,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download the Skia archive from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m148-0.95.0"
+skia = "m148-0.95.1"
 
 [features]
 default = ["binary-cache", "embed-icudtl", "pdf"]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.96.0"
+version = "0.97.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2021"
 rust-version.workspace = true

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -31,7 +31,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download the Skia archive from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m148-0.95.1"
+skia = "m148-0.95.2"
 
 [features]
 default = ["binary-cache", "embed-icudtl", "pdf"]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.95.0"
+version = "0.96.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2021"
 rust-version.workspace = true

--- a/skia-bindings/build_support/binaries_config.rs
+++ b/skia-bindings/build_support/binaries_config.rs
@@ -129,15 +129,13 @@ impl BinariesConfiguration {
     pub fn commit_to_cargo(&self) {
         cargo::add_link_search(self.output_directory.to_str().unwrap());
 
-        // On Linux, the order is significant, first the static libraries we built, and then
-        // the system libraries.
-
         let target = cargo::target();
 
         if target.is_emscripten() {
-            // Since Skia m147, the wasm GN toolchain emits static archives as `*.a.wasm`.
+            // Since Skia milestone 148, the wasm GN toolchain emits static archives as
+            // `*.wasm.a`.
             for lib in &self.ninja_built_libraries {
-                let from = self.output_directory.join(format!("lib{lib}.a.wasm"));
+                let from = self.output_directory.join(format!("lib{lib}.wasm.a"));
                 let to = self.output_directory.join(format!("lib{lib}.a"));
                 fs::copy(&from, &to).unwrap_or_else(|e| {
                     panic!(
@@ -150,6 +148,8 @@ impl BinariesConfiguration {
             }
         }
 
+        // On Linux, the order is significant, first the static libraries we built, and then
+        // the system libraries.
         cargo::add_static_link_libs(&target, self.built_libraries(true));
         cargo::add_link_libs(&self.link_libraries);
     }

--- a/skia-bindings/build_support/skia_bindgen.rs
+++ b/skia-bindings/build_support/skia_bindgen.rs
@@ -774,6 +774,8 @@ const ENUM_REWRITES: &[EnumEntry] = &[
     ("IsAnimated", rewrite::k_xxx),
     // m142: PngRustEncoder::CompressionLevel
     ("CompressionLevel", rewrite::k_opt_xxx),
+    // m148: SkShapers::CT::LineBreakMode
+    ("LineBreakMode", rewrite::k_xxx),
 ];
 
 pub(crate) mod rewrite {

--- a/skia-bindings/src/shaper.cpp
+++ b/skia-bindings/src/shaper.cpp
@@ -13,13 +13,11 @@
 #include "third_party/icu/SkLoadICU.h"
 #endif
 
-extern "C" SkShaper* C_SkShaper_MakeCoreText() {
 #ifdef SK_SHAPER_CORETEXT_AVAILABLE
-    return SkShapers::CT::CoreText().release();
-#else
-    return nullptr;
-#endif
+extern "C" SkShaper* C_SkShaper_MakeCoreText(SkShapers::CT::LineBreakMode lineBreakMode) {
+    return SkShapers::CT::CoreText(lineBreakMode).release();
 }
+#endif
 
 extern "C" SkShaper* C_SkShaper_Make(SkFontMgr* fontMgr) {
     return SkShaper::Make(sk_sp<SkFontMgr>(fontMgr)).release();

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -18,7 +18,7 @@ categories = [
 ]
 license = "MIT"
 
-version = "0.95.0"
+version = "0.96.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2021"
 rust-version.workspace = true
@@ -61,7 +61,7 @@ gpu = []
 
 [dependencies]
 bitflags = "2.0"
-skia-bindings = { version = "=0.95.0", path = "../skia-bindings", default-features = false }
+skia-bindings = { version = "=0.96.0", path = "../skia-bindings", default-features = false }
 
 
 # D3D types & ComPtr

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -18,7 +18,7 @@ categories = [
 ]
 license = "MIT"
 
-version = "0.96.0"
+version = "0.97.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2021"
 rust-version.workspace = true
@@ -61,7 +61,7 @@ gpu = []
 
 [dependencies]
 bitflags = "2.0"
-skia-bindings = { version = "=0.96.0", path = "../skia-bindings", default-features = false }
+skia-bindings = { version = "=0.97.0", path = "../skia-bindings", default-features = false }
 
 
 # D3D types & ComPtr

--- a/skia-safe/src/core/color_type.rs
+++ b/skia-safe/src/core/color_type.rs
@@ -88,13 +88,16 @@ pub enum ColorType {
     /// Bits: [A:127..96 B:95..64 G:63..32 R:31..0]
     RGBAF32 = SkColorType::kRGBA_F32_SkColorType as _,
 
-    // The following 6 color types are just for reading from - not for rendering to
     /// Two channel RG data (8 bits per channel). Blue is forced to 0, alpha is forced to opaque.
     /// Bits: [G:15..8 R:7..0]
     R8G8UNorm = SkColorType::kR8G8_unorm_SkColorType as _,
     /// Single channel data (16-bit half-float) interpreted as alpha. RGB are 0.
     /// Bits: [A:15..0]
     A16Float = SkColorType::kA16_float_SkColorType as _,
+    /// Single channel data (16 bits half-float) interpreted as red. G and B are forced to 0, alpha
+    /// is forced to opaque.
+    /// Bits: [R:15..0]
+    R16Float = SkColorType::kR16_float_SkColorType as _,
     /// Two channel RG data (16-bit half-float per channel) packed into a LE 32-bit word.
     /// Blue is forced to 0, alpha is forced to opaque.
     /// Bits: [G:31..16 R:15..0]

--- a/skia-safe/src/core/milestone.rs
+++ b/skia-safe/src/core/milestone.rs
@@ -1,1 +1,1 @@
-pub const MILESTONE: usize = 147;
+pub const MILESTONE: usize = 148;

--- a/skia-safe/src/modules.rs
+++ b/skia-safe/src/modules.rs
@@ -22,6 +22,7 @@ pub mod shapers {
     // Re-exports `shapers::primitive`.
     pub use crate::shaper::shapers::*;
 
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
     pub mod ct {
         pub use crate::shaper::core_text::*;
     }

--- a/skia-safe/src/modules/paragraph/paragraph_style.rs
+++ b/skia-safe/src/modules/paragraph/paragraph_style.rs
@@ -193,6 +193,10 @@ impl fmt::Debug for ParagraphStyle {
             .field("hinting_is_on", &self.hinting_is_on())
             .field("replace_tab_characters", &self.replace_tab_characters())
             .field("fake_missing_font_styles", &self.fake_missing_font_styles())
+            .field(
+                "letter_spacing_by_css_spec",
+                &self.letter_spacing_by_css_spec(),
+            )
             .finish()
     }
 }
@@ -327,6 +331,15 @@ impl ParagraphStyle {
 
     pub fn set_apply_rounding_hack(&mut self, value: bool) -> &mut Self {
         self.native_mut().fApplyRoundingHack = value;
+        self
+    }
+
+    pub fn letter_spacing_by_css_spec(&self) -> bool {
+        self.native().fLetterSpacingByCSSSpec
+    }
+
+    pub fn set_letter_spacing_by_css_spec(&mut self, value: bool) -> &mut Self {
+        self.native_mut().fLetterSpacingByCSSSpec = value;
         self
     }
 }

--- a/skia-safe/src/modules/shaper.rs
+++ b/skia-safe/src/modules/shaper.rs
@@ -14,6 +14,7 @@ use skia_bindings::{
 use crate::{prelude::*, scalar, Font, FontMgr, FourByteTag, Point, TextBlob};
 
 // The following three are re-exported in `modules.rs` via `mod shapers {}`.
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub(crate) mod core_text;
 pub(crate) mod harfbuzz;
 pub(crate) mod unicode;
@@ -71,11 +72,12 @@ impl Shaper {
         unsafe { sb::SkShaper_PurgeHarfBuzzCache() }
     }
 
-    pub fn new_core_text() -> Option<Self> {
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    pub fn new_core_text(line_break_mode: crate::shapers::ct::LineBreakMode) -> Self {
         #[cfg(feature = "embed-icudtl")]
         crate::icu::init();
 
-        Self::from_ptr(unsafe { sb::C_SkShaper_MakeCoreText() })
+        Self::from_ptr(unsafe { sb::C_SkShaper_MakeCoreText(line_break_mode) }).unwrap()
     }
 
     pub fn new(font_mgr: impl Into<Option<FontMgr>>) -> Self {

--- a/skia-safe/src/modules/shaper/core_text.rs
+++ b/skia-safe/src/modules/shaper/core_text.rs
@@ -1,5 +1,8 @@
 use crate::Shaper;
 
-pub fn core_text() -> Option<Shaper> {
-    Shaper::new_core_text()
+pub use skia_bindings::SkShapers_CT_LineBreakMode as LineBreakMode;
+variant_name!(LineBreakMode::Default);
+
+pub fn core_text(line_break_mode: LineBreakMode) -> Shaper {
+    Shaper::new_core_text(line_break_mode)
 }

--- a/skia-safe/tests/send_sync.rs
+++ b/skia-safe/tests/send_sync.rs
@@ -331,6 +331,10 @@ mod textlayout {
 mod shaper {
     use skia_safe::shaper::*;
     use static_assertions::*;
+
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    assert_impl_all!(skia_safe::shapers::ct::LineBreakMode: Send, Sync);
+
     assert_impl_all!(Shaper: Send, Sync);
     assert_not_impl_any!(FontRunIterator: Send, Sync);
     assert_not_impl_any!(BiDiRunIterator: Send, Sync);


### PR DESCRIPTION
This PR aligns rust-skia with Skia's `chrome/m148` branch.

- [x] Update `README.md` ([rendered](https://github.com/pragmatrix/rust-skia/blob/m148/README.md))  
  > Most important here is to change the Skia branch name and the current Skia submodule tag at the top of the `README.md` file.
- [x] Diff the the following files to see if the build organization has changed significantly:
  - [x] `/BUILD.gn`
  - [x] `/gn/*` (recursively)
  - [x] `/modules/skshaper/BUILD.gn`
  - [x] `/modules/skshaper/skshaper.gni`
  - [x] `/modules/paragraph/BUILD.gn`
  - [x] `/modules/paragraph/skparagraph.gni`
  - [x] `/modules/skottie/BUILD.gn`
  - [x] `/modules/skottie/skottie.gni`
  - [x] `/modules/svg/BUILD.gn`
  - [x] `/modules/svg/svg.gni`
- [x] Skia builds ([release notes](https://github.com/google/skia/blob/chrome/m148/RELEASE_NOTES.md)).
- [x] `/skia-bindings` builds.
- [x] `/skia-safe`: Update & add new wrappers by diffing include files.  
  > Add TODOs for everything that can not be updated right now, and attempt to stay compatible with previous versions of skia-safe without trying too hard before version 1.0. Use `deprecated` attributes if needed.
  - [x] `codec/`
  - [x] `core/`
  - [x] `docs/`
  - [x] `effects/`
  - [x] `encode/`
  - [x] `gpu/`
    - [x] `ganesh/`
    - [x] `mtl/`
    - [x] `vk/`
  - [x] `pathops/`
  - [x] `svg/`
  - [x] `utils/`
  - [x] `modules/`
    - [x] `paragraph/`
    - [x] `shaper/`
    - [x] `skottie/`
    - [x] `skresources/`
    - [x] `svg/`
  - [x] `private/base/*`
    - [x] `SkPoint_impl.h`
- [x] Look for `todo!()` macros. 
- [x] Review `Send` & `Sync` implementations for new wrappers.
- [x] Review `Debug` implementation for new wrapper types and functions.
- [x] Release date of the matching Chrome version in less than 7 days?
- [x] Any pending changes in the Skia `chrome/m148` branch that aren't synchronized yet?
- [x] Rebase on or merge with master.
- [x] Do the `rust-skia:` commits in the `skia-bindings/skia` subdirectory match with `master` (`make diff-skia`).
- [x] Update versions of `skia-bindings/Cargo.toml` and `skia-safe/Cargo.toml` and also add the version to the new `deprecated` attributes.
- [x] Does the tag/hash in `skia-bindings/Cargo.toml` under `[package.metadata]` match the `skia` submodule?
- [x] Review API changes: `make diff-api`.
- [x] Do one final review of all the changes.
- [x] Run `make doc` and fix all warnings.

