### PR TITLE
Add cached Linux binaries for Neovide FreeType builds

### DIFF
--- a/.github/workflows/linux-binaries.yaml
+++ b/.github/workflows/linux-binaries.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        features: ["", "gl", "textlayout", "vulkan", "gl,textlayout", "gl,x11", "textlayout,vulkan", "gl,textlayout,vulkan", "gl,textlayout,x11", "gl,svg,textlayout,x11", "svg,textlayout,vulkan,webp", "gl,svg,textlayout,wayland,x11", "egl,gl,skottie,svg,textlayout,vulkan,wayland,webp,x11"]
+        features: ["", "gl", "textlayout", "vulkan", "gl,textlayout", "gl,x11", "textlayout,vulkan", "embed-freetype,gl,textlayout", "gl,textlayout,vulkan", "gl,textlayout,x11", "gl,svg,textlayout,x11", "svg,textlayout,vulkan,webp", "gl,svg,textlayout,wayland,x11", "egl,gl,skottie,svg,textlayout,vulkan,wayland,webp,x11"]
         target: ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "aarch64-linux-android", "x86_64-linux-android", "i686-linux-android"]
         include:
           - target: x86_64-unknown-linux-gnu
@@ -60,6 +60,12 @@ jobs:
             features: 'gl,x11'
           - target: i686-linux-android
             features: 'gl,x11'
+          - target: aarch64-linux-android
+            features: 'embed-freetype,gl,textlayout'
+          - target: x86_64-linux-android
+            features: 'embed-freetype,gl,textlayout'
+          - target: i686-linux-android
+            features: 'embed-freetype,gl,textlayout'
           - target: aarch64-linux-android
             features: 'gl,textlayout,x11'
           - target: x86_64-linux-android

--- a/mk-workflows/src/config.rs
+++ b/mk-workflows/src/config.rs
@@ -144,6 +144,7 @@ pub fn binaries_jobs(workflow: &Workflow) -> Vec<Job> {
     features.extend(vizia_binaries_features(workflow));
     features.extend(skia_canvas_binaries_features(workflow));
     features.extend(grida_canvas_binaries_features(workflow));
+    features.extend(neovide_binaries_features(workflow));
 
     features.sort();
     features.dedup();
@@ -237,6 +238,15 @@ fn grida_canvas_binaries_features(workflow: &Workflow) -> Vec<Features> {
     }
 }
 
+// Binaries for Neovide: <https://github.com/neovide/neovide>
+// <https://github.com/neovide/neovide/pull/3544>
+fn neovide_binaries_features(workflow: &Workflow) -> Vec<Features> {
+    match workflow.host_os {
+        HostOS::Linux => vec!["embed-freetype,gl,textlayout".into()],
+        _ => Vec::new(),
+    }
+}
+
 fn windows_targets() -> Vec<TargetConf> {
     [TargetConf::new("x86_64-pc-windows-msvc", "d3d")].into()
 }
@@ -275,10 +285,11 @@ fn linux_aarch64_targets() -> Vec<TargetConf> {
 }
 
 fn android_targets() -> Vec<TargetConf> {
+    // Android already embeds FreeType, so an explicit feature would duplicate existing binaries.
     [
-        TargetConf::new("aarch64-linux-android", "").disable("egl,x11,wayland"),
-        TargetConf::new("x86_64-linux-android", "").disable("egl,x11,wayland"),
-        TargetConf::new("i686-linux-android", "").disable("egl,x11,wayland"),
+        TargetConf::new("aarch64-linux-android", "").disable("egl,embed-freetype,x11,wayland"),
+        TargetConf::new("x86_64-linux-android", "").disable("egl,embed-freetype,x11,wayland"),
+        TargetConf::new("i686-linux-android", "").disable("egl,embed-freetype,x11,wayland"),
     ]
     .into()
 }


### PR DESCRIPTION
## Summary

- publish Linux binaries for the `embed-freetype,gl,textlayout` feature combination used by Neovide
- exclude the explicit combination from Android targets, where FreeType is already embedded and the jobs would duplicate existing binary keys
- regenerate the Linux binaries workflow

## Motivation

[neovide/neovide#3544](https://github.com/neovide/neovide/pull/3544) enables embedded FreeType on Linux so Skia can paint current COLRv1 fonts. rust-skia already includes `embed-freetype` in its cache key as `ftembed`, but its release matrix does not publish the combination Neovide uses, forcing downstream source builds.

This adds future `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu` assets with the `ftembed-gl-jpegd-jpege-pdf-textlayout` key.

## Validation

- `rustfmt --edition 2024 --check mk-workflows/src/{config,main,target}.rs`
- `clippy-driver --edition=2024 -Dwarnings mk-workflows/src/main.rs`
- compiled and ran the workflow generator directly with Rust 1.97.1
- reran generation and verified the workflow output is idempotent
- verified `embed-freetype,gl,textlayout` maps to `ftembed-gl-textlayout` in the cache key

## AI assistance disclosure

AI assistance was used to help inspect the workflow generator and draft this change. I reviewed the implementation and ran the validation listed above.
