### PR TITLE
fix(windows): lowercase advapi32 library name for cross-compilation compatibility

### DIFF
--- a/skia-bindings/build_support/platform/windows.rs
+++ b/skia-bindings/build_support/platform/windows.rs
@@ -97,8 +97,8 @@ impl PlatformDetails for Generic {
 }
 
 fn generic_link_libraries(features: &Features) -> Vec<String> {
-    // `Advapi32` is needed by `skunicode_icu.lib`.
-    let mut libs = vec!["usp10", "ole32", "user32", "gdi32", "fontsub", "Advapi32"];
+    // `advapi32` is needed by `skunicode_icu.lib`.
+    let mut libs = vec!["usp10", "ole32", "user32", "gdi32", "fontsub", "advapi32"];
     if features[feature::GL] {
         libs.push("opengl32");
     }


### PR DESCRIPTION
## Summary

Fix `Advapi32` → `advapi32` casing in `generic_link_libraries()` to match the actual library file name.

## Problem

The MSVC linker is case-insensitive, so this works fine for native Windows builds. However, cross-compilation toolchains like mingw and zig cc resolve library names
case-sensitively. The actual file is `advapi32.lib` — the uppercase `A` causes linker failures:

```
= note: error(link): undefined reference to library 'Advapi32'
```

All other libraries in the same list (`usp10`, `ole32`, `user32`, `gdi32`, `fontsub`) already use lowercase.


fixes #1294 