### PR TITLE
Milestone 152

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![crates.io](https://img.shields.io/crates/v/skia-safe)](https://crates.io/crates/skia-safe) [![license](https://img.shields.io/crates/l/skia-safe)](LICENSE) [![docs.rs](https://docs.rs/skia-safe/badge.svg)](https://docs.rs/skia-safe) [![Windows QA](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/windows-qa.yaml) [![Linux QA](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/linux-qa.yaml) [![macOS QA](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml/badge.svg?branch=master)](https://github.com/rust-skia/rust-skia/actions/workflows/macos-qa.yaml)
 
-Skia Submodule Status: chrome/m151 ([upstream changes][skia-upstream], [our changes][skia-ours]).
+Skia Submodule Status: chrome/m152 ([upstream changes][skia-upstream], [our changes][skia-ours]).
 
-[skia-upstream]: https://github.com/rust-skia/skia/compare/m151-0.99.1...google:chrome/m151
-[skia-ours]: https://github.com/google/skia/compare/chrome/m151...rust-skia:m151-0.99.1
+[skia-upstream]: https://github.com/rust-skia/skia/compare/m152-0.100.0...google:chrome/m152
+[skia-ours]: https://github.com/google/skia/compare/chrome/m152...rust-skia:m152-0.100.0
 
 ## About
 

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -31,7 +31,7 @@ doctest = false
 # Metadata used from inside the packaged crate that defines where to download the Skia archive from.
 # Note: use short hashes here because of filesystem path size restrictions.
 [package.metadata]
-skia = "m151-0.99.1"
+skia = "m152-0.100.0"
 
 [features]
 default = ["binary-cache", "embed-icudtl", "pdf"]

--- a/skia-bindings/Cargo.toml
+++ b/skia-bindings/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["skia", "rust-bindings", "vulkan", "opengl", "pdf"]
 categories = ["external-ffi-bindings", "graphics", "multimedia::images", "rendering::graphics-api", "visualization"]
 license = "MIT"
 
-version = "0.100.0"
+version = "0.101.0"
 authors = ["LongYinan <lynweklm@gmail.com>", "Armin Sander <armin@replicator.org>"]
 edition.workspace = true
 rust-version.workspace = true

--- a/skia-bindings/src/bindings.cpp
+++ b/skia-bindings/src/bindings.cpp
@@ -537,6 +537,11 @@ extern "C" bool C_SkData_unique(const SkData* self) {
     return self->unique();
 }
 
+extern "C" SkData* C_SkData_shareSubset(const SkData* self, size_t offset, size_t length) {
+    auto subset = self->shareSubset(offset, length);
+    return const_cast<SkData*>(subset.release());
+}
+
 extern "C" SkData* C_SkData_MakeWithCopy(const void* data, size_t length) {
     return SkData::MakeWithCopy(data, length).release();
 }
@@ -1571,6 +1576,14 @@ extern "C" void C_SkRRect_setRect(SkRRect* self, const SkRect* rect) {
     self->setRect(*rect);
 }
 
+extern "C" bool C_SkRRect_containsPoint(const SkRRect* self, const SkPoint* point) {
+    return self->contains(*point);
+}
+
+extern "C" bool C_SkRRect_containsRect(const SkRRect* self, const SkRect* rect) {
+    return self->contains(*rect);
+}
+
 extern "C" void C_SkRRect_dumpToString(const SkRRect* self, bool asHex, SkString* str) {
     *str = self->dumpToString(asHex);
 }
@@ -1737,7 +1750,7 @@ extern "C" void C_SkTypeface_serialize2(const SkTypeface* self, SkWStream* strea
 }
 
 extern "C" SkTypeface* C_SkTypeface_MakeDeserialize(SkStream* stream, SkFontMgr* lastResortFontMgr) {
-    return SkTypeface::MakeDeserialize(stream, sp(lastResortFontMgr)).release();
+    return SkTypeface::MakeDeserialize(stream, sp(lastResortFontMgr), nullptr).release();
 }
 
 extern "C" void C_SkTypeface_unicharsToGlyphs(const SkTypeface* self, const SkUnichar* uni, size_t uniCount, SkGlyphID* glyphs, size_t glyphsCount) {

--- a/skia-safe/Cargo.toml
+++ b/skia-safe/Cargo.toml
@@ -18,7 +18,7 @@ categories = [
 ]
 license = "MIT"
 
-version = "0.100.0"
+version = "0.101.0"
 authors = ["Armin Sander <armin@replicator.org>"]
 edition.workspace = true
 rust-version.workspace = true
@@ -62,7 +62,7 @@ graphite = ["skia-bindings/graphite"]
 
 [dependencies]
 bitflags = "2.0"
-skia-bindings = { version = "=0.100.0", path = "../skia-bindings", default-features = false }
+skia-bindings = { version = "=0.101.0", path = "../skia-bindings", default-features = false }
 
 
 # D3D types & ComPtr

--- a/skia-safe/src/core/data.rs
+++ b/skia-safe/src/core/data.rs
@@ -75,6 +75,12 @@ impl Data {
         self
     }
 
+    /// Returns data that shares a subset of this data's storage without copying it.
+    /// Returns `None` when `offset + length` exceeds this data's size.
+    pub fn share_subset(&self, offset: usize, length: usize) -> Option<Self> {
+        Self::from_ptr(unsafe { sb::C_SkData_shareSubset(self.native(), offset, length) })
+    }
+
     // TODO: rename to copy_from() ? or from_bytes()?
     pub fn new_copy(data: &[u8]) -> Self {
         Data::from_ptr(unsafe { sb::C_SkData_MakeWithCopy(data.as_ptr() as _, data.len()) })
@@ -159,6 +165,13 @@ mod tests {
         let d1 = Data::new_copy(x);
         let d2 = Data::new_copy(x);
         assert!(d1 == d2)
+    }
+
+    #[test]
+    fn share_subset() {
+        let data = Data::new_copy(&[1, 2, 3]);
+        assert_eq!(data.share_subset(1, 2).unwrap().as_bytes(), &[2, 3]);
+        assert!(data.share_subset(2, 2).is_none());
     }
 
     #[test]

--- a/skia-safe/src/core/milestone.rs
+++ b/skia-safe/src/core/milestone.rs
@@ -1,1 +1,1 @@
-pub const MILESTONE: usize = 151;
+pub const MILESTONE: usize = 152;

--- a/skia-safe/src/core/path.rs
+++ b/skia-safe/src/core/path.rs
@@ -22,8 +22,7 @@ use crate::{
 /// outside the geometry. [`Path`] also describes the winding rule used to fill
 /// overlapping contours.
 ///
-/// Internally, [`Path`] lazily computes metrics likes bounds and convexity. Call
-/// [`Path::update_bounds_cache`] to make [`Path`] thread safe.
+/// Internally, [`Path`] lazily computes convexity.
 pub type Path = Handle<SkPath>;
 unsafe impl Send for Path {}
 
@@ -114,8 +113,7 @@ impl fmt::Debug for Path {
 /// outside the geometry. [`Path`] also describes the winding rule used to fill
 /// overlapping contours.
 ///
-/// Internally, [`Path`] lazily computes metrics likes bounds and convexity. Call
-/// [`Path::update_bounds_cache`] to make [`Path`] thread safe.
+/// Internally, [`Path`] lazily computes convexity.
 impl Path {
     /// Create a new path with the specified spans.
     ///
@@ -720,13 +718,11 @@ impl Path {
         Rect::from_native_ref(unsafe { &*sb::C_SkPath_getBounds(self.native()) })
     }
 
-    /// Updates internal bounds so that subsequent calls to `bounds()` are instantaneous.
-    /// Unaltered copies of [`Path`] may also access cached bounds through `bounds()`.
-    ///
-    /// For now, identical to calling `bounds()` and ignoring the returned value.
-    ///
-    /// Call to prepare [`Path`] subsequently drawn from multiple threads,
-    /// to avoid a race condition where each draw separately computes the bounds.
+    /// Calls [`Self::bounds()`] and ignores the result.
+    #[deprecated(
+        since = "0.100.0",
+        note = "SkPath bounds are no longer computed lazily"
+    )]
     pub fn update_bounds_cache(&mut self) -> &mut Self {
         self.bounds();
         self

--- a/skia-safe/src/core/rrect.rs
+++ b/skia-safe/src/core/rrect.rs
@@ -1,4 +1,4 @@
-use crate::{Matrix, Rect, Vector, interop, prelude::*, scalar};
+use crate::{Matrix, Point, Rect, Vector, interop, prelude::*, scalar};
 use skia_bindings::{self as sb, SkRRect};
 use std::{fmt, mem, ptr};
 
@@ -231,8 +231,15 @@ impl RRect {
         copied
     }
 
+    /// Returns true if `point` is inside the bounds and corner radii, and this rounded rectangle is
+    /// not empty.
+    pub fn contains_point(&self, point: impl Into<Point>) -> bool {
+        let point = point.into();
+        unsafe { sb::C_SkRRect_containsPoint(self.native(), point.native()) }
+    }
+
     pub fn contains(&self, rect: impl AsRef<Rect>) -> bool {
-        unsafe { self.native().contains(rect.as_ref().native()) }
+        unsafe { sb::C_SkRRect_containsRect(self.native(), rect.as_ref().native()) }
     }
 
     pub fn is_valid(&self) -> bool {


### PR DESCRIPTION

This PR aligns rust-skia with Skia's `chrome/m152` branch.

- [x] Update `README.md` ([rendered](https://github.com/pragmatrix/rust-skia/blob/m152/README.md))  
  > Most important here is to change the Skia branch name and the current Skia submodule tag at the top of the `README.md` file.
- [x] Diff the the following files to see if the build organization has changed significantly:
  - [x] `/BUILD.gn`
  - [x] `/gn/*` (recursively)
  - [x] `/modules/skshaper/BUILD.gn`
  - [x] `/modules/skshaper/skshaper.gni`
  - [x] `/modules/paragraph/BUILD.gn`
  - [x] `/modules/paragraph/skparagraph.gni`
  - [x] `/modules/skottie/BUILD.gn`
  - [x] `/modules/skottie/skottie.gni`
  - [x] `/modules/svg/BUILD.gn`
  - [x] `/modules/svg/svg.gni`
- [x] Skia builds ([release notes](https://github.com/google/skia/blob/chrome/m152/RELEASE_NOTES.md)).
- [x] `/skia-bindings` builds.
- [x] `/skia-safe`: Update & add new wrappers by diffing include files.  
  > Add TODOs for everything that can not be updated right now, and attempt to stay compatible with previous versions of skia-safe without trying too hard before version 1.0. Use `deprecated` attributes if needed.
  - [x] `codec/`
  - [x] `core/`
  - [x] `docs/`
  - [x] `effects/`
  - [x] `encode/`
  - [x] `gpu/`
    - [x] `ganesh/`
    - [x] `mtl/`
    - [x] `vk/`
  - [x] `pathops/`
  - [x] `svg/`
  - [x] `utils/`
  - [x] `modules/`
    - [x] `paragraph/`
    - [x] `shaper/`
    - [x] `skottie/`
    - [x] `skresources/`
    - [x] `svg/`
- [x] Look for `todo!()` macros. 
- [x] Review `Send` & `Sync` implementations for new wrappers.
- [x] Review `Debug` implementation for new wrapper types and functions.
- [x] Release date of the matching Chrome version in less than 7 days?
- [x] Any pending changes in the Skia `chrome/m152` branch that aren't synchronized yet?
- [x] Rebase on or merge with master.
- [x] Do the `rust-skia:` commits in the `skia-bindings/skia` subdirectory match with `master` (`make diff-skia`).
- [x] Update versions of `skia-bindings/Cargo.toml` and `skia-safe/Cargo.toml` and also add the version to the new `deprecated` attributes.
- [x] Review API changes: `make diff-api`.
- [x] Do one final review of all the changes.
- [x] Run `make doc` and fix all warnings.

