### PR TITLE
fix(windows): enable RTTI (/GR) for MSVC bindgen to fix std::function compilation

### DIFF
--- a/skia-bindings/build_support/skia_bindgen.rs
+++ b/skia-bindings/build_support/skia_bindgen.rs
@@ -239,11 +239,12 @@ pub fn generate_bindings(
         cc_args.push(std_cpp_arg);
     }
 
-    // Disable RTTI. Otherwise RustWStream may cause compilation errors.
-    bindgen_args.push("-fno-rtti".into());
+    // Disable RTTI on non-MSVC targets. On MSVC, RTTI must stay enabled (/GR)
+    // because std::function in <functional> uses typeid, which fails with /GR-.
     if target.builds_with_msvc() {
-        cc_args.push("/GR-".into());
+        cc_args.push("/GR".into());
     } else {
+        bindgen_args.push("-fno-rtti".into());
         cc_args.push("-fno-rtti".into());
     }
 


### PR DESCRIPTION
## Summary

Enable RTTI (`/GR`) instead of disabling it (`/GR-`) during the bindgen step on MSVC targets.

## Problem

The bindgen configuration unconditionally passes `-fno-rtti` (and `/GR-` on MSVC) when generating bindings. On MSVC with textlayout features enabled, harfbuzz/skparagraph
headers pull in `<functional>`, and MSVC's `std::function` implementation uses `typeid` — which requires RTTI:

```
error C2338: static_assert failed: 'typeid is not supported with /GR-'
```

This blocks building rust-skia with textlayout on Windows.

## Fix

Switch from `/GR-` to `/GR` on MSVC, and move the `-fno-rtti` bindgen arg into the non-MSVC branch. The bindgen step only parses headers — it does not link against Skia
object files, so there is no ODR or ABI conflict with Skia's own `/GR-` build.

fixes #1296
