### PR TITLE
linux: Don't override --target when building under a Yocto SDK

### DIFF
--- a/skia-bindings/build_support/platform/linux.rs
+++ b/skia-bindings/build_support/platform/linux.rs
@@ -12,8 +12,14 @@ impl PlatformDetails for Linux {
 
     fn gn_args(&self, config: &BuildConfiguration, builder: &mut GnArgsBuilder) {
         generic::gn_args(config, builder);
-        // This makes it possible for clang++ to locate the C++ includes.
-        builder.target_str = Some(linux_shortened_target_str(&config.target));
+        // This makes it possible for clang++ to locate the C++ includes when using a
+        // host clang with multi-arch cross packages. Skip when a Yocto SDK is in use
+        // (SDKTARGETSYSROOT set): the SDK's cc/cxx already specify a vendor-qualified
+        // `--target=`, and appending a shortened one here makes clang pick the wrong
+        // gcc toolchain inside the sysroot.
+        if std::env::var("SDKTARGETSYSROOT").is_err() {
+            builder.target_str = Some(linux_shortened_target_str(&config.target));
+        }
 
         let target = &config.target;
         builder.cflags(flags(target));


### PR DESCRIPTION
Yocto cc/cxx already pass a vendor-qualified `--target=` (e.g. `arm-poky-linux-gnueabi`). Appending a shortened, vendor-less target via extra_cflags causes clang to look for a gcc toolchain that doesn't exist inside the sysroot, breaking C++ stdlib header lookup (`cstddef not found`).