### PR TITLE
Fix freetype2 linking based on embed-freetype feature

### DIFF
--- a/skia-bindings/build_support/platform/linux.rs
+++ b/skia-bindings/build_support/platform/linux.rs
@@ -38,7 +38,11 @@ pub fn link_libraries(features: &Features) -> Vec<String> {
     let mut libs = vec!["stdc++".to_string()];
 
     // Use pkg-config for system libraries when available
-    add_pkg_config_libs(&mut libs, "freetype2", &["freetype"]);
+    // When `embed-freetype` is enabled, Skia builds its own FreeType
+    // (`skia_use_system_freetype2 = no()`), so the system library must not be linked.
+    if !features[feature::EMBED_FREETYPE] {
+        add_pkg_config_libs(&mut libs, "freetype2", &["freetype"]);
+    }
     add_pkg_config_libs(&mut libs, "fontconfig", &["fontconfig"]);
 
     if features[feature::GL] {


### PR DESCRIPTION
This pull request addresses issue #1325 by modifying the linking behavior for `freetype2` on Linux.

### Changes Made:
- Updated the `linux.rs` file to conditionally link the system `freetype2` library based on the `embed-freetype` feature.
- When `embed-freetype` is enabled, Skia builds its own FreeType, so the system library should not be linked. This is achieved by adding a conditional check:

  ```rust
  if !features[feature::EMBED_FREETYPE] {
      add_pkg_config_libs(&mut libs, "freetype2", &["freetype"]);
  }
  ```

### Additional Notes:
- The handling of `fontconfig` remains unchanged, as its design is still open for discussion.
- The fix is verified to compile cleanly with `cargo check`.

---

## AI Assistance Disclosure

This pull request, including the code change and this description, was produced with the assistance of an AI coding tool (GitHub Copilot). I reviewed and take responsibility for the final content.
