### PR TITLE
fix(docs): Include Vulkan in the binding docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 doc-features-win="gl,vulkan,d3d,textlayout,svg,skottie,ureq,webp"
 doc-features-mac="gl,vulkan,metal,textlayout,svg,skottie,ureq,webp"
-doc-features-docs-rs="gl,textlayout,svg,skottie,ureq,webp"
+doc-features-docs-rs="gl,textlayout,svg,skottie,ureq,webp,vulkan"
 
 .PHONY: all
 all:


### PR DESCRIPTION
Currently, anybody depending on skia-safe with the `vulkan` feature enabled and who publishes to docs.rs will get an error in its crate docs on docs.rs

Example with my rust-skia fork:
- Using my fork without this PR changes: https://docs.rs/crate/skia-safe-docs-error/0.1.0/builds/3415238
- Using my fork using this PR changes: https://docs.rs/crate/skia-safe-docs-error/0.1.1/builds/3415312

Now... I kinda lied because in my fork I also enabled other features, these ones specifically:
```
doc-features-docs-rs="gl,egl,vulkan,x11,wayland,textlayout,svg,skottie,ureq,webp,pdf"
```

But I am not yet sure about these. Stuff like `x11`, `wayland` and `pdf` are not afaik exposed as public apis.

Thoughts?