### PR TITLE
fix: Avoid icu conflicts on Windows

### DIFF
--- a/skia-bindings/build_support/platform/windows.rs
+++ b/skia-bindings/build_support/platform/windows.rs
@@ -67,6 +67,8 @@ impl PlatformDetails for Msvc {
 
         // <https://github.com/llvm/llvm-project/issues/95133>
         builder.cflag("-D__RTMINTRIN_H");
+
+        undefine_icu_renaming_guard(config, builder);
     }
 
     fn link_libraries(&self, features: &Features) -> Vec<String> {
@@ -81,8 +83,10 @@ impl PlatformDetails for Generic {
         false
     }
 
-    fn gn_args(&self, _config: &BuildConfiguration, builder: &mut GnArgsBuilder) {
+    fn gn_args(&self, config: &BuildConfiguration, builder: &mut GnArgsBuilder) {
         builder.target_os_and_default_cpu("win");
+
+        undefine_icu_renaming_guard(config, builder);
     }
 
     fn link_libraries(&self, features: &Features) -> Vec<String> {
@@ -93,6 +97,19 @@ impl PlatformDetails for Generic {
         if let Some(specific_target) = specific_target(target) {
             builder.override_target(specific_target);
         }
+    }
+}
+
+/// Skia builds its vendored ICU with `U_DISABLE_RENAMING=1`, producing unversioned symbols
+/// like `ucptrie_close` that collide with the OS ICU import thunks in the `windows-targets`
+/// umbrella library. The linker can then silently bind ICU to `icu.dll`, which crashes at
+/// startup on Windows versions whose OS ICU is too old (e.g. Windows 10), and lld fails
+/// with duplicate symbol errors.
+/// Undefining the macro restores ICU's default version-suffixed names, making a collision
+/// impossible. See <https://github.com/rust-skia/rust-skia/issues/1242>.
+fn undefine_icu_renaming_guard(config: &BuildConfiguration, builder: &mut GnArgsBuilder) {
+    if config.features[feature::TEXTLAYOUT] {
+        builder.cflag("-UU_DISABLE_RENAMING");
     }
 }
 


### PR DESCRIPTION
disclaimer: Fable did the fix, but I tested and confirmed it indeed works.

Closes https://github.com/rust-skia/rust-skia/issues/1242

Basically, a user of Freya reported that his locally-built freya app was crashing with an error on his Windows 10 machine:

<img width="414" height="156" alt="image" src="https://github.com/user-attachments/assets/31dc7b3a-5e04-4273-ab14-51fed3b2301b" />

He analyzed the binary and it seemed to be an error with icu.

As I dont use Windows I spawned a Fable agent to look into this as first check and to my surprise it came with a suggestion (this PR changes), I made an [RC](https://crates.io/crates/freya-skia-safe/0.99.0-rc.1) release of my skia-safe soft fork for this user to try, and it worked for him! ✅ 

Fable also mentioned that this issue was actually related to https://github.com/rust-skia/rust-skia/issues/1242. Seems to be the same issue my user had but instead of runtime crash, it fails at compile time! To be sure of this I created a small [repro repo](https://github.com/marc2332/rust-skia-1242) where I added a windows ci with lld enabled and the latest stable freya release to see if it would fail, and it [did](https://github.com/marc2332/rust-skia-1242/actions/runs/31829540318/job/94861650532) (great!! I was able to reproduce the issue):

<img width="1967" height="701" alt="image" src="https://github.com/user-attachments/assets/2457a1a7-e67b-4882-9ed7-ddc84f8d805a" />

Then in the repro I [switched](https://github.com/marc2332/rust-skia-1242/commit/ca4eb7c638f6e97c97d2c8bb5b0e4c532542305a) to a branch of freya that uses the RC release of my soft fork with this PR changes to see if it would indeed work, and it [did](https://github.com/marc2332/rust-skia-1242/actions/runs/31830105877) ✅ !

<img width="1877" height="1318" alt="image" src="https://github.com/user-attachments/assets/070c56ce-ca26-40f6-b51b-cfd6b464340b" />

So, it worked for my user and in the repro ci 😄.

I am no expert on Windows, neither in skia internals, feel free to edit or close with a better alternative. 🦀 🫡 

p.d: No AI was used in the writing of this PR description :)