### PR TITLE
Fix docs.rs builds: ship bindings_docs.rs in published tarballs (#720)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,15 +46,20 @@ crate-post-release-test:
 #   .cargo/credentials
 
 .PHONY: publish
-publish: package-bindings package-safe publish-bindings wait publish-safe
+publish: package-bindings package-safe publish-bindings-docs wait publish-safe
 
 .PHONY: publish-only
-publish-only: publish-bindings publish-safe
+publish-only: publish-bindings-docs publish-safe
 
 .PHONY: publish-bindings
 publish-bindings:
 	cd skia-bindings && cargo publish -vv --no-verify
 
+# `publish-bindings-docs` is the variant that ships `bindings_docs.rs` in
+# the tarball -- without that file, `DOCS_RS=1` builds of downstream crates
+# fail at the bindings copy step (see rust-skia#720). The aggregate
+# `publish` and `publish-only` targets above always go through this target
+# so released tarballs include the documentation bindings.
 .PHONY: publish-bindings-docs
 publish-bindings-docs: bindings-docs
 	cd skia-bindings && cp /tmp/bindings.rs bindings_docs.rs

--- a/skia-bindings/build.rs
+++ b/skia-bindings/build.rs
@@ -205,11 +205,22 @@ fn generate_bindings(
 /// On docs.rs, rustdoc runs inside a container with no networking, so copy a pre-generated
 /// `bindings.rs` file.
 fn fake_bindings() -> Result<(), io::Error> {
+    let source = std::path::Path::new("bindings_docs.rs");
+    if !source.exists() {
+        return Err(io::Error::other(
+            "bindings_docs.rs is missing from the published skia-bindings \
+             tarball. The release Makefile must run `make publish-bindings-docs` \
+             (not `make publish-bindings`) so the documentation bindings end up \
+             in the tarball. Without this file, docs.rs builds of skia-safe and \
+             every downstream crate fail here. See \
+             https://github.com/rust-skia/rust-skia/issues/720",
+        ));
+    }
     println!("COPYING bindings_docs.rs to OUT_DIR/skia/bindings.rs");
     let bindings_target = cargo::output_directory()
         .join(binaries_config::SKIA_OUTPUT_DIR)
         .join("bindings.rs");
-    fs::copy("bindings_docs.rs", bindings_target).map(|_| ())
+    fs::copy(source, bindings_target).map(|_| ())
 }
 
 /// Environment variables used by this build script.


### PR DESCRIPTION
Closes #720 (or unblocks it -- happy to tag whichever the maintainers prefer).

## The bug

`DOCS_RS=1` builds of `skia-bindings` (and therefore `skia-safe` and every
downstream crate) fail with:

```
DETECTED DOCS_RS BUILD
COPYING bindings_docs.rs to OUT_DIR/skia/bindings.rs
Error: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

I just reproduced this on `skia-bindings 0.97.0` -- see the comment I left on
#720. Both `skia-safe` itself and downstream crates (e.g. my own
`skia-canvas 0.1.0`) show `doc_status: false` on docs.rs, so the registry
is currently dark for the entire `rust-skia` ecosystem.

## Root cause

The `bindings_docs.rs` file that `fake_bindings()` tries to copy isn't
shipped in the published tarball, even though it's listed in
`skia-bindings/Cargo.toml`'s `include` set.

Tracing through the Makefile:

- `make publish` runs `package-bindings package-safe publish-bindings wait publish-safe`
- `publish-bindings` is just `cargo publish --no-verify` -- no docs prep.
- The separate `publish-bindings-docs` target *does* run `bindings-docs`
  (which builds Skia with the docs-rs features) and `cp`s the generated
  `bindings.rs` into `skia-bindings/bindings_docs.rs` before publishing
  with `--allow-dirty`.

So the docs prep recipe exists but the master target doesn't call it. The
last few releases must have gone out through `publish-bindings` rather
than `publish-bindings-docs`, and the tarballs ended up without the file.

## The change

Two small commits:

1. **Makefile** -- `publish` and `publish-only` now route through
   `publish-bindings-docs`. The standalone `publish-bindings` target is
   left as-is for ad-hoc use. One-character functional change plus a comment
   block on `publish-bindings-docs` explaining why it must be the canonical
   release path.

2. **skia-bindings/build.rs** -- `fake_bindings()` now checks
   `Path::exists()` and returns an `io::Error` whose message identifies
   the missing file, points at the publish-side fix
   (`make publish-bindings-docs`), and links to this issue. No behavior
   change on the happy path. This is the defensive belt-and-braces piece:
   even if some future regression bypasses the Makefile fix, downstream
   consumers will see a diagnosable error instead of bare
   `NotFound` from `fs::copy`.

## What this does *not* do

This PR only fixes the publish recipe. It does not retroactively patch the
already-published `0.97.0` (or earlier) tarballs -- those would need a
patch-version re-publish (`0.97.1` etc.) to actually unblock docs.rs for
existing consumers. Happy to follow up with that once this lands if helpful.

I considered a build-time bindgen fallback (regen `bindings_docs.rs` on
the fly when missing), but that requires running bindgen against the
bundled Skia headers without a prior Skia compile, which is a much larger
change and would need definitions-extraction work. The Makefile fix is the
narrow, low-risk path to closing this issue.

## Test plan

- [ ] Run `make publish` end-to-end on a release candidate; verify
      `skia-bindings/bindings_docs.rs` exists before the publish step.
- [ ] `cargo package --list` on the produced tarball includes
      `bindings_docs.rs`.
- [ ] After publish, the next docs.rs build of any consumer succeeds
      (downstream builds will be the proof).
