### PR TITLE
Add APIs to access font data as Data. (Allows sharing of font memory - issue #1092)

### DIFF
--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -1764,6 +1764,10 @@ extern "C" SkStreamAsset* C_SkTypeface_openStream(const SkTypeface* self, int* t
     return self->openStream(ttcIndex).release();
 }
 
+extern "C" SkStreamAsset* C_SkTypeface_openExistingStream(const SkTypeface* self, int* ttcIndex) {
+    return self->openExistingStream(ttcIndex).release();
+}
+
 extern "C" void C_SkTypeface_getBounds(const SkTypeface* self, SkRect* uninitialized) {
     new (uninitialized) SkRect(self->getBounds());
 }
@@ -2838,6 +2842,10 @@ extern "C" size_t C_SkStream_read(SkStream* stream, void* buffer, size_t len) {
 
 extern "C" size_t C_SkStreamAsset_getLength(const SkStreamAsset* self) {
     return self->getLength();
+}
+
+extern "C" const SkData* C_SkStreamAsset_getData(const SkStreamAsset* self) {
+    return self->getData().release();
 }
 
 extern "C" void C_SkWStream_destruct(SkWStream* self) {

--- a/skia-org/src/skparagraph_example.rs
+++ b/skia-org/src/skparagraph_example.rs
@@ -35,7 +35,7 @@ fn draw_lorem_ipsum_ubuntu_font(canvas: &Canvas) {
         // We need a system font manager to be able to load typefaces.
         let font_mgr = FontMgr::new();
         let typeface = font_mgr
-            .new_from_data(UBUNTU_REGULAR, None)
+            .new_from_bytes(UBUNTU_REGULAR, None)
             .expect("Failed to load Ubuntu font");
 
         typeface_font_provider.register_typeface(typeface, TYPEFACE_ALIAS);

--- a/skia-safe/src/core/font_mgr.rs
+++ b/skia-safe/src/core/font_mgr.rs
@@ -2,7 +2,7 @@ use skia_bindings::{self as sb, SkFontMgr, SkFontStyleSet, SkRefCntBase};
 use std::{ffi::CString, fmt, mem, os::raw::c_char, ptr};
 
 use crate::{
-    FontStyle, Typeface, Unichar, font_arguments,
+    Data, FontStyle, Typeface, Unichar, font_arguments,
     interop::{self, DynamicMemoryWStream},
     prelude::*,
 };
@@ -261,25 +261,29 @@ impl FontMgr {
         panic!("Removed without replacement")
     }
 
-    // pub fn new_from_data(
-    //     &self,
-    //     bytes: &[u8],
-    //     ttc_index: impl Into<Option<usize>>,
-    // ) -> Option<Typeface> {
-    //     let data: Data = Data::new_copy(bytes);
-    //     Typeface::from_ptr(unsafe {
-    //         sb::C_SkFontMgr_makeFromData(
-    //             self.native(),
-    //             data.into_ptr(),
-    //             ttc_index.into().unwrap_or_default().try_into().unwrap(),
-    //         )
-    //     })
-    // }
+    /// Create a typeface for the supplied data and TTC index (use 0 for files
+    /// that are not collections). When possible the underlying data allocation
+    /// is shared, but otherwise will be copied.
+    ///
+    /// Returns `None` if the the data is unrecognized.
+    pub fn new_from_data(&self, data: Data, ttc_index: impl Into<Option<u32>>) -> Option<Typeface> {
+        Typeface::from_ptr(unsafe {
+            sb::C_SkFontMgr_makeFromData(
+                self.native(),
+                data.into_ptr(),
+                ttc_index.into().unwrap_or_default().try_into().unwrap(),
+            )
+        })
+    }
 
-    pub fn new_from_data(
+    /// Create a typeface from the supplied byte and TTC index (0 for files
+    /// that are not collections). The bytes will be copied.
+    ///
+    /// Returns `None` if the the data is unrecognized.
+    pub fn new_from_bytes(
         &self,
         bytes: &[u8],
-        ttc_index: impl Into<Option<usize>>,
+        ttc_index: impl Into<Option<u32>>,
     ) -> Option<Typeface> {
         let mut stream = DynamicMemoryWStream::from_bytes(bytes);
         let mut stream = stream.detach_as_stream();
@@ -402,5 +406,16 @@ mod tests {
 
         let _ = request::font_style_from_model(&[]);
         let _ = request::model_from_font_style(FontStyle::default());
+    }
+
+    #[test]
+    fn new_typeface_from_data_using_default() {
+        let font_mgr = FontMgr::default();
+        let default_typeface = font_mgr
+            .legacy_make_typeface(None, FontStyle::normal())
+            .unwrap();
+        let (data, ttc_index) = default_typeface.to_existing_font_data().unwrap();
+        let duplicate_face = font_mgr.new_from_data(data, ttc_index);
+        assert!(duplicate_face.is_some());
     }
 }

--- a/skia-safe/src/core/font_mgr.rs
+++ b/skia-safe/src/core/font_mgr.rs
@@ -414,8 +414,14 @@ mod tests {
         let default_typeface = font_mgr
             .legacy_make_typeface(None, FontStyle::normal())
             .unwrap();
-        let (data, ttc_index) = default_typeface.to_existing_font_data().unwrap();
-        let duplicate_face = font_mgr.new_from_data(data, ttc_index);
-        assert!(duplicate_face.is_some());
+
+        // If the underlying platform can provide the existing font data as Data
+        // test that it round trips
+        if let Some((data, ttc_index)) = default_typeface.to_existing_font_data() {
+            let duplicate_face = font_mgr.new_from_data(data, ttc_index);
+            assert!(duplicate_face.is_some());
+        } else {
+            println!("On this platform the default font does not supply existing font data.");
+        }
     }
 }

--- a/skia-safe/src/core/typeface.rs
+++ b/skia-safe/src/core/typeface.rs
@@ -364,10 +364,10 @@ impl Typeface {
         Some(name.as_str().into())
     }
 
-    /// Returns raw font data bytes and the TTC index.
+    /// Returns raw font data bytes and the TTC index (or 0 if not a collection).
     ///
     /// Returns `None` on failure.
-    pub fn to_font_data(&self) -> Option<(Vec<u8>, usize)> {
+    pub fn to_font_bytes(&self) -> Option<(Vec<u8>, u32)> {
         let mut ttc_index = 0;
         StreamAsset::from_ptr(unsafe { sb::C_SkTypeface_openStream(self.native(), &mut ttc_index) })
             .and_then(|mut stream| {
@@ -380,7 +380,19 @@ impl Typeface {
             })
     }
 
-    // TODO: openExistingStream()
+    /// Attempts to re-use existing font data when possible, avoiding additional memory
+    /// allocation, otherwise this is the similar to calling `to_font_bytes`. Returns a
+    /// `Data` object which can access the font data and the TTC index (or 0 if not a collection).
+    ///
+    /// Returns `None` on failure.
+    pub fn to_existing_font_data(&self) -> Option<(Data, u32)> {
+        let mut ttc_index = 0;
+        let stream = unsafe { sb::C_SkTypeface_openExistingStream(self.native(), &mut ttc_index) };
+        StreamAsset::from_ptr(stream).and_then(|stream| {
+            let data = unsafe { sb::C_SkStreamAsset_getData(stream.native()) };
+            Data::from_ptr_const(data).map(|data| (data, ttc_index.try_into().unwrap()))
+        })
+    }
 
     // TODO: createScalerContext()
 
@@ -472,11 +484,20 @@ mod tests {
     }
 
     #[test]
-    fn get_font_data_of_default() {
+    fn get_font_bytes_of_default() {
         let tf = FontMgr::new()
             .legacy_make_typeface(None, FontStyle::normal())
             .unwrap();
-        let (data, _ttc_index) = tf.to_font_data().unwrap();
+        let (data, _ttc_index) = tf.to_font_bytes().unwrap();
+        assert!(!data.is_empty());
+    }
+
+    #[test]
+    fn get_existing_font_data_of_default() {
+        let tf = FontMgr::new()
+            .legacy_make_typeface(None, FontStyle::normal())
+            .unwrap();
+        let (data, _ttc_index) = tf.to_existing_font_data().unwrap();
         assert!(!data.is_empty());
     }
 }

--- a/skia-safe/src/core/typeface.rs
+++ b/skia-safe/src/core/typeface.rs
@@ -380,9 +380,13 @@ impl Typeface {
             })
     }
 
-    /// Attempts to re-use existing font data when possible, avoiding additional memory
-    /// allocation, otherwise this is the similar to calling `to_font_bytes`. Returns a
-    /// `Data` object which can access the font data and the TTC index (or 0 if not a collection).
+    /// Attempts to re-use existing font data when possible, avoiding additional
+    /// memory allocation. If existing font data is not available, the typical
+    /// way to access font data is via tables using `copy_table_data` (or
+    /// `get_table_data`).
+    ///
+    /// Returns a `Data` object which can access the font data and the TTC
+    /// index (or 0 if not a collection).
     ///
     /// Returns `None` on failure.
     pub fn to_existing_font_data(&self) -> Option<(Data, u32)> {
@@ -497,7 +501,13 @@ mod tests {
         let tf = FontMgr::new()
             .legacy_make_typeface(None, FontStyle::normal())
             .unwrap();
-        let (data, _ttc_index) = tf.to_existing_font_data().unwrap();
-        assert!(!data.is_empty());
+
+        // If the font manager can supply data for the default font check
+        // that it isn't empty - this is a pretty trivial test
+        if let Some((data, _ttc_index)) = tf.to_existing_font_data() {
+            assert!(!data.is_empty());
+        } else {
+            println!("On this platform the default font does not supply existing font data.");
+        }
     }
 }

--- a/skia-safe/src/modules/resources.rs
+++ b/skia-safe/src/modules/resources.rs
@@ -257,7 +257,7 @@ pub mod helpers {
         url: &str,
     ) -> Option<Typeface> {
         if let Some(data) = provider.load(url, name) {
-            return font_mgr.new_from_data(&data, None);
+            return font_mgr.new_from_bytes(&data, None);
         }
         // Try to provide the default font if downloading fails.
         font_mgr.legacy_make_typeface(None, FontStyle::default())

--- a/skia-safe/src/utils/ordered_font_mgr.rs
+++ b/skia-safe/src/utils/ordered_font_mgr.rs
@@ -77,7 +77,7 @@ mod tests {
         let single_font_provider = |filename: &str| {
             let path = Path::new(filename);
             let font_data = fs::read(path).unwrap();
-            let font = sys_mgr.new_from_data(&font_data, None).unwrap();
+            let font = sys_mgr.new_from_bytes(&font_data, None).unwrap();
             let mut provider = TypefaceFontProvider::new();
             provider.register_typeface(font, None);
             provider


### PR DESCRIPTION
This allows sharing font memory and memory mapped files with Skia in the manner Skia expects it.

* Rename Typeface::to_font_data to Typeface::to_font_bytes for consistency with the rest of the API
* Add Typeface::to_existing_font_data to return a Data attempting to share the underlying bytes, if possible
* Rename Typeface::new_from_data to Typeface::new_from_bytes
* Add a new version of Typeface::new_from_data using a Data object
* Update the type of the true type collection index to u32

Resolves #1092.

----------------------------------------

This seemed like the cleanest way to fit this functionality into the overall system since Skia hides a lot of the specifics of the fonts behind the scenes and SkData already provides all of the details. Plus this is how Skia itself does it.

The existing Rust API didn't fit the naming conventions of the rest of the library where `to_bytes` is used to mean `Vec<u8>`, so I also cleaned up that up (which makes this a minor API *breaking* change - but it's just a rename) and made the size of the collection index u32 (per the specs).

Testing (Linux, x86_64):
* `build`
* `build --release`
* `build test`
* `build --examples`
* ran `skia-org` and examined output
* `find -name \*.rs -print0 | xargs -0 grep to_font_data`
* `find -name \*.rs -print0 | xargs -0 grep new_from_data`
* used APIs in an unreleased application that loads dozens of fonts and does shaping (also saw improvements in performance due to shared data between the shaping and rendering)
* `cargo fmt`, `cargo clippy`

In my own applications:
* Examined output of `heaptrack` before and after, confirming that a 30MB font file was shared successfully
* Examined process mapping and confirmed the file was memory mapped
* In a one-off test harness confirmed that the sharing worked the other direction too, creating several instances of a typeface opened via Rust's `memmap2` crate

