### PR TITLE
Implement AsRef<[u8]> for Data to complement Deref

### DIFF
--- a/skia-safe/src/core/data.rs
+++ b/skia-safe/src/core/data.rs
@@ -34,6 +34,12 @@ impl Deref for Data {
     }
 }
 
+impl AsRef<[u8]> for Data {
+    fn as_ref(&self) -> &[u8] {
+        self.deref().as_ref()
+    }
+}
+
 impl PartialEq for Data {
     // Although there is an implementation in SkData for equality testing, we
     // prefer to stay on the Rust side for that.
@@ -170,5 +176,52 @@ mod tests {
         let data = Data::from_stream(cursor, 1).unwrap();
         assert_eq!(data.len(), 1);
         assert_eq!(data[0], 1u8);
+    }
+
+    #[test]
+    fn data_deref_and_asref() {
+        fn sample(_t: &[u8]) {}
+        fn sample_asref(_t: &(impl AsRef<[u8]> + ?Sized)) {}
+        fn sample_arc_asref(_t: std::sync::Arc<dyn AsRef<[u8]> + Sync + Send>) {}
+        fn sample_rc_asref(_t: std::rc::Rc<dyn AsRef<[u8]>>) {}
+
+        let data = Data::new_str("Test Case");
+
+        // Explicitly calling as_bytes
+        sample(data.as_bytes());
+        sample_asref(data.as_bytes());
+
+        // Passing a reference to the data itself - sample is deduced from Deref but AsRef is not
+        sample(&data);
+        sample_asref(&data);
+
+        // Index access, from Deref
+        let _x = data[0];
+        let _y = &data[0..2];
+
+        // Placing the Data into more common owners - other libraries expose these in their APIs
+        let data_arc = std::sync::Arc::new(data.clone());
+        sample(&data_arc);
+        sample_asref(&*data_arc);
+        sample_arc_asref(data_arc.clone());
+
+        let data_rc = std::rc::Rc::new(data.clone());
+        sample_rc_asref(data_rc.clone());
+
+        // The primary goal of this test case is to ensure that it type checks
+        // however, sanity check the conversions too
+        assert_eq!(data.as_bytes(), &*data);
+
+        let data_as_ref: &[u8] = data.as_ref();
+        assert_eq!(data_as_ref, data.deref());
+
+        let data_as_ref: &[u8] = &data;
+        assert_eq!(data_as_ref, data.as_bytes());
+
+        let data_as_ref: &[u8] = &data_arc;
+        assert_eq!(data_as_ref, data.as_bytes());
+
+        let data_as_ref: &[u8] = &data_rc;
+        assert_eq!(data_as_ref, data.as_bytes());
     }
 }

--- a/skia-safe/src/core/data.rs
+++ b/skia-safe/src/core/data.rs
@@ -36,7 +36,7 @@ impl Deref for Data {
 
 impl AsRef<[u8]> for Data {
     fn as_ref(&self) -> &[u8] {
-        self.deref().as_ref()
+        self.deref()
     }
 }
 


### PR DESCRIPTION
The standard library documentation for Deref [recommends](https://doc.rust-lang.org/std/convert/trait.AsRef.html#generic-implementations) implementers of Deref consider implementing AsRef too. For external libraries that work with shared bytes (fonts, images, etc.) but are not coupled to Skia itself this can allow for easier integration with APIs expecting impl AsRef<[u8]>.

------

## Testing Done

* `cargo test`
* `cargo build --examples --features gl`
* `cargo fmt`
* `cargo clippy`
*  Tested using a local project + [harfrust](https://github.com/harfbuzz/harfrust) with the feature flag `experimental_font_api` which uses `read_fonts` - see [FontBlob](https://github.com/googlefonts/fontations/blob/main/read-fonts/src/model/font/blob.rs)

## Note

The `RCHandle` also implements `AsRef` in a generic manner but only for types implementing traits that `[u8]` would not, so this seems okay.  If for some reason this isn't desired, it's possible for consumers of the API to add another structure to hold the `Data` instance and implement `AsRef` on that struct - just a bit more cumbersome.
