### PR TITLE
fix(build): skip bundled icu.ninja when system ICU is set via SKIA_GN_ARGS

### DIFF
--- a/skia-bindings/build_support/skia_bindgen.rs
+++ b/skia-bindings/build_support/skia_bindgen.rs
@@ -856,7 +856,10 @@ pub(crate) mod definitions {
     };
 
     use super::env;
-    use crate::build_support::features::{self, feature};
+    use crate::build_support::{
+        cargo,
+        features::{self, feature},
+    };
 
     /// A preprocessor definition.
     pub type Definition = (String, Option<String>);
@@ -946,8 +949,13 @@ pub(crate) mod definitions {
                 "obj/modules/skunicode/skunicode_core.ninja".into(),
                 "obj/modules/skunicode/skunicode_icu.ninja".into(),
             ]);
-            // shaper.cpp includes SkLoadICU.h
-            if !use_system_libraries {
+            // shaper.cpp includes SkLoadICU.h — skip bundled ICU ninja when
+            // system ICU is active (either via SKIA_USE_SYSTEM_LIBRARIES or
+            // skia_use_system_icu=true in SKIA_GN_ARGS).
+            let system_icu = use_system_libraries
+                || cargo::env_var("SKIA_GN_ARGS")
+                    .is_some_and(|args| args.contains("skia_use_system_icu=true"));
+            if !system_icu {
                 files.push("obj/third_party/icu/icu.ninja".into())
             }
         }


### PR DESCRIPTION
## Problem

When `skia_use_system_icu=true` is passed via `SKIA_GN_ARGS` (without setting `SKIA_USE_SYSTEM_LIBRARIES=1`), the Skia GN build correctly uses system ICU and does not
generate `obj/third_party/icu/icu.ninja`. However, `ninja_files_for_features()` unconditionally adds `icu.ninja` when `use_system_libraries` is false, causing a panic:

```
Failed to read ninja file: obj/third_party/icu/icu.ninja: No such file or directory
```

This forces an all-or-nothing choice: either set `SKIA_USE_SYSTEM_LIBRARIES=1` (which enables system versions of *all* libraries including libjpeg-turbo, libpng, etc.) or
don't use system ICU at all.

## Use case

Cross-compiling with zig cc and `-isystem /usr/include` makes system ICU headers visible to Skia's bundled ICU build, causing conflicts (`localematcher.cpp` errors). The
fix is `skia_use_system_icu=true`, but `SKIA_USE_SYSTEM_LIBRARIES=1` is too broad — it also enables `skia_use_system_libjpeg_turbo=true` which fails when `jconfig.h` is
not in the expected path on the build machine.

## Fix

In `ninja_files_for_features()`, check both `use_system_libraries` and `SKIA_GN_ARGS` for `skia_use_system_icu=true` before adding `icu.ninja`. This is
backwards-compatible: existing builds with `SKIA_USE_SYSTEM_LIBRARIES=1` continue to work as before.

## Context

Our CI cross-compiles for Linux using zig cc. System ICU headers leak into the bundled ICU build via `-isystem`, so we need `skia_use_system_icu=true` without pulling in
all other system libraries.
