### PR TITLE
Milestone 150

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -14,6 +14,8 @@
                 "SK_SHAPER_CORETEXT_AVAILABLE",
                 "SK_CODEC_DECODES_WEBP"
             ],
+            "compilerPath": "/usr/bin/clang++",
+            "intelliSenseMode": "macos-clang-arm64",
             "macFrameworkPath": [],
             "cppStandard": "c++17"
         }

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Skia Submodule Status: chrome/m150 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m150-0.98.0...google:chrome/m150
-[skia-ours]: https://github.com/google/skia/compare/chrome/m150...rust-skia:m150-0.98.0
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m150-0.98.1...google:chrome/m150
+[skia-ours]: https://github.com/google/skia/compare/chrome/m150...rust-skia:m150-0.98.1
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![docs.rs](https://docs.rs/skia-safe/badge.svg)](https://docs.rs/skia-safe) [![Windows QA](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml) [![Linux QA](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml) [![macOS QA](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml)
 
-Skia Submodule Status: chrome/m149 ([upstream changes][skia-upstream], [our changes][skia-ours]).
+Skia Submodule Status: chrome/m150 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m149-0.97.4...google:chrome/m149
-[skia-ours]: https://github.com/google/skia/compare/chrome/m149...rust-skia:m149-0.97.4
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m150-0.98.0...google:chrome/m150
+[skia-ours]: https://github.com/google/skia/compare/chrome/m150...rust-skia:m150-0.98.0
 
 ## About
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -31,7 +31,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download the Skia archive from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m149-0.97.4"
+skia = "m150-0.98.0"
 
 [features]
 default = ["binary-cache", "embed-icudtl", "pdf"]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -31,7 +31,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download the Skia archive from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m150-0.98.0"
+skia = "m150-0.98.1"
 
 [features]
 default = ["binary-cache", "embed-icudtl", "pdf"]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.98.0"
+version = "0.99.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition = "2021"
 rust-version.workspace = true

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -71,6 +71,7 @@
 #include "include/core/SkRRect.h"
 #include "include/core/SkRSXform.h"
 #include "include/core/SkStream.h"
+#include "include/core/SkStrikeRef.h"
 #include "include/core/SkStrokeRec.h"
 #include "include/core/SkSurface.h"
 #include "include/core/SkSwizzle.h"
@@ -1598,6 +1599,10 @@ extern "C" bool C_SkRegion_quickContains(const SkRegion* self, const SkIRect* r)
     return self->quickContains(*r);
 }
 
+extern "C" bool C_SkRegion_setRects(SkRegion* self, const SkIRect* rects, int count) {
+    return self->setRects(SkSpan(rects, count));
+}
+
 extern "C" void C_SkRegion_getBoundaryPath(const SkRegion* self, SkPath* uninitialized) {
     new (uninitialized) SkPath(self->getBoundaryPath());
 }
@@ -1889,6 +1894,49 @@ extern "C" void C_SkFont_getIntercepts(
     VecSink<SkScalar>* vs) {
     auto r = self->getIntercepts(SkSpan(glyphs, count), SkSpan(pos, count), top, bottom, paint);
     vs->set(r);
+}
+
+extern "C" void C_SkFont_makeStrikeRef(const SkFont* self, SkStrikeRef* uninitialized) {
+    new (uninitialized) SkStrikeRef(self->makeStrikeRef());
+}
+
+extern "C" void C_SkStrikeRef_CopyConstruct(SkStrikeRef* uninitialized, const SkStrikeRef* self) {
+    new (uninitialized) SkStrikeRef(*self);
+}
+
+extern "C" void C_SkStrikeRef_destruct(SkStrikeRef* self) {
+    self->~SkStrikeRef();
+}
+
+extern "C" bool C_SkStrikeRef_isValid(const SkStrikeRef* self) {
+    return static_cast<bool>(*self);
+}
+
+extern "C" void C_SkStrikeRef_getWidths(
+    const SkStrikeRef* self,
+    const SkGlyphID* glyphs,
+    size_t glyphCount,
+    SkScalar* widths,
+    size_t widthCount) {
+    self->getWidths(SkSpan(glyphs, glyphCount), SkSpan(widths, widthCount));
+}
+
+extern "C" SkScalar C_SkStrikeRef_getWidth(const SkStrikeRef* self, SkGlyphID glyph) {
+    return self->getWidth(glyph);
+}
+
+extern "C" void C_SkStrikeRef_getWidthsBounds(
+    const SkStrikeRef* self,
+    const SkGlyphID* glyphs,
+    size_t glyphCount,
+    SkScalar* widths,
+    size_t widthCount,
+    SkRect* bounds,
+    size_t boundsCount) {
+    self->getWidthsBounds(
+        SkSpan(glyphs, glyphCount),
+        SkSpan(widths, widthCount),
+        SkSpan(bounds, boundsCount));
 }
 
 extern "C" bool C_SkFont_getPath(const SkFont* self, SkGlyphID glyphID, SkPath* pathR) {

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -18,7 +18,7 @@ categories = [
 ]
 license = "MIT"
 
-version = "0.98.0"
+version = "0.99.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition = "2021"
 rust-version.workspace = true
@@ -61,7 +61,7 @@ gpu = []
 
 [dependencies]
 bitflags = "2.0"
-skia-bindings = { version = "=0.98.0", path = "../skia-bindings", default-features = false }
+skia-bindings = { version = "=0.99.0", path = "../skia-bindings", default-features = false }
 
 
 # D3D types & ComPtr

--- a/skia-safe/src/core.rs
+++ b/skia-safe/src/core.rs
@@ -70,6 +70,7 @@ pub mod sampling_options;
 mod scalar_;
 pub mod shader;
 mod size;
+mod strike_ref;
 pub mod stroke_rec;
 pub mod surface;
 mod surface_props;
@@ -158,6 +159,7 @@ pub use sampling_options::{
 pub use scalar_::*;
 pub use shader::Shader;
 pub use size::*;
+pub use strike_ref::StrikeRef;
 pub use stroke_rec::StrokeRec;
 pub use surface::{surfaces, Surface};
 pub use surface_props::*;

--- a/skia-safe/src/core/font.rs
+++ b/skia-safe/src/core/font.rs
@@ -4,7 +4,7 @@ use skia_bindings::{self as sb, SkFont, SkFont_PrivFlags};
 
 use crate::{
     interop::VecSink, prelude::*, scalar, EncodedText, FontHinting, FontMetrics, GlyphId, Paint,
-    Path, Point, Rect, Typeface, Unichar,
+    Path, Point, Rect, StrikeRef, Typeface, Unichar,
 };
 
 pub type Edging = skia_bindings::SkFont_Edging;
@@ -303,6 +303,10 @@ impl Font {
 
     pub fn get_widths(&self, glyphs: &[GlyphId], widths: &mut [scalar]) {
         self.get_widths_bounds(glyphs, Some(widths), None, None)
+    }
+
+    pub fn make_strike_ref(&self) -> StrikeRef {
+        StrikeRef::construct(|s| unsafe { sb::C_SkFont_makeStrikeRef(self.native(), s) })
     }
 
     pub fn get_widths_bounds(

--- a/skia-safe/src/core/font.rs
+++ b/skia-safe/src/core/font.rs
@@ -306,7 +306,13 @@ impl Font {
     }
 
     pub fn make_strike_ref(&self) -> StrikeRef {
-        StrikeRef::construct(|s| unsafe { sb::C_SkFont_makeStrikeRef(self.native(), s) })
+        let strike_ref =
+            StrikeRef::construct(|s| unsafe { sb::C_SkFont_makeStrikeRef(self.native(), s) });
+        assert!(
+            unsafe { sb::C_SkStrikeRef_isValid(strike_ref.native()) },
+            "SkFont::makeStrikeRef() returned an invalid SkStrikeRef"
+        );
+        strike_ref
     }
 
     pub fn get_widths_bounds(

--- a/skia-safe/src/core/milestone.rs
+++ b/skia-safe/src/core/milestone.rs
@@ -1,1 +1,1 @@
-pub const MILESTONE: usize = 149;
+pub const MILESTONE: usize = 150;

--- a/skia-safe/src/core/region.rs
+++ b/skia-safe/src/core/region.rs
@@ -107,8 +107,11 @@ impl Region {
 
     pub fn set_rects(&mut self, rects: &[IRect]) -> bool {
         unsafe {
-            self.native_mut()
-                .setRects(rects.native().as_ptr(), rects.len().try_into().unwrap())
+            sb::C_SkRegion_setRects(
+                self.native_mut(),
+                rects.native().as_ptr(),
+                rects.len().try_into().unwrap(),
+            )
         }
     }
 

--- a/skia-safe/src/core/strike_ref.rs
+++ b/skia-safe/src/core/strike_ref.rs
@@ -21,17 +21,11 @@ impl NativeClone for sb::SkStrikeRef {
 
 impl fmt::Debug for StrikeRef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("StrikeRef")
-            .field("is_valid", &self.is_valid())
-            .finish()
+        f.debug_struct("StrikeRef").finish()
     }
 }
 
 impl StrikeRef {
-    pub fn is_valid(&self) -> bool {
-        unsafe { sb::C_SkStrikeRef_isValid(self.native()) }
-    }
-
     pub fn get_width(&self, glyph: GlyphId) -> scalar {
         unsafe { sb::C_SkStrikeRef_getWidth(self.native(), glyph) }
     }
@@ -100,7 +94,6 @@ mod tests {
         assert!(!glyphs.is_empty());
 
         let strike_ref = font.make_strike_ref();
-        assert!(strike_ref.is_valid());
 
         let mut font_widths = vec![0.0; glyphs.len()];
         font.get_widths(&glyphs, &mut font_widths);

--- a/skia-safe/src/core/strike_ref.rs
+++ b/skia-safe/src/core/strike_ref.rs
@@ -1,0 +1,121 @@
+use std::fmt;
+
+use skia_bindings as sb;
+
+use crate::{prelude::*, scalar, GlyphId, Rect};
+
+pub type StrikeRef = Handle<sb::SkStrikeRef>;
+unsafe_send_sync!(StrikeRef);
+
+impl NativeDrop for sb::SkStrikeRef {
+    fn drop(&mut self) {
+        unsafe { sb::C_SkStrikeRef_destruct(self) }
+    }
+}
+
+impl NativeClone for sb::SkStrikeRef {
+    fn clone(&self) -> Self {
+        construct(|s| unsafe { sb::C_SkStrikeRef_CopyConstruct(s, self) })
+    }
+}
+
+impl fmt::Debug for StrikeRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StrikeRef")
+            .field("is_valid", &self.is_valid())
+            .finish()
+    }
+}
+
+impl StrikeRef {
+    pub fn is_valid(&self) -> bool {
+        unsafe { sb::C_SkStrikeRef_isValid(self.native()) }
+    }
+
+    pub fn get_width(&self, glyph: GlyphId) -> scalar {
+        unsafe { sb::C_SkStrikeRef_getWidth(self.native(), glyph) }
+    }
+
+    pub fn get_widths(&self, glyphs: &[GlyphId], widths: &mut [scalar]) {
+        assert_eq!(glyphs.len(), widths.len());
+        unsafe {
+            sb::C_SkStrikeRef_getWidths(
+                self.native(),
+                glyphs.as_ptr(),
+                glyphs.len(),
+                widths.as_mut_ptr(),
+                widths.len(),
+            )
+        }
+    }
+
+    pub fn get_widths_bounds(
+        &self,
+        glyphs: &[GlyphId],
+        mut widths: Option<&mut [scalar]>,
+        mut bounds: Option<&mut [Rect]>,
+    ) {
+        let count = glyphs.len();
+
+        {
+            if let Some(slice) = &widths {
+                assert_eq!(count, slice.len())
+            };
+            if let Some(slice) = &bounds {
+                assert_eq!(count, slice.len())
+            };
+        }
+
+        let widths_ptr = widths.as_ptr_or_null_mut();
+        let widths_count = widths.map_or(0, |slice| slice.len());
+        let bounds_ptr = bounds.native_mut().as_ptr_or_null_mut();
+        let bounds_count = bounds.map_or(0, |slice| slice.len());
+
+        unsafe {
+            sb::C_SkStrikeRef_getWidthsBounds(
+                self.native(),
+                glyphs.as_ptr(),
+                count,
+                widths_ptr,
+                widths_count,
+                bounds_ptr,
+                bounds_count,
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Font, FontMgr, FontStyle};
+
+    #[test]
+    fn strike_ref_widths_match_font_widths() {
+        let font_mgr = FontMgr::new();
+        let typeface = font_mgr
+            .legacy_make_typeface(None, FontStyle::normal())
+            .unwrap();
+        let font = Font::new(typeface, 14.0);
+        let glyphs = font.text_to_glyphs_vec("StrikeRef");
+        assert!(!glyphs.is_empty());
+
+        let strike_ref = font.make_strike_ref();
+        assert!(strike_ref.is_valid());
+
+        let mut font_widths = vec![0.0; glyphs.len()];
+        font.get_widths(&glyphs, &mut font_widths);
+
+        let mut strike_widths = vec![0.0; glyphs.len()];
+        strike_ref.get_widths(&glyphs, &mut strike_widths);
+
+        assert_eq!(strike_widths, font_widths);
+        assert_eq!(strike_ref.get_width(glyphs[0]), font_widths[0]);
+
+        let mut font_bounds = vec![Default::default(); glyphs.len()];
+        let mut strike_bounds = vec![Default::default(); glyphs.len()];
+        font.get_widths_bounds(&glyphs, None, Some(&mut font_bounds), None);
+        strike_ref.get_widths_bounds(&glyphs, None, Some(&mut strike_bounds));
+
+        assert_eq!(strike_bounds, font_bounds);
+    }
+}

--- a/skia-safe/src/core/yuva_pixmaps.rs
+++ b/skia-safe/src/core/yuva_pixmaps.rs
@@ -124,8 +124,9 @@ impl YUVAPixmapInfo {
         self.native().fDataType
     }
 
-    /// Row bytes for the ith plane. Returns `None` if `i` >= [`Self::num_planes()`] or this
-    /// [YUVAPixmapInfo] is invalid.
+    /// Row bytes for the ith plane.
+    ///
+    /// Returns [None] if `i` is out of range.
     pub fn row_bytes(&self, i: usize) -> Option<usize> {
         (i < self.num_planes()).then(|| unsafe {
             sb::C_SkYUVAPixmapInfo_rowBytes(self.native(), i.try_into().unwrap())
@@ -137,7 +138,9 @@ impl YUVAPixmapInfo {
         (0..self.num_planes()).map(move |i| self.row_bytes(i).unwrap())
     }
 
-    /// Image info for the ith plane, or `None` if `i` >= [`Self::num_planes()`]
+    /// Image info for the ith plane.
+    ///
+    /// Returns [None] if `i` is out of range.
     pub fn plane_info(&self, i: usize) -> Option<&ImageInfo> {
         (i < self.num_planes()).then(|| {
             ImageInfo::from_native_ref(unsafe {
@@ -169,8 +172,7 @@ impl YUVAPixmapInfo {
 
     /// Takes an allocation that is assumed to be at least [compute_total_bytes(&self)] in size and
     /// configures the first [numPlanes(&self)] entries in pixmaps array to point into that memory.
-    /// The remaining entries of pixmaps are default initialized. Returns [None] if this
-    /// [YUVAPixmapInfo] not valid.
+    /// The remaining entries of pixmaps are default initialized.
     #[allow(clippy::missing_safety_doc)]
     pub unsafe fn init_pixmaps_from_single_allocation(
         &self,
@@ -313,7 +315,9 @@ impl YUVAPixmaps {
         }
     }
 
-    /// Get the ith [Pixmap] plane. `Pixmap` will be default initialized if i >= numPlanes.
+    /// Get the ith [Pixmap] plane.
+    ///
+    /// Panics if `i` is out of range.
     pub fn plane(&self, i: usize) -> &Pixmap {
         &self.planes()[i]
     }

--- a/skia-safe/tests/send_sync.rs
+++ b/skia-safe/tests/send_sync.rs
@@ -132,6 +132,7 @@ mod core {
     assert_impl_all!(RRect: Send, Sync);
     assert_impl_all!(RSXform: Send, Sync);
     assert_impl_all!(Shader: Send, Sync);
+    assert_impl_all!(StrikeRef: Send, Sync);
     assert_not_impl_any!(Surface: Send, Sync);
     assert_impl_all!(SurfaceProps: Send, Sync);
     assert_impl_all!(TextBlob: Send, Sync);


### PR DESCRIPTION
This PR aligns rust-skia with Skia's `chrome/m150` branch.

- [x] Update `README.md` ([rendered](https://github.com/pragmatrix/rust-skia/blob/m150/README.md))  
  > Most important here is to change the Skia branch name and the current Skia submodule tag at the top of the `README.md` file.
- [x] Diff the the following files to see if the build organization has changed significantly:
  - [x] `/BUILD.gn`
  - [x] `/gn/*` (recursively)
  - [x] `/modules/skshaper/BUILD.gn`
  - [x] `/modules/skshaper/skshaper.gni`
  - [x] `/modules/paragraph/BUILD.gn`
  - [x] `/modules/paragraph/skparagraph.gni`
  - [x] `/modules/skottie/BUILD.gn`
  - [x] `/modules/skottie/skottie.gni`
  - [x] `/modules/svg/BUILD.gn`
  - [x] `/modules/svg/svg.gni`
- [x] Skia builds ([release notes](https://github.com/google/skia/blob/chrome/m150/RELEASE_NOTES.md)).
- [x] `/skia-bindings` builds.
- [x] `/skia-safe`: Update & add new wrappers by diffing include files.  
  > Add TODOs for everything that can not be updated right now, and attempt to stay compatible with previous versions of skia-safe without trying too hard before version 1.0. Use `deprecated` attributes if needed.
  - [x] `codec/`
  - [x] `core/`
  - [x] `docs/`
  - [x] `effects/`
  - [x] `encode/`
  - [x] `gpu/`
    - [x] `ganesh/`
    - [x] `mtl/`
    - [x] `vk/`
  - [x] `pathops/`
  - [x] `svg/`
  - [x] `utils/`
  - [x] `modules/`
    - [x] `paragraph/`
    - [x] `shaper/`
    - [x] `skottie/`
    - [x] `skresources/`
    - [x] `svg/`
  - [x] `private/base/*`
    - [x] `SkPoint_impl.h`
- [x] Look for `todo!()` macros. 
- [x] Review `Send` & `Sync` implementations for new wrappers.
- [x] Review `Debug` implementation for new wrapper types and functions.
- [x] Release date of the matching Chrome version in less than 7 days?
- [x] Any pending changes in the Skia `chrome/m150` branch that aren't synchronized yet?
- [x] Rebase on or merge with master.
- [x] Do the `rust-skia:` commits in the `skia-bindings/skia` subdirectory match with `master` (`make diff-skia`).
- [x] Update versions of `skia-bindings/Cargo.toml` and `skia-safe/Cargo.toml` and also add the version to the new `deprecated` attributes.
- [x] Review API changes: `make diff-api`.
- [x] Do one final review of all the changes.
- [x] Run `make doc` and fix all warnings.

