### PR TITLE
Recover from stale cached binary downloads

### DIFF
--- a/skia-bindings/build_support/binary_cache/download.rs
+++ b/skia-bindings/build_support/binary_cache/download.rs
@@ -192,6 +192,23 @@ fn should_try_download_binaries(
 }
 
 fn download_and_install(url: impl AsRef<str>, output_directory: &Path) -> io::Result<()> {
+    let url = url.as_ref();
+    download_and_unpack(url, output_directory).or_else(|err| {
+        // A stale cached download, for example one restored from an outdated CI cache, can make
+        // the download fail (servers reject resuming a file that is already complete or too
+        // large with HTTP 416, which newer curl versions may also silently ignore) or produce a
+        // corrupt archive. Delete the cached file and retry once from scratch.
+        let Some(cache_file_path) = utils::download_cache_path(url).filter(|p| p.exists()) else {
+            return Err(err);
+        };
+        println!("DOWNLOAD OR UNPACK FAILED: {err}");
+        println!("DELETING THE CACHED DOWNLOAD AND RETRYING");
+        fs::remove_file(cache_file_path)?;
+        download_and_unpack(url, output_directory)
+    })
+}
+
+fn download_and_unpack(url: &str, output_directory: &Path) -> io::Result<()> {
     let archive = utils::download(url, true)?;
     println!(
         "UNPACKING ARCHIVE INTO: {}",

--- a/skia-bindings/build_support/binary_cache/utils.rs
+++ b/skia-bindings/build_support/binary_cache/utils.rs
@@ -1,10 +1,27 @@
 use std::{
-    env,
-    fs::{self, File},
-    io::{self, Error, ErrorKind, Read},
+    env, fs,
+    io::{self, Error, ErrorKind},
     path::{Path, PathBuf},
     str,
 };
+
+/// The path under which [`download`] caches the downloaded file when invoked with
+/// `resume_and_cache`, or `None` when there is no usable cache location.
+pub fn download_cache_path(url: impl AsRef<str>) -> Option<PathBuf> {
+    // Specify the directory where the downloaded files are stored.
+    let Ok(out_dir) = env::var("OUT_DIR") else {
+        eprintln!("OUT_DIR not available");
+        return None;
+    };
+
+    let url = url.as_ref();
+    let Some(file_name) = url.split('/').next_back() else {
+        eprintln!("Failed to extract filename from `{url}`");
+        return None;
+    };
+
+    Some(PathBuf::from(out_dir).join(".cache").join(file_name))
+}
 
 /// Downloads a file from a URL,
 ///
@@ -25,17 +42,13 @@ pub fn download(url: impl AsRef<str>, resume_and_cache: bool) -> io::Result<Vec<
         return Err(ErrorKind::Unsupported.into());
     }
 
-    // Specify the directory where the downloaded files are stored.
-    let Ok(out_dir) = env::var("OUT_DIR") else {
-        eprintln!("OUT_DIR not available");
-        return Err(ErrorKind::Unsupported.into());
-    };
-
-    let mut out_dir = PathBuf::from(&out_dir);
-
-    let Some(file_name) = url.split('/').next_back() else {
-        eprintln!("Failed to extract filename from `{url}`");
-        return Err(ErrorKind::InvalidInput.into());
+    let cache_file_path = if resume_and_cache {
+        let Some(path) = download_cache_path(url) else {
+            return Err(ErrorKind::Unsupported.into());
+        };
+        Some(path)
+    } else {
+        None
     };
 
     let mut command = std::process::Command::new("curl");
@@ -48,8 +61,7 @@ pub fn download(url: impl AsRef<str>, resume_and_cache: bool) -> io::Result<Vec<
         // no progress meter but keep error messages.
         .arg("-sS");
 
-    let cache_file_path = out_dir.join(".cache").join(file_name);
-    if resume_and_cache {
+    if let Some(cache_file_path) = &cache_file_path {
         // resumed transfer offset
         command
             .arg("-C")
@@ -67,11 +79,8 @@ pub fn download(url: impl AsRef<str>, resume_and_cache: bool) -> io::Result<Vec<
         Ok(out) => {
             // read bytes from the file
             if out.status.success() {
-                if resume_and_cache {
-                    let mut file = File::open(cache_file_path)?;
-                    let mut result = Vec::with_capacity(file.metadata()?.len() as usize);
-                    file.read_to_end(&mut result)?;
-                    Ok(result)
+                if let Some(cache_file_path) = cache_file_path {
+                    fs::read(cache_file_path)
                 } else {
                     Ok(out.stdout)
                 }


### PR DESCRIPTION
When OUT_DIR/.cache contains a stale skia-binaries archive, for example one restored from an outdated CI cache, resuming the download with curl -C - is rejected by the server with HTTP 416 (Requested Range Not Satisfiable) if the cached file is already complete or larger than the remote file. Older curl versions (7.81 on Ubuntu 22.04) then fail with exit code 22, newer ones (8.7 on macOS) exit successfully and hand the possibly corrupt cached file to the unpacker. Either way the binaries download was considered failed and the build fell back to a full Skia source build - and kept doing so on every subsequent build, since the cached file was never cleaned up.

Recover in download_and_install: when the download or the unpacking of the archive fails while a cached download file exists, delete the cached file and retry once from scratch. A cached file that is complete and valid continues to be reused.