### PR TITLE
fix(linux): auto-detect C++ standard library (libstdc++ vs libc++)

### DIFF
--- a/skia-bindings/build_support/platform/linux.rs
+++ b/skia-bindings/build_support/platform/linux.rs
@@ -34,8 +34,15 @@ impl PlatformDetails for Linux {
     }
 }
 
+fn cxx_stdlib() -> String {
+    match cc::Build::new().cpp(true).try_get_compiler() {
+        Ok(compiler) if compiler.is_like_clang() => "c++".to_string(),
+        _ => "stdc++".to_string(),
+    }
+}
+
 pub fn link_libraries(features: &Features) -> Vec<String> {
-    let mut libs = vec!["stdc++".to_string()];
+    let mut libs = vec![cxx_stdlib()];
 
     // Use pkg-config for system libraries when available
     add_pkg_config_libs(&mut libs, "freetype2", &["freetype"]);


### PR DESCRIPTION
Use `cc::Build` to probe the C++ compiler and select the library via `is_like_clang()`.

## Problem

The C++ standard library is hardcoded to `stdc++`` (libstdc++) on Linux (linux.rs:38). Users building with `clang` or `zig cc` get linker errors because these compilers default
to `libc++` (c++), not libstdc++.

There is currently no way to work around this without patching `linux.rs` directly.

## Suggested Fix

Auto-detect the C++ compiler family using `cc::Build` (already a dependency, used in `skia_bindgen.rs`) and select the appropriate standard library:

```
fn cxx_stdlib() -> String {
    match cc::Build::new().cpp(true).try_get_compiler() {
      Ok(compiler) if compiler.is_like_clang() => "c++".to_string(),
      _ => "stdc++".to_string(),
    }
}
```

This covers three cases:
- gcc/g++ (default on most distros) → stdc++ — no change from current behavior
- clang++ → c++
- zig cc (uses bundled libc++) → c++

The detection respects CXX / TARGET_CXX environment variables and handles cross-compilation correctly — `cc::Build` reads the `TARGET` env var set by Cargo automatically.
`try_get_compiler` is used instead of `get_compiler` so that probe failures (missing compiler, broken toolchain) fall back to `stdc++` rather than panicking the build script.

Alpine/musl builds (alpine.rs) delegate to linux::link_libraries(), so they pick up this fix automatically.

## Context

Our CI builds for Linux using `zig cc` as the C++ compiler for reproducible cross-compilation. The hardcoded `stdc++` breaks linking at that stage. We've been patching `linux.rs` locally, but I think it's time to push it to upstream.

## Alternative considered

An environment variable like `SKIA_CXX_STDLIB=c++` — simpler but requires manual configuration for every clang/zig user. Auto-detection is zero-config for the common case;
an env var override could be added later if needed.
