### PR TITLE
Add binaries for Slint

### DIFF
--- a/.github/workflows/linux-binaries.yaml
+++ b/.github/workflows/linux-binaries.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        features: ["", "gl", "textlayout", "vulkan", "gl,textlayout", "gl,x11", "textlayout,vulkan", "gl,textlayout,vulkan", "gl,textlayout,x11", "gl,svg,textlayout,x11", "svg,textlayout,vulkan,webp", "gl,svg,textlayout,wayland,x11", "egl,gl,skottie,svg,textlayout,vulkan,wayland,webp,x11"]
+        features: ["", "gl", "textlayout", "vulkan", "gl,textlayout", "gl,vulkan", "gl,x11", "textlayout,vulkan", "gl,textlayout,vulkan", "gl,textlayout,x11", "gl,svg,textlayout,x11", "svg,textlayout,vulkan,webp", "gl,svg,textlayout,wayland,x11", "egl,gl,skottie,svg,textlayout,vulkan,wayland,webp,x11"]
         target: ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "aarch64-linux-android", "x86_64-linux-android", "i686-linux-android"]
         include:
           - target: x86_64-unknown-linux-gnu

--- a/.github/workflows/macos-binaries.yaml
+++ b/.github/workflows/macos-binaries.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        features: ["", "gl", "metal", "textlayout", "vulkan", "gl,textlayout", "metal,textlayout", "textlayout,vulkan", "gl,metal,textlayout", "gl,textlayout,vulkan", "svg,textlayout,webp", "gl,metal,svg,textlayout", "gl,svg,textlayout,vulkan", "metal,svg,textlayout,webp"]
+        features: ["", "gl", "metal", "textlayout", "vulkan", "gl,metal", "gl,textlayout", "metal,textlayout", "textlayout,vulkan", "gl,metal,textlayout", "gl,textlayout,vulkan", "svg,textlayout,webp", "gl,metal,svg,textlayout", "gl,svg,textlayout,vulkan", "metal,svg,textlayout,webp"]
         target: ["aarch64-apple-darwin", "x86_64-apple-darwin", "aarch64-apple-ios", "aarch64-apple-ios-sim", "x86_64-apple-ios"]
         include:
           - target: aarch64-apple-darwin
@@ -63,6 +63,8 @@ jobs:
             macosxDeploymentTarget: '10.13'
           - features: 'vulkan'
             macosxDeploymentTarget: '10.13'
+          - features: 'gl,metal'
+            macosxDeploymentTarget: '10.14'
           - features: 'gl,textlayout'
             macosxDeploymentTarget: '10.13'
           - features: 'metal,textlayout'

--- a/.github/workflows/windows-arm-binaries.yaml
+++ b/.github/workflows/windows-arm-binaries.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        features: ["", "d3d", "gl", "textlayout", "vulkan", "d3d,textlayout", "gl,textlayout", "textlayout,vulkan", "d3d,gl,textlayout", "gl,textlayout,vulkan", "svg,textlayout,vulkan,webp"]
+        features: ["", "d3d", "gl", "textlayout", "vulkan", "d3d,gl", "d3d,textlayout", "gl,textlayout", "textlayout,vulkan", "d3d,gl,textlayout", "gl,textlayout,vulkan", "svg,textlayout,vulkan,webp"]
         target: ["aarch64-pc-windows-msvc"]
         include:
           - target: aarch64-pc-windows-msvc

--- a/.github/workflows/windows-binaries.yaml
+++ b/.github/workflows/windows-binaries.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        features: ["", "d3d", "gl", "textlayout", "vulkan", "d3d,textlayout", "gl,textlayout", "textlayout,vulkan", "d3d,gl,textlayout", "gl,svg,textlayout", "gl,textlayout,vulkan", "svg,textlayout,vulkan,webp", "d3d,gl,svg,textlayout,vulkan"]
+        features: ["", "d3d", "gl", "textlayout", "vulkan", "d3d,gl", "d3d,textlayout", "gl,textlayout", "textlayout,vulkan", "d3d,gl,textlayout", "gl,svg,textlayout", "gl,textlayout,vulkan", "svg,textlayout,vulkan,webp", "d3d,gl,svg,textlayout,vulkan"]
         target: ["x86_64-pc-windows-msvc"]
         include:
           - target: x86_64-pc-windows-msvc

--- a/mk-workflows/src/config.rs
+++ b/mk-workflows/src/config.rs
@@ -144,6 +144,7 @@ pub fn binaries_jobs(workflow: &Workflow) -> Vec<Job> {
     features.extend(vizia_binaries_features(workflow));
     features.extend(skia_canvas_binaries_features(workflow));
     features.extend(grida_canvas_binaries_features(workflow));
+    features.extend(slint_binaries_features(workflow));
 
     features.sort();
     features.dedup();
@@ -234,6 +235,30 @@ fn grida_canvas_binaries_features(workflow: &Workflow) -> Vec<Features> {
             vec!["gl,textlayout,svg,webp".into()]
         }
         _ => Vec::new(),
+    }
+}
+
+/// Specific binary releases for the Slint UI toolkit <https://github.com/slint-ui/slint>
+///
+/// Slint shapes and lays out text itself, so it combines `gl` with the platform's
+/// accelerator but does not use `textlayout`. Every published combination of `gl`
+/// plus an accelerator currently enables `textlayout`, which embeds Skia's ICU data
+/// and adds about 10 MB to the resulting binary.
+fn slint_binaries_features(workflow: &Workflow) -> Vec<Features> {
+    match workflow.host_os {
+        HostOS::MacOS => {
+            vec!["gl,metal".into()]
+        }
+        HostOS::Windows | HostOS::WindowsArm => {
+            vec!["d3d,gl".into()]
+        }
+        // Covers the Android targets built by the Linux workflow as well.
+        HostOS::Linux => {
+            vec!["gl,vulkan".into()]
+        }
+        HostOS::Wasm => {
+            vec![]
+        }
     }
 }
 


### PR DESCRIPTION
As with Slint we now use parley for text layout and shaping, we don't need Skia's built-in textlayout anymore. (I suppose other toolkits will follow suit :).