### PR TITLE
feat(vulkan): add make_vk + Surface::wait + FlushInfo::set_signal_semaphores

### DIFF
--- a/skia-bindings/src/vulkan.cpp
+++ b/skia-bindings/src/vulkan.cpp
@@ -1,7 +1,9 @@
 #include "include/gpu/MutableTextureState.h"
 #include "include/gpu/ganesh/vk/GrBackendDrawableInfo.h"
+#include "include/gpu/ganesh/GrBackendSemaphore.h"
 #include "include/gpu/ganesh/GrBackendSurface.h"
 #include "include/gpu/ganesh/GrDirectContext.h"
+#include "include/gpu/ganesh/vk/GrVkBackendSemaphore.h"
 #include "include/gpu/ganesh/vk/GrVkBackendSurface.h"
 #include "include/gpu/ganesh/vk/GrVkDirectContext.h"
 #include "include/gpu/ganesh/vk/GrVkTypes.h"
@@ -218,5 +220,20 @@ extern "C" void C_VulkanYcbcrConversionInfo_Construct_Format(
     VkFormatFeatureFlags formatFeatures) {
     new (uninitialized) skgpu::VulkanYcbcrConversionInfo(
         format, ycbcrModel, ycbcrRange, xChromaOffset, yChromaOffset, chromaFilter, forceExplicitReconstruction, components, formatFeatures);
+}
+
+//
+// gpu/ganesh/vk/GrVkBackendSemaphore.h
+//
+
+extern "C" void C_GrBackendSemaphore_ConstructVk(
+    GrBackendSemaphore* uninitialized,
+    VkSemaphore semaphore) {
+    new(uninitialized) GrBackendSemaphore(GrBackendSemaphores::MakeVk(semaphore));
+}
+
+extern "C" VkSemaphore C_GrBackendSemaphores_GetVkSemaphore(
+    const GrBackendSemaphore* semaphore) {
+    return GrBackendSemaphores::GetVkSemaphore(*semaphore);
 }
 

--- a/skia-safe/src/core/surface.rs
+++ b/skia-safe/src/core/surface.rs
@@ -943,7 +943,39 @@ impl Surface {
         SurfaceProps::from_native_ref(unsafe { &*sb::C_SkSurface_props(self.native()) })
     }
 
-    // TODO: wait()
+    /// Inserts a list of GPU semaphores that the current GPU-backed API
+    /// must wait on before executing any more commands on the GPU for
+    /// this surface. If this call returns `false`, then the GPU back-end
+    /// will not wait on any passed-in semaphores, and the client will
+    /// still own the semaphores, regardless of the value of
+    /// `delete_semaphores_after_wait`.
+    ///
+    /// If `delete_semaphores_after_wait` is `false` then Skia will not
+    /// delete the semaphores. In this case it is the client's
+    /// responsibility to not destroy or attempt to reuse the semaphores
+    /// until it knows that Skia has finished waiting on them. This can
+    /// be done by using `finished_proc`s on flush calls.
+    ///
+    /// Returns: `true` if the GPU is waiting on the semaphores
+    #[cfg(feature = "gpu")]
+    pub fn wait(
+        &mut self,
+        wait_semaphores: &[crate::gpu::BackendSemaphore],
+        delete_semaphores_after_wait: impl Into<Option<bool>>,
+    ) -> bool {
+        let delete_after_wait = delete_semaphores_after_wait.into().unwrap_or(true);
+        unsafe {
+            sb::SkSurface_wait(
+                self.native_mut(),
+                wait_semaphores
+                    .len()
+                    .try_into()
+                    .expect("wait_semaphores length exceeds c_int"),
+                wait_semaphores.native().as_ptr(),
+                delete_after_wait,
+            )
+        }
+    }
 }
 
 pub use surfaces::BackendSurfaceAccess;

--- a/skia-safe/src/gpu.rs
+++ b/skia-safe/src/gpu.rs
@@ -66,6 +66,8 @@ pub mod backend_render_targets {
 pub mod backend_semaphores {
     #[cfg(feature = "d3d")]
     pub use super::ganesh::d3d::backend_semaphores::*;
+    #[cfg(feature = "vulkan")]
+    pub use super::ganesh::vk::backend_semaphores::*;
 }
 
 pub mod direct_contexts {

--- a/skia-safe/src/gpu/ganesh/types.rs
+++ b/skia-safe/src/gpu/ganesh/types.rs
@@ -2,6 +2,7 @@ use std::ptr;
 
 use crate::gpu;
 use crate::gpu::GpuStatsFlags;
+use crate::prelude::NativeSliceAccess;
 use skia_bindings as sb;
 
 pub use skia_bindings::GrBackendApi as BackendApi;
@@ -54,6 +55,28 @@ impl Default for FlushInfo {
 }
 
 native_transmutable!(sb::GrFlushInfo, FlushInfo);
+
+impl FlushInfo {
+    /// Sets the signal-semaphore array Skia will signal when work
+    /// submitted by the next flush call has executed on the GPU. Each
+    /// entry is treated as in/out by Skia: initialized semaphores are
+    /// signaled directly, uninitialized entries are filled with a
+    /// freshly-created semaphore.
+    ///
+    /// # Safety
+    /// `semaphores` must outlive any flush call that consumes this
+    /// [`FlushInfo`]. The flush operation may write back into the slice,
+    /// so the caller must keep it borrowed mutably until the flush
+    /// returns.
+    pub unsafe fn set_signal_semaphores(
+        &mut self,
+        semaphores: &mut [gpu::BackendSemaphore],
+    ) -> &mut Self {
+        self.num_semaphores = semaphores.len();
+        self.signal_semaphores = semaphores.native_mut().as_mut_ptr();
+        self
+    }
+}
 
 pub use sb::GrSemaphoresSubmitted as SemaphoresSubmitted;
 variant_name!(SemaphoresSubmitted::Yes);

--- a/skia-safe/src/gpu/ganesh/vk.rs
+++ b/skia-safe/src/gpu/ganesh/vk.rs
@@ -1,8 +1,10 @@
 mod backend_drawable_info;
+mod backend_semaphore;
 mod vk_backend_surface;
 mod vk_direct_context;
 pub mod vk_types;
 
 pub use backend_drawable_info::*;
+pub use backend_semaphore::*;
 pub use vk_backend_surface::*;
 pub use vk_direct_context::*;

--- a/skia-safe/src/gpu/ganesh/vk/backend_semaphore.rs
+++ b/skia-safe/src/gpu/ganesh/vk/backend_semaphore.rs
@@ -1,0 +1,39 @@
+use skia_bindings as sb;
+
+use crate::{
+    gpu::{BackendSemaphore, vk},
+    prelude::*,
+};
+
+pub mod backend_semaphores {
+    use super::*;
+
+    /// Returns a [`BackendSemaphore`] that wraps the given Vulkan
+    /// `VkSemaphore` handle. The handle remains owned by the caller; Skia
+    /// signals or waits on it when this semaphore is passed to a flush
+    /// or [`crate::Surface::wait`] operation.
+    ///
+    /// # Safety
+    /// `semaphore` must be a valid `VkSemaphore` that stays alive until
+    /// all operations Skia performs with the returned [`BackendSemaphore`]
+    /// have completed.
+    pub unsafe fn make_vk(semaphore: vk::Semaphore) -> BackendSemaphore {
+        let backend_semaphore = BackendSemaphore::construct(|out| unsafe {
+            sb::C_GrBackendSemaphore_ConstructVk(out, semaphore)
+        });
+        assert!(backend_semaphore.is_initialized());
+        backend_semaphore
+    }
+
+    /// Returns the underlying `VkSemaphore` handle of an initialized
+    /// Vulkan-flavoured [`BackendSemaphore`], or `None` when the
+    /// semaphore is not initialized as Vulkan.
+    pub fn get_vk_semaphore(semaphore: &BackendSemaphore) -> Option<vk::Semaphore> {
+        if !semaphore.is_initialized() || semaphore.backend() != sb::GrBackendApi::Vulkan {
+            return None;
+        }
+        // No null check (like `get_d3d_fence_info`): `vk::Semaphore` is
+        // `u64` on 32-bit targets, where `is_null()` would not compile.
+        Some(unsafe { sb::C_GrBackendSemaphores_GetVkSemaphore(semaphore.native()) })
+    }
+}

--- a/skia-safe/src/gpu/vk.rs
+++ b/skia-safe/src/gpu/vk.rs
@@ -46,6 +46,7 @@ pub use sb::VkRect2D as Rect2D;
 pub use sb::VkRenderPass as RenderPass;
 pub use sb::VkSamplerYcbcrModelConversion as SamplerYcbcrModelConversion;
 pub use sb::VkSamplerYcbcrRange as SamplerYcbcrRange;
+pub use sb::VkSemaphore as Semaphore;
 pub use sb::VkSharingMode as SharingMode;
 
 pub const QUEUE_FAMILY_IGNORED: u32 = !0;


### PR DESCRIPTION
Adds the Vulkan semaphore wrappers, to parity with the existing D3D pair:

- `gpu::backend_semaphores::make_vk` / `get_vk_semaphore` (C shims in `vulkan.cpp`)
- `Surface::wait` — fills the `// TODO: wait()` placeholder
- `FlushInfo::set_signal_semaphores` (`unsafe`; caller keeps the slice alive)
- `pub use sb::VkSemaphore as vk::Semaphore`

Feature-gated, `cargo fmt` clean. Tested: `cargo build -p skia-safe --features gpu,vulkan` (FORCE_SKIA_BUILD) on Linux x86_64 + macOS arm64.
